### PR TITLE
Fix getting started links

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -4,7 +4,7 @@ Getting Started with Shoop
 .. note::
 
    If you are planning on developing Shoop,
-   read the :doc:`other Getting Started guide <getting_started_dev>` instead.
+   read the `other Getting Started guide <getting_started_dev.rst>`__ instead.
 
 Installation
 ------------

--- a/doc/getting_started_dev.rst
+++ b/doc/getting_started_dev.rst
@@ -4,7 +4,7 @@ Getting Started with Shoop Development
 .. note::
 
    If you are planning on using Shoop for developing your own shop,
-   read the :doc:`other Getting Started guide <getting_started>` instead.
+   read the `other Getting Started guide <getting_started.rst>`__ instead.
 
 Installation for Development
 ----------------------------


### PR DESCRIPTION
Currently getting_started links to getting_started_dev and the other way around. Github doesn't know how to render the links, these versions work according to the preview at least.