### PR TITLE
Money: Do not read Django settings at init

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ if sys.version_info[0] == 2:
 
 TESTS_REQUIRE = [
     "beautifulsoup4==4.3.2",
+    "mock==1.0.1",
     "pytest-cache==1.0",
     "pytest==2.7.1",
     "pytest-cov==1.8.1",

--- a/shoop/utils/money.py
+++ b/shoop/utils/money.py
@@ -13,8 +13,16 @@ class Money(numbers.UnitedDecimal):
     def __new__(cls, value="0", currency=None, *args, **kwargs):
         assert currency is None, "currency support is not yet implemented"
         instance = super(Money, cls).__new__(cls, value, *args, **kwargs)
-        instance.currency = currency or settings.SHOOP_HOME_CURRENCY
+        instance._currency = currency
         return instance
 
+    @property
+    def currency(self):
+        return (self._currency or settings.SHOOP_HOME_CURRENCY)
+
     def _units_match(self, other):
-        return (self.currency == getattr(other, "currency", None))
+        return (
+            (isinstance(other, Money) and self._currency == other._currency)
+            or
+            (self.currency == getattr(other, "currency", None))
+        )

--- a/shoop_tests/utils/test_money.py
+++ b/shoop_tests/utils/test_money.py
@@ -1,0 +1,38 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from mock import patch
+
+from shoop.utils.money import Money
+
+
+def test_money_init_does_not_call_settings():
+    def guarded_getattr(self, name):
+        assert False, 'nobody should read settings yet'
+
+    with patch.object(type(settings), '__getattr__', guarded_getattr):
+        Money(42)
+
+
+def test_money_default_currency():
+    m = Money(42)
+    assert m.currency == settings.SHOOP_HOME_CURRENCY
+
+
+def test_units_match():
+    class XxxMoney(int):
+        currency = 'XXX'
+
+    m1 = Money(1)
+    m2 = Money(2)
+    m3 = Money(3)
+    m3._currency = 'XXX'
+    m4 = XxxMoney(4)
+
+    assert m1._units_match(m2)
+    assert not m1._units_match(m3)
+    assert m3._units_match(m4)


### PR DESCRIPTION
Creating a Money object in used to call settings.SHOOP_HOME_CURRENCY.
That is not good, because Money objects may be used at import time and
settings should not be read before Django is properly initialized.

Add a test case for this and for default currency being correct and for
the _units_match method.