### PR TITLE
Fix copyright misinformation (SHOOP-978)

### DIFF
--- a/VENDOR-LICENSES.md
+++ b/VENDOR-LICENSES.md
@@ -1,6 +1,17 @@
 Licenses for Vendored Software
 ==============================
 
+Sphinx plugins for Django documentation
+---------------------------------------
+
+* Copyright: Copyright (c) Django Software Foundation and individual
+  contributors.
+* License: Django's BSD license
+  <https://github.com/django/django/blob/master/LICENSE>
+* Repository: https://github.com/django/django
+
+* doc/_ext/djangodocs.py
+
 Doppio One
 ----------
 

--- a/_misc/ensure_license_headers.py
+++ b/_misc/ensure_license_headers.py
@@ -45,7 +45,15 @@ def find_files(extension):
     for (path, dirnames, filenames) in os.walk('.'):
         for filename in filenames:
             if filename.endswith(extension):
-                yield os.path.join(path, filename)
+                filepath = os.path.join(path, filename)
+                if not is_file_ignored(filepath):
+                    yield filepath
+
+
+def is_file_ignored(filepath):
+    return (
+        ('vendor' in filepath) or
+        os.path.join('doc', '_ext', 'djangodocs.py') in filepath)
 
 
 def has_header(path):

--- a/_misc/ensure_license_headers.py
+++ b/_misc/ensure_license_headers.py
@@ -18,7 +18,7 @@ LICENSE file in the root directory of this source tree.
 PY_HEADER = '\n'.join(('# ' + line).strip() for line in HEADER.splitlines())
 JS_HEADER = (
     '/**\n' +
-    '\n'.join((' * ' + line).strip() for line in HEADER.splitlines()) +
+    '\n'.join((' * ' + line).rstrip() for line in HEADER.splitlines()) +
     '\n */')
 
 PY_HEADER_LINES = PY_HEADER.encode('utf-8').splitlines()

--- a/doc/_ext/djangodocs.py
+++ b/doc/_ext/djangodocs.py
@@ -1,9 +1,3 @@
-# This file is part of Shoop.
-#
-# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-#
-# This source code is licensed under the AGPLv3 license found in the
-# LICENSE file in the root directory of this source tree.
 """
 Sphinx plugins for Django documentation.
 """

--- a/doc/_ext/djangodocs.py.LICENSE
+++ b/doc/_ext/djangodocs.py.LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) Django Software Foundation and individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of Django nor the names of its contributors may be used
+       to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/shoop/admin/gulp_bits/bower-files.js
+++ b/shoop/admin/gulp_bits/bower-files.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var mainBowerFiles = require('main-bower-files');
 var path = require("path");

--- a/shoop/admin/gulp_bits/bower-install-task.js
+++ b/shoop/admin/gulp_bits/bower-install-task.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var gulp = require("gulp");
 var glob = require("glob");

--- a/shoop/admin/gulp_bits/css-packages.js
+++ b/shoop/admin/gulp_bits/css-packages.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 module.exports = {
     "base": {

--- a/shoop/admin/gulp_bits/index.js
+++ b/shoop/admin/gulp_bits/index.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var _ = require("lodash");
 var gulp = require('gulp');

--- a/shoop/admin/gulp_bits/js-packages.js
+++ b/shoop/admin/gulp_bits/js-packages.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var bowerFiles = require("./bower-files");
 var root = require("path").resolve(__dirname + "/..");

--- a/shoop/admin/gulp_bits/metatasks.js
+++ b/shoop/admin/gulp_bits/metatasks.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var _ = require("lodash");
 var autoprefixer = require("gulp-autoprefixer");

--- a/shoop/admin/gulp_bits/settings.js
+++ b/shoop/admin/gulp_bits/settings.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var _ = require("lodash");
 

--- a/shoop/admin/gulpfile.js
+++ b/shoop/admin/gulpfile.js
@@ -1,9 +1,9 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 require("./gulp_bits"); // It's all in there, man!

--- a/shoop/admin/modules/media/static_src/media/browser/Browser.js
+++ b/shoop/admin/modules/media/static_src/media/browser/Browser.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 window.MediaBrowser = (function() {
     var BrowserView = require("./BrowserView");

--- a/shoop/admin/modules/media/static_src/media/browser/BrowserView.js
+++ b/shoop/admin/modules/media/static_src/media/browser/BrowserView.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var FileUpload = require("./FileUpload");
 

--- a/shoop/admin/modules/media/static_src/media/browser/FileUpload.js
+++ b/shoop/admin/modules/media/static_src/media/browser/FileUpload.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var fd = require("filedrop");
 var queue = [];

--- a/shoop/admin/modules/media/webpack.config.js
+++ b/shoop/admin/modules/media/webpack.config.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 module.exports = {
     entry: __dirname + "/static_src/media/browser/Browser",

--- a/shoop/admin/static_src/base/js/content-blocks.js
+++ b/shoop/admin/static_src/base/js/content-blocks.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     $('.toggle-contents').click(function(e) {

--- a/shoop/admin/static_src/base/js/custom-selects.js
+++ b/shoop/admin/static_src/base/js/custom-selects.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     var isMobile = !!(/Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent));

--- a/shoop/admin/static_src/base/js/dropdown-animation.js
+++ b/shoop/admin/static_src/base/js/dropdown-animation.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 // Add slideDown animation to all bootstrap dropdowns
 $('.dropdown').on('show.bs.dropdown', function() {

--- a/shoop/admin/static_src/base/js/form-utils.js
+++ b/shoop/admin/static_src/base/js/form-utils.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 window.setNextActionAndSubmit = function(formId, nextAction) {
     var $form = $("#" + formId);

--- a/shoop/admin/static_src/base/js/main-menu.js
+++ b/shoop/admin/static_src/base/js/main-menu.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/base/js/materialize.js
+++ b/shoop/admin/static_src/base/js/materialize.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 /**
  * Materialize a Mithril.js virtual tree into a DOM node.

--- a/shoop/admin/static_src/base/js/media-widget.js
+++ b/shoop/admin/static_src/base/js/media-widget.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 /**
  * Support for media browsing widgets.

--- a/shoop/admin/static_src/base/js/messages.js
+++ b/shoop/admin/static_src/base/js/messages.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 window["Messages"] = (function Messages() {
     var queue = [];

--- a/shoop/admin/static_src/base/js/remarkable-field.js
+++ b/shoop/admin/static_src/base/js/remarkable-field.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     if(!window.Remarkable) return;

--- a/shoop/admin/static_src/base/js/search.js
+++ b/shoop/admin/static_src/base/js/search.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/base/js/side-nav.js
+++ b/shoop/admin/static_src/base/js/side-nav.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/base/js/timesince.js
+++ b/shoop/admin/static_src/base/js/timesince.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/base/js/tooltip.js
+++ b/shoop/admin/static_src/base/js/tooltip.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/dashboard/js/dashboard-charts.js
+++ b/shoop/admin/static_src/dashboard/js/dashboard-charts.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 window.DashboardCharts = (function(Chartist) {
     var chartTypeInfo = {

--- a/shoop/admin/static_src/dashboard/js/dashboard.js
+++ b/shoop/admin/static_src/dashboard/js/dashboard.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 $(function() {
     "use strict";

--- a/shoop/admin/static_src/picotable/picotable.js
+++ b/shoop/admin/static_src/picotable/picotable.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 /* exported Picotable */
 /* global alert, require */

--- a/shoop/admin/static_src/remarkable/remarkable.js
+++ b/shoop/admin/static_src/remarkable/remarkable.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var marked = require("marked");
 var m = require("mithril");

--- a/shoop/admin/static_src/remarkable/webpack.config.js
+++ b/shoop/admin/static_src/remarkable/webpack.config.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 module.exports = {
     entry: __dirname + "/remarkable",

--- a/shoop/notify/static/notify/admin/script-item-editor.js
+++ b/shoop/notify/static/notify/admin/script-item-editor.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 (function() {
     var $lastFocusedTemplateInput = null;

--- a/shoop/notify/static_src/script-editor.js
+++ b/shoop/notify/static_src/script-editor.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 var style = require("style!css!autoprefixer!less!./script-editor.less");
 

--- a/shoop/notify/webpack.config.js
+++ b/shoop/notify/webpack.config.js
@@ -1,10 +1,10 @@
 /**
-* This file is part of Shoop.
-*
-* Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
-*
-* This source code is licensed under the AGPLv3 license found in the
-* LICENSE file in the root directory of this source tree.
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 module.exports = {
     entry: "./static_src/script-editor.js",


### PR DESCRIPTION
There was one more vendored file that was incorrectly classified as
being ours: djangodocs.py.  Remove the incorrect copyright header from
it.  Also make ensure_license_headers.py script to ignore vendored files
in the future and fix JS header format.