### PR TITLE
Persist GET parameters in checkout phase redirect

### DIFF
--- a/shoop/front/views/checkout.py
+++ b/shoop/front/views/checkout.py
@@ -5,8 +5,11 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from django.core.urlresolvers import reverse
 from django.shortcuts import redirect
 from django.views.generic import View
+from six.moves import urllib
+
 from shoop.front.checkout import CheckoutProcess
 from shoop.utils.importing import cached_load
 
@@ -32,7 +35,9 @@ class BaseCheckoutView(View):
 
         current_phase = process.prepare_current_phase(phase_identifier)
         if not current_phase.final and current_phase.identifier != phase_identifier:
-            return redirect("shoop:checkout", phase=current_phase.identifier)
+            url = reverse("shoop:checkout", kwargs={"phase": current_phase.identifier})
+            params = ("?" + urllib.parse.urlencode(request.GET)) if request.GET else ""
+            return redirect(url + params)
         return current_phase.dispatch(request, *args, **kwargs)
 
 


### PR DESCRIPTION
This is because some custom phases might need `GET` params to operate.