### PR TITLE
Clean up and speed up admin statics build

### DIFF
--- a/shoop/admin/gulp_bits/bower-files.js
+++ b/shoop/admin/gulp_bits/bower-files.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the AGPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-var mainBowerFiles = require('main-bower-files');
+var mainBowerFiles = require("main-bower-files");
 var path = require("path");
 var gutil = require("gulp-util");
 
@@ -14,13 +14,13 @@ function bowerFiles(root) {
     try {
         return mainBowerFiles({
             paths: {
-                bowerDirectory: path.normalize(path.join(root, 'bower_components')),
-                bowerJson: path.normalize(path.join(root, 'bower.json'))
+                bowerDirectory: path.normalize(path.join(root, "bower_components")),
+                bowerJson: path.normalize(path.join(root, "bower.json"))
             },
             filter: /js$/,
             includeSelf: true
         });
-    } catch(e) {
+    } catch (e) {
         gutil.log("Bower Files error (root=" + root + "):" + e);
         return [];
     }

--- a/shoop/admin/gulp_bits/bower-install-task.js
+++ b/shoop/admin/gulp_bits/bower-install-task.js
@@ -14,7 +14,6 @@ var _ = require("lodash");
 var path = require("path");
 var fs = require("fs");
 
-
 gulp.task("bower", [], function(complete) {
     glob("{modules,static_src}/**/bower.json", {
         ignore: ["**/node_modules/**", "**/bower_components/**"]
@@ -24,7 +23,7 @@ gulp.task("bower", [], function(complete) {
             var dir = path.dirname(bowerJsonPath);
             var bowerComponentsDir = path.join(dir, "bower_components");
             gutil.log("Bower start:", bowerJsonPath);
-            if(!fs.existsSync(bowerComponentsDir)) {
+            if (!fs.existsSync(bowerComponentsDir)) {
                 fs.mkdirSync(bowerComponentsDir);
                 gutil.log("  mkdir:", bowerComponentsDir);
             }

--- a/shoop/admin/gulp_bits/bower-install-task.js
+++ b/shoop/admin/gulp_bits/bower-install-task.js
@@ -15,14 +15,10 @@ var path = require("path");
 var fs = require("fs");
 
 
-gulp.task('bower', [], function(complete) {
-    glob("{modules,static_src}/**/bower.json", function(er, files) {
-        files = _.reject(files, function(path) {
-            return /node_modules/.test(path)
-        });
-        files = _.reject(files, function(path) {
-            return /bower_components/.test(path)
-        });
+gulp.task("bower", [], function(complete) {
+    glob("{modules,static_src}/**/bower.json", {
+        ignore: ["**/node_modules/**", "**/bower_components/**"]
+    }, function(er, files) {
         var deferredComplete = _.after(files.length, complete);
         _.each(files, function(bowerJsonPath) {
             var dir = path.dirname(bowerJsonPath);
@@ -37,10 +33,10 @@ gulp.task('bower', [], function(complete) {
                 {},
                 {cwd: dir, directory: "bower_components"}
             );
-            install.on('log', function(log) {
+            install.on("log", function(log) {
                 gutil.log("Bower/" + bowerJsonPath + ":" + log.message);
             });
-            install.on('end', function() {
+            install.on("end", function() {
                 gutil.log("Bower complete:", bowerJsonPath);
                 deferredComplete();
             });

--- a/shoop/admin/gulp_bits/index.js
+++ b/shoop/admin/gulp_bits/index.js
@@ -7,7 +7,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 var _ = require("lodash");
-var gulp = require('gulp');
+var gulp = require("gulp");
 var gutil = require("gulp-util");
 var settings = require("./settings");
 
@@ -22,7 +22,7 @@ if (process.argv.indexOf("bower") == -1) {
     require("./metatasks").installTasks();
 }
 
-gulp.task('default', function() {
+gulp.task("default", function() {
     console.log(gutil.colors.cyan.bold(
         "*** Please use `npm run build` instead of running `gulp` directly!\n" +
         "  * Using `npm run build` will ensure Bower prerequisites are installed before\n" +

--- a/shoop/admin/gulp_bits/js-packages.js
+++ b/shoop/admin/gulp_bits/js-packages.js
@@ -28,7 +28,7 @@ module.exports = {
             "js/content-blocks.js",
             "js/custom-selects.js",
             "js/remarkable-field.js",
-            "js/form-utils.js",
+            "js/form-utils.js"
         ]
     },
     "dashboard": {
@@ -49,7 +49,7 @@ module.exports = {
     "picotable": {
         "base": "./static_src/picotable",
         "files": [
-            "picotable.js",
+            "picotable.js"
         ]
     }
 };

--- a/shoop/admin/gulp_bits/metatasks.js
+++ b/shoop/admin/gulp_bits/metatasks.js
@@ -20,12 +20,12 @@ var plumber = require("gulp-plumber");
 var settings = require("./settings");
 var size = require("gulp-size");
 var sourcemaps = require("gulp-sourcemaps");
-var babel = require('gulp-babel');
+var babel = require("gulp-babel");
 var uglify = require("gulp-uglify");
 var webpack = require("webpack");
 
 function basifyFile(spec, file) {
-    if(!spec.base) return file;
+    if (!spec.base) return file;
     return path.join(spec.base, file);
 }
 
@@ -50,7 +50,7 @@ module.exports.CSS_TASK_NAMES = _.map(cssPackages, function(spec, name) {
             .pipe(size({title: taskName}))
             .pipe(gulp.dest(settings.DEST_DIR + "/css"));
     });
-    if(!spec.watches) spec.watches = [spec.entrypoint];
+    if (!spec.watches) spec.watches = [spec.entrypoint];
     var watches = spec.watches.map(basifyFile.bind(null, spec));
     settings.addWatchRule(taskName, watches);
 
@@ -79,23 +79,23 @@ function normalJsBundle(spec, name) {
 
 function webpackJsBundle(spec, name) {
     var taskName = "js:" + name;
-    if(_.isString(spec.webpack)) {  // Allow loading webpack configuration from file
+    if (_.isString(spec.webpack)) {  // Allow loading webpack configuration from file
         spec.webpack = require(spec.webpack);
     }
     spec.webpack.output = _.extend(spec.webpack.output || {}, {
         path: settings.DEST_DIR + "/js",
         filename: name + ".js"
     });
-    if(settings.PRODUCTION) {
+    if (settings.PRODUCTION) {
         spec.webpack.plugins = [
             new webpack.optimize.UglifyJsPlugin(),
-            new webpack.optimize.DedupePlugin(),
+            new webpack.optimize.DedupePlugin()
         ];
     }
     var packer = webpack(spec.webpack);
 
     var complete = function(err, stats) {
-        if(err) throw new gutil.PluginError(taskName, err);
+        if (err) throw new gutil.PluginError(taskName, err);
         gutil.log(taskName, stats.toString({colors: true}));
     };
 


### PR DESCRIPTION
* I noticed the NPM `glob` module has an ignore mechanism, so why not use that.
* As discussed on Slack, clean installations would kvetch about Bower files being missing before running `gulp bower`. Now, the regular tasks that use Bower files aren't even being installed if we're doing `gulp bower`, so that won't happen. (In addition, there's lots less code to load in this case, so speed-ups too! Win win!)
* Code style, man! JSCS'd the heck out of those bits.