### PR TITLE
Fix variable variation form regression (and an important root cause)

### DIFF
--- a/shoop/admin/modules/products/views/variation/variable_variation_forms.py
+++ b/shoop/admin/modules/products/views/variation/variable_variation_forms.py
@@ -24,7 +24,8 @@ from shoop.utils.multilanguage_model_form import to_language_codes
 
 class VariableVariationChildrenForm(forms.Form):
     def __init__(self, **kwargs):
-        self.parent_product = kwargs.pop("parent_product", None)
+        self.parent_product = kwargs.pop("parent_product")
+        self.request = kwargs.pop("request", None)
         super(VariableVariationChildrenForm, self).__init__(**kwargs)
         self._build_fields()
 

--- a/shoop/core/fields/__init__.py
+++ b/shoop/core/fields/__init__.py
@@ -40,6 +40,16 @@ class InternalIdentifierField(models.CharField):
             return (prepared_value or None)
         return prepared_value
 
+    def deconstruct(self):
+        (name, path, args, kwargs) = super(InternalIdentifierField, self).deconstruct()
+        kwargs["null"] = self.null
+        kwargs["unique"] = self.unique
+        kwargs["blank"] = self.blank
+        # Irrelevant for migrations, and usually translated anyway:
+        kwargs.pop("verbose_name", None)
+        kwargs.pop("help_text", None)
+        return (name, path, args, kwargs)
+
 
 class MoneyField(models.DecimalField):
 

--- a/shoop/core/fields/__init__.py
+++ b/shoop/core/fields/__init__.py
@@ -22,10 +22,11 @@ IdentifierValidator = RegexValidator("[a-z][a-z_]+")
 class InternalIdentifierField(models.CharField):
 
     def __init__(self, **kwargs):
+        if "unique" not in kwargs:
+            raise ValueError("You must explicitly set the `unique` flag for `InternalIdentifierField`s.")
         kwargs.setdefault("max_length", 64)
         kwargs.setdefault("blank", True)
         kwargs.setdefault("null", bool(kwargs.get("blank")))  # If it's allowed to be blank, it should be null
-        kwargs.setdefault("unique", True)
         kwargs.setdefault("verbose_name", _("internal identifier"))
         kwargs.setdefault("help_text", _(u"Do not change this value if you are not sure what you're doing."))
         kwargs.setdefault("editable", False)

--- a/shoop/core/migrations/0002_identifier_field_unique.py
+++ b/shoop/core/migrations/0002_identifier_field_unique.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+def add_identifiers(apps, schema_editor):
+    for model_name in ("Attribute", "OrderStatus"):
+        model = apps.get_model("shoop", model_name)
+        for obj in model.objects.filter(identifier__isnull=True):
+            obj.identifier = "%s%s" % (model_name, obj.pk)
+            obj.save(update_fields=("identifier",))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_identifiers, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='attribute',
+            name='identifier',
+            field=shoop.core.fields.InternalIdentifierField(unique=True, blank=False, max_length=64, null=False, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='orderstatus',
+            name='identifier',
+            field=shoop.core.fields.InternalIdentifierField(unique=True, blank=False, db_index=True, max_length=64, null=False, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='productvariationvariable',
+            name='identifier',
+            field=shoop.core.fields.InternalIdentifierField(blank=True, unique=False, max_length=64, null=True, editable=False),
+        ),
+        migrations.AlterField(
+            model_name='productvariationvariablevalue',
+            name='identifier',
+            field=shoop.core.fields.InternalIdentifierField(blank=True, unique=False, max_length=64, null=True, editable=False),
+        ),
+    ]

--- a/shoop/core/models/attributes.py
+++ b/shoop/core/models/attributes.py
@@ -100,7 +100,7 @@ class AttributeQuerySet(TranslatableQuerySet):
 
 @python_2_unicode_compatible
 class Attribute(TranslatableModel):
-    identifier = InternalIdentifierField(blank=False, null=False, editable=True)
+    identifier = InternalIdentifierField(unique=True, blank=False, null=False, editable=True)
     searchable = models.BooleanField(default=True)
     type = EnumIntegerField(AttributeType, default=AttributeType.TRANSLATED_STRING)
     visibility_mode = EnumIntegerField(AttributeVisibility, default=AttributeVisibility.SHOW_ON_PRODUCT_PAGE)

--- a/shoop/core/models/categories.py
+++ b/shoop/core/models/categories.py
@@ -74,7 +74,7 @@ class CategoryManager(TranslatableManager, TreeManager):
 class Category(MPTTModel, TranslatableModel):
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children', verbose_name=_('parent category'))
     shops = models.ManyToManyField("Shop", blank=True, related_name="categories")
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=False)
     status = EnumIntegerField(CategoryStatus, db_index=True, verbose_name=_('status'), default=CategoryStatus.INVISIBLE)
     image = FilerImageField(verbose_name=_('image'), blank=True, null=True)
     ordering = models.IntegerField(default=0, verbose_name=_('ordering'))

--- a/shoop/core/models/contacts.py
+++ b/shoop/core/models/contacts.py
@@ -22,7 +22,7 @@ from shoop.core.utils.name_mixin import NameMixin
 
 @python_2_unicode_compatible
 class ContactGroup(TranslatableModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     members = models.ManyToManyField("Contact", related_name="groups", verbose_name=_('members'), blank=True)
     show_pricing = models.BooleanField(verbose_name=_('show as pricing option'), default=True)
 
@@ -44,7 +44,7 @@ class Contact(NameMixin, PolymorphicModel):
     is_all_seeing = False
 
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
-    identifier = InternalIdentifierField(null=True, blank=True)
+    identifier = InternalIdentifierField(unique=True, null=True, blank=True)
     is_active = models.BooleanField(default=True, db_index=True)
     # TODO: parent contact?
     default_shipping_address = models.ForeignKey(

--- a/shoop/core/models/manufacturers.py
+++ b/shoop/core/models/manufacturers.py
@@ -19,7 +19,7 @@ __all__ = ("Manufacturer",)
 @python_2_unicode_compatible
 class Manufacturer(models.Model):
     created_on = models.DateTimeField(auto_now_add=True, verbose_name=_('added'))
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
 
     name = models.CharField(max_length=128, verbose_name=_('name'))
     url = models.CharField(null=True, blank=True, max_length=128, verbose_name=_('URL'))

--- a/shoop/core/models/methods.py
+++ b/shoop/core/models/methods.py
@@ -85,7 +85,7 @@ class MethodQuerySet(TranslatableQuerySet):
 class Method(ModuleInterface, TranslatableModel):
     tax_class = models.ForeignKey("TaxClass", verbose_name=_('tax class'))
     status = EnumIntegerField(MethodStatus, db_index=True, default=MethodStatus.ENABLED, verbose_name=_('status'))
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     module_identifier = models.CharField(max_length=64, blank=True, verbose_name=_('module'))
     module_data = JSONField(blank=True, null=True)
 

--- a/shoop/core/models/orders.py
+++ b/shoop/core/models/orders.py
@@ -150,7 +150,7 @@ class Order(models.Model):
     # Identification
     shop = UnsavedForeignKey("Shop")
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
-    identifier = InternalIdentifierField(db_index=True, verbose_name=_('order identifier'))
+    identifier = InternalIdentifierField(unique=True, db_index=True, verbose_name=_('order identifier'))
     # TODO: label is actually a choice field, need to check migrations/choice deconstruction
     label = models.CharField(max_length=32, db_index=True, verbose_name=_('label'))
     # The key shouldn't be possible to deduce (i.e. it should be random), but it is

--- a/shoop/core/models/product_media.py
+++ b/shoop/core/models/product_media.py
@@ -33,7 +33,7 @@ class ProductMediaKind(Enum):
 
 @python_2_unicode_compatible
 class ProductMedia(TranslatableModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     product = models.ForeignKey("Product", related_name="media")
     shops = models.ManyToManyField("Shop", related_name="product_media")
     kind = EnumIntegerField(

--- a/shoop/core/models/product_variation.py
+++ b/shoop/core/models/product_variation.py
@@ -128,13 +128,13 @@ def get_combination_hash_from_variable_mapping(parent, variables):
     """
     mapping = {}
     for variable_identifier, value_identifier in variables.items():
-        variable_identifier, _ = ProductVariationVariable.objects.get_or_create(
-            product=parent, identifier=variable_identifier
+        variable, _ = ProductVariationVariable.objects.get_or_create(
+            product=parent, identifier=force_text(variable_identifier)
         )
-        value_identifier, _ = ProductVariationVariableValue.objects.get_or_create(
-            variable=variable_identifier, identifier=value_identifier
+        value, _ = ProductVariationVariableValue.objects.get_or_create(
+            variable=variable, identifier=force_text(value_identifier)
         )
-        mapping[variable_identifier] = value_identifier
+        mapping[variable] = value
     return hash_combination(mapping)
 
 

--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -96,7 +96,7 @@ class ProductVerificationMode(Enum):
 
 @python_2_unicode_compatible
 class ProductType(TranslatableModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     translations = TranslatedFields(
         name=models.CharField(max_length=64, verbose_name=_('name')),
     )

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -23,7 +23,7 @@ class ShopStatus(Enum):
 
 @python_2_unicode_compatible
 class Shop(TranslatableModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     domain = models.CharField(max_length=128, blank=True, null=True, unique=True)
     status = EnumIntegerField(ShopStatus, default=ShopStatus.DISABLED)
     owner = models.ForeignKey("Contact", blank=True, null=True)

--- a/shoop/core/models/suppliers.py
+++ b/shoop/core/models/suppliers.py
@@ -25,7 +25,7 @@ class Supplier(ModuleInterface, models.Model):
     default_module_spec = "shoop.core.suppliers:BaseSupplierModule"
     module_provides_key = "supplier_module"
 
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     name = models.CharField(max_length=64)
     type = EnumIntegerField(SupplierType, default=SupplierType.INTERNAL)
     stock_managed = models.BooleanField(default=False)

--- a/shoop/core/models/taxes.py
+++ b/shoop/core/models/taxes.py
@@ -21,7 +21,7 @@ from ._base import TranslatableShoopModel
 class Tax(TranslatableShoopModel):
     identifier_attr = 'code'
 
-    code = InternalIdentifierField()
+    code = InternalIdentifierField(unique=True)
 
     translations = TranslatedFields(
         name=models.CharField(max_length=64),
@@ -66,7 +66,7 @@ class Tax(TranslatableShoopModel):
 
 
 class TaxClass(TranslatableShoopModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     translations = TranslatedFields(
         name=models.CharField(max_length=100, verbose_name=_('name')),
     )
@@ -78,7 +78,7 @@ class TaxClass(TranslatableShoopModel):
 
 
 class CustomerTaxGroup(TranslatableShoopModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     translations = TranslatedFields(
         name=models.CharField(max_length=100, verbose_name=_('name')),
     )

--- a/shoop/core/models/units.py
+++ b/shoop/core/models/units.py
@@ -23,7 +23,7 @@ __all__ = ("SalesUnit",)
 
 @python_2_unicode_compatible
 class SalesUnit(TranslatableModel):
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     decimals = models.PositiveSmallIntegerField(default=0, verbose_name=_(u"allowed decimals"))
 
     translations = TranslatedFields(

--- a/shoop/notify/models/script.py
+++ b/shoop/notify/models/script.py
@@ -19,7 +19,7 @@ from shoop.notify.enums import StepNext
 @python_2_unicode_compatible
 class Script(models.Model):
     event_identifier = models.CharField(max_length=64, blank=False, db_index=True)
-    identifier = InternalIdentifierField()
+    identifier = InternalIdentifierField(unique=True)
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
     name = models.CharField(max_length=64)
     enabled = models.BooleanField(default=False, db_index=True)

--- a/shoop/simple_cms/models.py
+++ b/shoop/simple_cms/models.py
@@ -49,6 +49,7 @@ class Page(TranslatableModel):
     modified_on = models.DateTimeField(auto_now=True, editable=False)
 
     identifier = InternalIdentifierField(
+        unique=True,
         help_text=_('This identifier can be used in templates to create URLs'),
         editable=True
     )

--- a/shoop_tests/admin/test_product_variation.py
+++ b/shoop_tests/admin/test_product_variation.py
@@ -2,6 +2,8 @@
 from django.forms import formset_factory
 import pytest
 from shoop.admin.modules.products.views.variation.simple_variation_forms import SimpleVariationChildForm, SimpleVariationChildFormSet
+from shoop.admin.modules.products.views.variation.variable_variation_forms import VariableVariationChildrenForm
+from shoop.core.models.product_variation import ProductVariationVariable, ProductVariationVariableValue
 from shoop.testing.factories import create_product
 from shoop_tests.utils import printable_gibberish
 from shoop_tests.utils.forms import get_form_data
@@ -30,3 +32,19 @@ def test_simple_children_formset():
     formset = FormSet(parent_product=parent, data=data)
     formset.save()
     assert not parent.variation_children.exists()  # Got unlinked
+
+
+@pytest.mark.django_db
+def test_variable_variation_form():
+    var1 = printable_gibberish()
+    var2 = printable_gibberish()
+    parent = create_product(printable_gibberish())
+    for a in range(4):
+        for b in range(3):
+            child = create_product(printable_gibberish())
+            child.link_to_parent(parent, variables={var1: a, var2: b})
+    assert parent.variation_children.count() == 4 * 3
+
+    form = VariableVariationChildrenForm(parent_product=parent)
+    assert len(form.fields) == 12
+    # TODO: Improve this test?


### PR DESCRIPTION
Form regression introduced in 43a88d2092a525ac1785588443d2789c095403c5, refs SHOOP-1075.

More importantly: this adds a brand-new migration to fix the slightly broken `InternalIdentifierField` implementation. Refs SHOOP-1092.