### PR TITLE
Add possibility to set primary image for product

### DIFF
--- a/shoop/admin/modules/products/views/forms.py
+++ b/shoop/admin/modules/products/views/forms.py
@@ -8,7 +8,7 @@
 from __future__ import unicode_literals
 from django import forms
 
-from shoop.core.models import Product, ShopProduct
+from shoop.core.models import Product, ShopProduct, ProductMedia
 from shoop.core.models.attributes import AttributeType, Attribute
 from shoop.utils.i18n import get_language_name
 from shoop.utils.multilanguage_model_form import MultiLanguageModelForm, to_language_codes
@@ -38,6 +38,7 @@ class ProductBaseForm(MultiLanguageModelForm):
             "tax_class",
             "type",
             "width",
+            "primary_image",
             # I18n
             "description",
             "keywords",
@@ -48,6 +49,11 @@ class ProductBaseForm(MultiLanguageModelForm):
         widgets = {
             "keywords": forms.TextInput()
         }
+
+    def __init__(self, **kwargs):
+        super(ProductBaseForm, self).__init__(**kwargs)
+        instance = kwargs.get("instance")
+        self.fields["primary_image"].queryset = ProductMedia.objects.active_product_images(product=instance)
 
 
 class ShopProductForm(forms.ModelForm):

--- a/shoop/admin/templates/shoop/admin/products/_edit_base_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_base_form.jinja
@@ -17,6 +17,7 @@
     {{ bs3.field(product_form.category) }}
     {{ bs3.field(product_form.stock_behavior) }}
     {{ bs3.field(product_form.shipping_mode) }}
+    {{ bs3.field(product_form.primary_image) }}
     {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="additional-language") %}
         {{ bs3.field(product_form[map.variation_name]) }}
         {{ bs3.field(product_form[map.status_text]) }}


### PR DESCRIPTION
Product edit allows choosing one of the linked ProductMedia active and public image types as primary for particular product.

While this is not shop based, it does fix problem with default front templates that product images are not visible unless one is set as active.