### PR TITLE
shoop_setup_utils: Fix find_packages (SHOOP-994)

### DIFF
--- a/shoop_setup_utils/finding.py
+++ b/shoop_setup_utils/finding.py
@@ -31,8 +31,8 @@ if hasattr(setuptools, "PackageFinder"):
 
     def find_packages(*args, **kwargs):
         kwargs.setdefault('exclude', excludes.get_exclude_patterns())
-        FastFindPackages.find(*args, **kwargs)
+        return FastFindPackages.find(*args, **kwargs)
 else:
     def find_packages(*args, **kwargs):
         kwargs.setdefault('exclude', excludes.get_exclude_patterns())
-        setuptools.find_packages(*args, **kwargs)
+        return setuptools.find_packages(*args, **kwargs)


### PR DESCRIPTION
Both versions of shoop_setup_utils.find_packages function always
returned None, rather than the correct result of package list, because
return statements were missing.  Fix that.