### PR TITLE
Fix showing contact detail at admin

### DIFF
--- a/shoop/admin/modules/contacts/views/detail.py
+++ b/shoop/admin/modules/contacts/views/detail.py
@@ -13,7 +13,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView
 from shoop.admin.toolbar import Toolbar, URLActionButton, PostActionButton
-from shoop.core.models import Contact, Order
+from shoop.core.models import Contact, PersonContact, Order
 
 
 class ContactDetailToolbar(Toolbar):
@@ -74,7 +74,10 @@ class ContactDetailView(DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(ContactDetailView, self).get_context_data(**kwargs)
-        order_q = Q(orderer=self.object) | Q(customer=self.object)
+        if isinstance(self.object, PersonContact):
+            order_q = Q(orderer=self.object) | Q(customer=self.object)
+        else:
+            order_q = Q(customer=self.object)
         user = getattr(self.object, "user", None)
         if user:
             order_q |= Q(creator=user)

--- a/shoop/admin/templates/shoop/admin/contacts/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/contacts/detail.jinja
@@ -23,7 +23,7 @@
                             <div class="row contact-addresses">
                                 <div class="col-md-6 shipping-address">
                                     <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                                    {% for line in contact.default_shipping_address %}
+                                    {% for line in contact.default_shipping_address or [] %}
                                         <p>{{ line }}</p>
                                     {% else %}
                                         <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
@@ -31,7 +31,7 @@
                                 </div>
                                 <div class="col-md-6 billing-address">
                                     <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
-                                    {% for line in contact.default_billing_address %}
+                                    {% for line in contact.default_billing_address or [] %}
                                         <p>{{ line }}</p>
                                     {% else %}
                                         <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}


### PR DESCRIPTION
Order.orderer is PersonContact so it can't be filtered with CompanyContact object.

Showing current addresses fail since None is not iterable. This happens when contact has only one address set.