### PR TITLE
Add borders to bootstrap select in admin

### DIFF
--- a/shoop/admin/static_src/base/less/shoop/custom-forms.less
+++ b/shoop/admin/static_src/base/less/shoop/custom-forms.less
@@ -117,6 +117,11 @@
             padding-right: 40px;
         }
 
+        .btn-select {
+            border-width: 2px;
+            border-color: @input-border-color;
+        }
+
         &.open {
             .dropdown-toggle {
                 box-shadow: none;


### PR DESCRIPTION
Other input fields have the 2px solid border but bootstrap select
was missing it.

Refs SHOOP-1036