### PR TITLE
Cross-sells to product detail page in default templates

### DIFF
--- a/shoop/front/templates/shoop/front/macros.jinja
+++ b/shoop/front/templates/shoop/front/macros.jinja
@@ -54,6 +54,21 @@
     </div>
 {% endmacro %}
 
+{% macro render_cross_sell_products(product, relation_type="", title="") %}
+    {%- set cross_sell_products = shoop.product.get_product_cross_sells(product, relation_type) %}
+    {% if cross_sell_products %}
+        <hr>
+        {% if title %}<h3>{{ title }}</h3>{% endif %}
+        <div class="row">
+            {% for product in cross_sell_products %}
+                <div class="col-md-3">
+                    {{ product_box(product) }}
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endmacro %}
+
 {% macro render_field(field, classes="") %}
     {% if field.field.widget.is_hidden %}
         {{ field.as_widget()|safe }}

--- a/shoop/front/templates/shoop/front/product/detail.jinja
+++ b/shoop/front/templates/shoop/front/product/detail.jinja
@@ -109,7 +109,7 @@
 
     {% if package_children %}
         <hr>
-        <h3>{% trans %}Sisältää seuraavat tuotteet{% endtrans %}</h3>
+        <h3>{% trans %}Includes these products{% endtrans %}</h3>
         <div class="row">
             {% for child in package_children %}
                 <div class="col-md-3">
@@ -120,7 +120,7 @@
 
     {% elif package_parents %}
         <hr>
-        <h3>{% trans %}Myös saatavilla paketissa{% endtrans %}</h3>
+        <h3>{% trans %}Also available in{% endtrans %}</h3>
         <div class="row">
             {% for parent in package_parents %}
                 <div class="col-md-3">
@@ -130,17 +130,16 @@
         </div>
     {% endif %}
 
-    {% set related_products = shoop.product.get_products_bought_with(product) %}
-    {% if related_products %}
-        <hr>
-        <h3>{% trans %}Käyttäjät, jotka ostivat tämän tuotteen ostivat myös:{% endtrans %}</h3>
-        <div class="row">
-            {% for related_product in related_products %}
-                <div class="col-md-3">
-                    {{ macros.product_box(related_product) }}
-                </div>
-            {% endfor %}
-        </div>
-    {% endif %}
+    {{ macros.render_cross_sell_products(
+        product, relation_type="related", title=_("Related products")
+    ) }}
+
+    {{ macros.render_cross_sell_products(
+        product, relation_type="recommended", title=_("We recommend these products")
+    ) }}
+
+    {{ macros.render_cross_sell_products(
+        product, relation_type="computed", title=_("Users who bought this product also bought")
+    ) }}
 
 {% endblock %}


### PR DESCRIPTION
* Add a template helper to be used in templates to render the wanted cross-sell products.
* Add all of them to the default template (related, recommended and computed)
* Translate the texts from finnish to english

Refs SHOOP-1040