### PR TITLE
Installation fixes (SHOOP-994)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,12 @@ Topic :: Software Development :: Libraries :: Python Modules
 """.strip().splitlines()
 
 utils.set_exclude_patters([
-    'build', 'contrib', 'doc', 'tests*',
+    'build', 'doc',
     'node_modules', 'bower_components',
     'var', '__pycache__', 'LC_MESSAGES',
     '.tox', 'venv*',
     '.git', '.gitignore',
+    'local_settings.py',
 ])
 
 REQUIRES = [

--- a/shoop_setup_utils/versions.py
+++ b/shoop_setup_utils/versions.py
@@ -20,23 +20,62 @@ def get_version(version, root, version_file):
     """
     if 'dev' not in version:
         return version
-    elif not os.path.exists(os.path.join(root, '.git')):
-        verstr = ''
-        if os.path.exists(version_file):
-            with open(version_file, 'rt') as fp:
-                verstr = fp.read(100).strip()
-        if verstr.startswith("__version__ = '" + version):
-            return verstr.split("'", 2)[1]
-        return version
+
+    git_repo_path = os.path.join(root, '.git')
+
+    if os.path.exists(git_repo_path) and not os.path.isdir(git_repo_path):
+        _remove_git_file_if_invalid(git_repo_path)
+
+    if os.path.exists(git_repo_path):
+        return _get_version_from_git(version, root) or version
+    else:
+        return _get_version_from_file(version_file, version) or version
+
+
+def _remove_git_file_if_invalid(git_file_path):
+    """
+    Remove invalid .git file.
+
+    This is needed, because .git file that points to non-existing
+    directory will cause problems with build_resources, since some git
+    commands are executed there and invalid .git file will cause them to
+    fail with error like
+
+      fatal: Not a git repository: ../.git/modules/shoop
+
+    Invalid .git files are created when "pip install" copies shoop from
+    a Git submodule to temporary build directory, for example.
+    """
+    with open(git_file_path, 'rb') as fp:
+        contents = fp.read(10000).decode('utf-8')
+    if contents.startswith('gitdir: '):
+        gitdir = contents.split(' ', 1)[1].rstrip()
+        if not os.path.isabs(gitdir):
+            gitdir = os.path.join(os.path.dirname(git_file_path), gitdir)
+        if not os.path.exists(gitdir):
+            os.remove(git_file_path)
+
+
+def _get_version_from_git(version, root):
     tag_name = 'v' + version.split('.post')[0].split('.dev')[0]
     describe_cmd = ['git', 'describe', '--dirty', '--match', tag_name]
     try:
         described = subprocess.check_output(describe_cmd, cwd=root)
     except Exception:
-        return version
+        return None
     suffix = described.decode('utf-8')[len(tag_name):].strip()
     cleaned_suffix = suffix[1:].replace('-g', '+g').replace('-dirty', '.dirty')
     return version + cleaned_suffix
+
+
+def _get_version_from_file(version_file, version_prefix=''):
+    verstr = ''
+    if os.path.exists(version_file):
+        with open(version_file, 'rt') as fp:
+            verstr = fp.read(100).strip()
+    if verstr.startswith("__version__ = '" + version_prefix):
+        return verstr.split("'", 2)[1]
+    return None
 
 
 def write_version_to_file(version, version_file):

--- a/shoop_workbench/settings/__init__.py
+++ b/shoop_workbench/settings/__init__.py
@@ -5,18 +5,35 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
 from shoop.utils.setup import Setup
+from . import base_settings
 
 
 def configure(setup):
-    from .base_settings import configure as base_configure
-    base_configure(setup)
-    try:
-        from .local_settings import configure as local_configure
-    except ImportError:
-        pass
-    else:
+    base_settings.configure(setup)
+
+    local_settings_file = os.getenv('LOCAL_SETTINGS_FILE')
+
+    # Backward compatibility: Find from current directory, if
+    # LOCAL_SETTINGS_FILE environment variables is unset
+    if local_settings_file is None:
+        cand = os.path.join(os.path.dirname(__file__), 'local_settings.py')
+        if os.path.exists(cand):
+            local_settings_file = cand
+
+    # Load local settings from file
+    if local_settings_file:
+        local_settings_ns = {}
+        execfile(local_settings_file, local_settings_ns)
+        if 'configure' not in local_settings_ns:
+            raise ImproperlyConfigured('No configure in local_settings')
+        local_configure = local_settings_ns['configure']
         local_configure(setup)
+
     return setup
 
 globals().update(Setup.configure(configure))


### PR DESCRIPTION
Fix pip install from Git submodule (SHOOP-1032) and exclude
local_settings.py from the Python package (SHOOP-1027). Also allow
specifying local settings for shoop_workbench by giving path of
local_settings.py in an environment variable.