### PR TITLE
Fix usages of `Category.get_ancestors()` in templates.

### DIFF
--- a/shoop/front/templates/shoop/front/product/category.jinja
+++ b/shoop/front/templates/shoop/front/product/category.jinja
@@ -6,7 +6,7 @@
 {% block breadcrumb %}
     <ol class="breadcrumb">
         <li><a href="/"><i class="glyphicon glyphicon-home"></i></a></li>
-        {% for c in category.get_ancestors(False, False) %}
+        {% for c in category.get_ancestors() if c.is_visible(customer=request.customer) %}
             <li><a href="{{ c.get_absolute_url() }}">{{ c.name }}</a></li>
         {% endfor %}
         <li class="active">{{ category.name }}</li>

--- a/shoop/front/templates/shoop/front/product/detail.jinja
+++ b/shoop/front/templates/shoop/front/product/detail.jinja
@@ -18,7 +18,7 @@
         <li><a href="/"><i class="glyphicon glyphicon-home"></i></a></li>
         {% set category = shop_product.primary_category %}
         {% if category %}
-            {% for c in category.get_parents() if c.is_visible(customer=request.customer) %}
+            {% for c in category.get_ancestors() if c.is_visible(customer=request.customer) %}
                 <li><a href="{{ shoop.urls.model_url(c) }}">{{ c.name }}</a></li>
             {% endfor %}
         {% endif %}


### PR DESCRIPTION
`get_parents()` wasn't actually even a thing...