### PR TITLE
Telemetry Sender

### DIFF
--- a/shoop/admin/__init__.py
+++ b/shoop/admin/__init__.py
@@ -16,6 +16,7 @@ class ShoopAdminAppConfig(AppConfig):
     required_installed_apps = ["bootstrap3"]
     provides = {
         "admin_module": [
+            "shoop.admin.modules.system:SystemModule",
             "shoop.admin.modules.products:ProductModule",
             "shoop.admin.modules.product_types:ProductTypeModule",
             "shoop.admin.modules.media:MediaModule",
@@ -26,7 +27,7 @@ class ShoopAdminAppConfig(AppConfig):
             "shoop.admin.modules.users:UserModule",
             "shoop.admin.modules.methods:MethodModule",
             "shoop.admin.modules.attributes:AttributeModule",
-            "shoop.admin.modules.demo:DemoModule"
+            "shoop.admin.modules.demo:DemoModule",
         ]
     }
 

--- a/shoop/admin/modules/system/__init__.py
+++ b/shoop/admin/modules/system/__init__.py
@@ -6,10 +6,10 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
-from shoop.admin.base import AdminModule, MenuEntry
+from shoop.admin.base import AdminModule, MenuEntry, Notification
 from django.utils.translation import ugettext_lazy as _
 from shoop.admin.utils.urls import admin_url
-from shoop.core.telemetry import is_telemetry_enabled
+from shoop.core.telemetry import is_in_grace_period, is_opt_out, is_telemetry_enabled
 
 
 class SystemModule(AdminModule):
@@ -35,3 +35,12 @@ class SystemModule(AdminModule):
                 category=self.category
             ) if is_telemetry_enabled() else None,
         ] if e]
+
+    def get_notifications(self, request):
+        if is_telemetry_enabled() and is_in_grace_period() and not is_opt_out():
+            yield Notification(
+                _("Statistics will be periodically sent to Shoop.io after 24 hours. Click here for more information."),
+                title=_("Telemetry"),
+                kind="info",
+                url="shoop_admin:telemetry"
+            )

--- a/shoop/admin/modules/system/__init__.py
+++ b/shoop/admin/modules/system/__init__.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+from shoop.admin.base import AdminModule, MenuEntry
+from django.utils.translation import ugettext_lazy as _
+from shoop.admin.utils.urls import admin_url
+from shoop.core.telemetry import is_telemetry_enabled
+
+
+class SystemModule(AdminModule):
+    name = _("System")
+    category = name
+
+    def get_urls(self):
+        return [
+            admin_url(
+                "^system/telemetry/$",
+                "shoop.admin.modules.system.views.telemetry.TelemetryView",
+                name="telemetry"
+            ),
+        ]
+
+    def get_menu_category_icons(self):
+        return {self.category: "fa fa-wrench"}
+
+    def get_menu_entries(self, request):
+        return [e for e in [
+            MenuEntry(
+                text=_("Telemetry"), icon="fa fa-tachometer", url="shoop_admin:telemetry",
+                category=self.category
+            ) if is_telemetry_enabled() else None,
+        ] if e]

--- a/shoop/admin/modules/system/views/telemetry.py
+++ b/shoop/admin/modules/system/views/telemetry.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.http.response import HttpResponseRedirect, HttpResponse
+from django.utils.translation import ugettext_lazy as _
+from django.views.generic.base import TemplateView
+from shoop.core import telemetry
+
+
+class TelemetryView(TemplateView):
+    template_name = "shoop/admin/system/telemetry.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super(TelemetryView, self).get_context_data(**kwargs)
+        context.update({
+            "opt_in": not telemetry.is_opt_out(),
+            "is_grace": telemetry.is_in_grace_period(),
+            "last_submission_time": telemetry.get_last_submission_time(),
+            "submission_data": telemetry.get_telemetry_data(request=self.request, indent=2),
+            "title": _("Telemetry")
+        })
+        return context
+
+    def get(self, request, *args, **kwargs):
+        if "last" in request.GET:
+            return HttpResponse(telemetry.get_last_submission_data(), content_type="text/plain; charset=UTF-8")
+        return super(TelemetryView, self).get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        opt = request.POST.get("opt")
+        if opt:
+            telemetry.set_opt_out(opt == "out")
+        return HttpResponseRedirect(request.path)

--- a/shoop/admin/templates/shoop/admin/system/telemetry.jinja
+++ b/shoop/admin/templates/shoop/admin/system/telemetry.jinja
@@ -1,0 +1,57 @@
+{% extends "shoop/admin/base.jinja" %}
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-4">
+                <h2>About Shoop Telemetry</h2>
+                <p>Shoop will occasionally send telemetry data to a Shoop.io server.</p>
+                <p>
+                    The data contains an unique installation key,
+                    as well as the hostname of the installation (as sent by the visiting browser; currently
+                    <code>{{ request.get_host() }}</code>).
+                </p>
+                <p>
+                    No business data or other customer information is ever sent.
+                    Shoop.io only uses the telemetry data for statistical purposes and for insights
+                    about the software's installation base.
+                </p>
+                <h2>Last Telemetry</h2>
+                {% if is_grace and opt_in %}
+                    <div class="alert alert-info">
+                        Telemetry submission is currently suspended;
+                        data will only be sent 24 hours after installation if still opted in at that point.
+                    </div>
+                {% elif last_submission_time %}
+                    Telemetry data was last submitted at {{ last_submission_time|datetime }}
+                    ({{ last_submission_time|timesince }} ago).<br>
+                    <a href="?last">See the data that was submitted.</a>
+                {% else %}
+                    Telemetry data has not yet been submitted.
+                {% endif %}
+            </div>
+            <div class="col-md-4">
+                <h2>Opt-in/opt-out</h2>
+                <form action="{{ request.path }}" method="post">
+                    {% csrf_token %}
+                    {% if opt_in %}
+                        <div class="alert alert-success">
+                            You are currently <b>opted in</b> to send telemetry data to Shoop.io.<br>
+                            <b>Thank you</b> for your valuable contribution. &hearts;<br><br>
+                            <button type="submit" value="out" name="opt" class="btn btn-default btn-block">Opt out</button>
+                        </div>
+                    {% else %}
+                        <div class="alert alert-danger">
+                            You are currently <b>opted out</b> of Shoop telemetry.<br><br>
+                            <button type="submit" value="in" name="opt" class="btn btn-default btn-block">Opt in</button>
+                        </div>
+                    {% endif %}
+                </form>
+            </div>
+            <div class="col-md-4">
+                <h2>Telemetry Data</h2>
+                <p>Here is an example of the data that would be submitted right now.</p>
+                <pre><code>{{ submission_data }}</code></pre>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/shoop/admin/views/dashboard.py
+++ b/shoop/admin/views/dashboard.py
@@ -8,6 +8,7 @@
 from django.views.generic.base import TemplateView
 from shoop.admin.dashboard import get_activity
 from shoop.admin.module_registry import get_modules
+from shoop.core.telemetry import try_send_telemetry
 
 
 class DashboardView(TemplateView):
@@ -22,3 +23,7 @@ class DashboardView(TemplateView):
             blocks.extend(module.get_dashboard_blocks(request=self.request))
         context["activity"] = get_activity(request=self.request)
         return context
+
+    def get(self, request, *args, **kwargs):
+        try_send_telemetry(request)
+        return super(DashboardView, self).get(request, *args, **kwargs)

--- a/shoop/core/settings.py
+++ b/shoop/core/settings.py
@@ -129,3 +129,9 @@ SHOOP_ORDER_KNOWN_SHIPPING_DATA_KEYS = []
 #: information in ``extra_data``, this setting may be used to make this data easily visible
 #: in the administration backend.
 SHOOP_ORDER_KNOWN_EXTRA_DATA_KEYS = []
+
+#: A flag to enable/disable the telemetry system
+SHOOP_TELEMETRY_ENABLED = True
+
+#: The submission URL for Shoop's telemetry (statistics) system
+SHOOP_TELEMETRY_URL = "https://telemetry.shoop.io/collect/"

--- a/shoop/core/telemetry.py
+++ b/shoop/core/telemetry.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.serializers.json import DjangoJSONEncoder
+
+from django.utils.crypto import get_random_string
+from django.utils.encoding import force_text
+from django.utils.timezone import now
+from shoop.core.models.persistent_cache import PersistentCacheEntry
+import json
+import platform
+import requests
+import shoop
+import sys
+
+OPT_OUT_KWARGS = dict(module="telemetry", key="opt_out")
+INSTALLATION_KEY_KWARGS = dict(module="telemetry", key="installation_key")
+LAST_DATA_KWARGS = dict(module="telemetry", key="last_data")
+
+
+def safe_json(data_dict, indent=None):
+    return json.dumps(data_dict, cls=DjangoJSONEncoder, sort_keys=True, indent=indent)
+
+
+def get_installation_key():
+    """
+    Get the unique installation ID for this Shoop instance.
+
+    If one doesn't exist, it's generated and saved at this point.
+
+    :return: Installation key string
+    :rtype: str
+    """
+    try:
+        return PersistentCacheEntry.objects.get(**INSTALLATION_KEY_KWARGS).data
+    except ObjectDoesNotExist:
+        key = get_random_string(48)
+        PersistentCacheEntry.objects.create(data=key, **INSTALLATION_KEY_KWARGS)
+        return key
+
+
+def is_opt_out():
+    return PersistentCacheEntry.objects.filter(**OPT_OUT_KWARGS).exists()
+
+
+def is_in_grace_period():
+    """
+    Return True if the telemetry module is within the 24-hours-from-installation
+    grace period where no stats are sent.  This is to "safely" allow opting out
+    of telemetry without leaving a trace.
+
+    :return: Graceness flag.
+    :rtype: bool
+    """
+    get_installation_key()  # Need to initialize here
+    installation_time = PersistentCacheEntry.objects.get(**INSTALLATION_KEY_KWARGS).time
+    return ((now() - installation_time).total_seconds() < 60 * 60 * 24)
+
+
+def is_telemetry_enabled():
+    return bool(settings.SHOOP_TELEMETRY_ENABLED)
+
+
+def set_opt_out(flag):
+    """
+    Set whether this installation is opted-out from telemetry submissions.
+
+    :param flag: Opt-out flag. True for opt-out, false for opt-in (default)
+    :type flag: bool
+    :return: New flag state
+    :rtype: bool
+    """
+    if flag and not is_opt_out():
+        PersistentCacheEntry.objects.create(data=True, **OPT_OUT_KWARGS)
+        return True
+    else:
+        PersistentCacheEntry.objects.filter(**OPT_OUT_KWARGS).delete()
+        return False
+
+
+def get_last_submission_time():
+    try:
+        return PersistentCacheEntry.objects.get(**LAST_DATA_KWARGS).time
+    except ObjectDoesNotExist:
+        return None
+
+
+def get_last_submission_data():
+    try:
+        return safe_json(PersistentCacheEntry.objects.get(**LAST_DATA_KWARGS).data, indent=4)
+    except ObjectDoesNotExist:
+        return None
+
+
+def save_telemetry_submission(data):
+    """
+    Save a blob of data as the latest telemetry submission.
+
+    Naturally updates the latest submission time.
+
+    :param data: A blob of data.
+    :type data: dict
+    """
+    pce, _ = PersistentCacheEntry.objects.get_or_create(defaults={"data": None}, **LAST_DATA_KWARGS)
+    pce.data = data
+    pce.save()
+
+
+def get_telemetry_data(request, indent=None):
+    """
+    Get the telemetry data that would be sent.
+
+    :param request: HTTP request. Optional.
+    :type request: django.http.HttpRequest|None
+    :return: Data blob.
+    :rtype: str
+    """
+    data_dict = {
+        "apps": settings.INSTALLED_APPS,
+        "host": (request.get_host() if request else None),
+        "key": get_installation_key(),
+        "machine": platform.machine(),
+        "platform": platform.platform(),
+        "python_version": sys.version,
+        "shoop_version": shoop.__version__,
+    }
+    return safe_json(data_dict, indent)
+
+
+class TelemetryNotSent(Exception):
+    def __init__(self, message, code):
+        self.message = message
+        self.code = code
+        super(TelemetryNotSent, self).__init__(message, code)
+
+
+def _send_telemetry(request, max_age_hours):
+    if not is_telemetry_enabled():
+        raise TelemetryNotSent("Telemetry not enabled", "disabled")
+
+    if is_opt_out():
+        raise TelemetryNotSent("Telemetry is opted-out", "optout")
+
+    if is_in_grace_period():
+        raise TelemetryNotSent("Telemetry in grace period", "grace")
+
+    if max_age_hours is not None:
+        last_send_time = get_last_submission_time()
+        if last_send_time:
+            if (now() - last_send_time).total_seconds() <= max_age_hours * 60 * 60:
+                raise TelemetryNotSent("Trying to resend too soon", "age")
+
+    data = get_telemetry_data(request)
+    try:
+        resp = requests.post(url=settings.SHOOP_TELEMETRY_URL, data=data, timeout=5)
+    except Exception as exc:
+        data = {
+            "data": data,
+            "error": force_text(exc),
+        }
+    else:
+        data = {
+            "data": data,
+            "response": force_text(resp.content, errors="replace"),
+            "status": resp.status_code,
+        }
+    save_telemetry_submission(data)
+    return data
+
+
+def try_send_telemetry(request=None, max_age_hours=72, raise_on_error=False):
+    """
+    Send telemetry information (unless opted-out, in grace period or disabled).
+
+    :param request: HTTP request. Optional.
+    :type request: django.http.HttpRequest|None
+    :param max_age_hours: How many hours must have passed since the
+                          last submission to be able to resend. If None, not checked.
+    :type max_age_hours: int|None
+    :param raise_on_error: Raise exceptions when telemetry is not sent instead of quietly returning False.
+    :type raise_on_error: bool
+    :return: Sent data (possibly with response information) or False if not sent.
+    :rtype: dict|bool
+    """
+    try:
+        return _send_telemetry(request=request, max_age_hours=max_age_hours)
+    except TelemetryNotSent:
+        if raise_on_error:
+            raise
+        return False  # pragma: no cover

--- a/shoop/testing/admin_module/__init__.py
+++ b/shoop/testing/admin_module/__init__.py
@@ -5,8 +5,10 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
 from shoop.admin.base import AdminModule, MenuEntry
 from shoop.admin.utils.urls import admin_url
+from django.utils.translation import ugettext_lazy as _
 
 
 class TestingAdminModule(AdminModule):
@@ -19,7 +21,7 @@ class TestingAdminModule(AdminModule):
         return [
             MenuEntry(
                 text="Create Mock Objects",
-                category="Testing",
+                category=_("System"),
                 url="shoop_admin:mocker",
                 icon="fa fa-star"
             )

--- a/shoop_tests/core/test_telemetry.py
+++ b/shoop_tests/core/test_telemetry.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
 from django.test.utils import override_settings
 from django.utils.timezone import now
 from mock import patch
@@ -83,3 +89,9 @@ def test_graceful_error():
             assert try_send_telemetry(raise_on_error=True).get("error")
 
 
+def test_disabling_telemetry_hides_menu_item(rf):
+    request = rf.get("/")
+    with override_settings(SHOOP_TELEMETRY_ENABLED=True):
+        assert any(me.original_url == "shoop_admin:telemetry" for me in SystemModule().get_menu_entries(request))
+    with override_settings(SHOOP_TELEMETRY_ENABLED=False):
+        assert not any(me.original_url == "shoop_admin:telemetry" for me in SystemModule().get_menu_entries(request))

--- a/shoop_tests/core/test_telemetry.py
+++ b/shoop_tests/core/test_telemetry.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from django.test.utils import override_settings
+from django.utils.timezone import now
+from mock import patch
+from requests.models import Response
+import datetime
+import json
+import pytest
+import requests
+from shoop.admin.modules.system import SystemModule
+
+from shoop.core.models import PersistentCacheEntry
+from shoop.core.telemetry import (
+    get_telemetry_data, set_opt_out, try_send_telemetry, is_opt_out,
+    get_installation_key, INSTALLATION_KEY_KWARGS, LAST_DATA_KWARGS,
+    TelemetryNotSent)
+
+
+def _backdate_installation_key():
+    get_installation_key()
+    PersistentCacheEntry.objects.filter(**INSTALLATION_KEY_KWARGS).update(time=now() - datetime.timedelta(days=24))
+
+
+def _clear_telemetry_submission():
+    PersistentCacheEntry.objects.filter(**LAST_DATA_KWARGS).delete()
+
+
+@pytest.mark.django_db
+def test_get_telemetry_data(rf):
+    assert json.loads(get_telemetry_data(rf.get("/"))).get("host")
+    assert not json.loads(get_telemetry_data(None)).get("host")
+
+
+@pytest.mark.django_db
+def test_optin_optout(rf):
+    with override_settings(SHOOP_TELEMETRY_ENABLED=True):
+        with patch.object(requests, "post", return_value=Response()) as requestor:
+            _clear_telemetry_submission()
+            assert not set_opt_out(False)  # Not opted out
+            assert not is_opt_out()
+            with pytest.raises(TelemetryNotSent) as ei:
+                try_send_telemetry(raise_on_error=True)  # Still gracey
+            assert ei.value.code == "grace"
+
+            _backdate_installation_key()
+            try_send_telemetry(max_age_hours=72)
+            try_send_telemetry(max_age_hours=None)  # Forcibly re-send for the hell of it
+            with pytest.raises(TelemetryNotSent) as ei:
+                try_send_telemetry(raise_on_error=True)  # Don't ignore last-send; shouldn't send anyway
+            assert ei.value.code == "age"
+
+            assert len(requestor.mock_calls) == 2
+            assert set_opt_out(True)
+            assert is_opt_out()
+            _clear_telemetry_submission()
+            with pytest.raises(TelemetryNotSent) as ei:
+                try_send_telemetry(max_age_hours=0, raise_on_error=True)
+            assert ei.value.code == "optout"
+            assert len(requestor.mock_calls) == 2
+
+
+@pytest.mark.django_db
+def test_disable(rf):
+    with override_settings(SHOOP_TELEMETRY_ENABLED=False):
+        _clear_telemetry_submission()
+        _backdate_installation_key()
+        set_opt_out(False)
+        with pytest.raises(TelemetryNotSent) as ei:
+            try_send_telemetry(raise_on_error=True, max_age_hours=None)  # Should re-send (if we weren't disabled)
+        assert ei.value.code == "disabled"
+
+
+@pytest.mark.django_db
+def test_graceful_error():
+    def thrower(*args, **kwargs):
+        raise ValueError("aaaagh")
+
+    with override_settings(SHOOP_TELEMETRY_ENABLED=True):
+        with patch.object(requests, "post", thrower) as requestor:
+            _clear_telemetry_submission()
+            _backdate_installation_key()
+            set_opt_out(False)
+            assert try_send_telemetry(raise_on_error=True).get("error")
+
+


### PR DESCRIPTION
Implements an **opt-in-by-default** telemetry sender.

The receiving side is <del>still missing</del>currently in PR review, so this doesn't do much except slow down loading of the admin dashboard for a few seconds every 72 hours.