### PR TITLE
Rework `SimplePricing` and pricing in general

### DIFF
--- a/shoop/admin/modules/products/views/forms.py
+++ b/shoop/admin/modules/products/views/forms.py
@@ -60,6 +60,7 @@ class ShopProductForm(forms.ModelForm):
     class Meta:
         model = ShopProduct
         fields = (
+            "default_price",
             "suppliers",
             "visible",
             "listed",

--- a/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
@@ -13,6 +13,7 @@
 {% endcall %}
 
 {% call content_block(shop_name_prefix ~ _("Purchasing"), "fa-shopping-cart") %}
+    {{ bs3.field(shop_product_form.default_price) }}
     {{ bs3.field(shop_product_form.suppliers, widget_class="multiselect") }}
     {{ bs3.field(shop_product_form.purchase_multiple) }}
     {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}

--- a/shoop/core/__init__.py
+++ b/shoop/core/__init__.py
@@ -21,7 +21,10 @@ class ShoopCoreAppConfig(AppConfig):
     provides = {
         "api_populator": [
             "shoop.core.api:populate_core_api"
-        ]
+        ],
+        "pricing_module": [
+            "shoop.core.pricing.default_pricing:DefaultPricingModule"
+        ],
     }
 
 

--- a/shoop/core/fields/__init__.py
+++ b/shoop/core/fields/__init__.py
@@ -57,7 +57,6 @@ class MoneyField(models.DecimalField):
     def __init__(self, **kwargs):
         kwargs.setdefault("decimal_places", 9)
         kwargs.setdefault("max_digits", 36)
-        kwargs.setdefault("default", 0)
         super(MoneyField, self).__init__(**kwargs)
 
 

--- a/shoop/core/migrations/0003_moneyfield_changes.py
+++ b/shoop/core/migrations/0003_moneyfield_changes.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('shoop', '0002_identifier_field_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='orderline',
+            name='_total_discount_amount',
+            field=shoop.core.fields.MoneyField(decimal_places=9, verbose_name='total amount of discount',
+                                               max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='orderline',
+            name='_unit_price_amount',
+            field=shoop.core.fields.MoneyField(decimal_places=9, verbose_name='unit price amount', max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='orderlinetax',
+            name='amount',
+            field=shoop.core.fields.MoneyField(decimal_places=9, verbose_name='tax amount', max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='orderlinetax',
+            name='base_amount',
+            field=shoop.core.fields.MoneyField(help_text='Amount that this tax is calculated from', decimal_places=9,
+                                               verbose_name='base amount', max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='payment',
+            name='amount',
+            field=shoop.core.fields.MoneyField(decimal_places=9, max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='purchase_price',
+            field=shoop.core.fields.MoneyField(blank=True, null=True, verbose_name='purchase price', default=None,
+                                               decimal_places=9, max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='suggested_retail_price',
+            field=shoop.core.fields.MoneyField(blank=True, null=True, verbose_name='suggested retail price',
+                                               default=None, decimal_places=9, max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='suppliedproduct',
+            name='purchase_price',
+            field=shoop.core.fields.MoneyField(blank=True, null=True, verbose_name='purchase price', default=None,
+                                               decimal_places=9, max_digits=36),
+        ),
+        migrations.AlterField(
+            model_name='suppliedproduct',
+            name='suggested_retail_price',
+            field=shoop.core.fields.MoneyField(blank=True, null=True, verbose_name='suggested retail price',
+                                               default=None, decimal_places=9, max_digits=36),
+        ),
+    ]

--- a/shoop/core/migrations/0004_shopproduct_default_price.py
+++ b/shoop/core/migrations/0004_shopproduct_default_price.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('shoop', '0003_moneyfield_changes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='shopproduct',
+            name='default_price',
+            field=shoop.core.fields.MoneyField(blank=True, null=True, verbose_name='Default price', decimal_places=9,
+                                               max_digits=36),
+        ),
+        migrations.AddField(
+            model_name='shop',
+            name='prices_include_tax',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/shoop/core/models/order_lines.py
+++ b/shoop/core/models/order_lines.py
@@ -84,8 +84,8 @@ class OrderLine(models.Model, LinePriceMixin):
 
     # The following fields govern calculation of the prices
     quantity = QuantityField(verbose_name=_('quantity'), default=1)
-    _unit_price_amount = MoneyField(verbose_name=_('unit price amount'))
-    _total_discount_amount = MoneyField(verbose_name=_('total amount of discount'))
+    _unit_price_amount = MoneyField(verbose_name=_('unit price amount'), default=0)
+    _total_discount_amount = MoneyField(verbose_name=_('total amount of discount'), default=0)
     _prices_include_tax = models.BooleanField(default=True)
 
     objects = OrderLineManager()

--- a/shoop/core/models/orders.py
+++ b/shoop/core/models/orders.py
@@ -214,8 +214,8 @@ class Order(models.Model):
     extra_data = JSONField(blank=True, null=True)
 
     # Money stuff
-    taxful_total_price = MoneyField(editable=False, verbose_name=_('grand total'))
-    taxless_total_price = MoneyField(editable=False, verbose_name=_('taxless total'))
+    taxful_total_price = MoneyField(editable=False, verbose_name=_('grand total'), default=0)
+    taxless_total_price = MoneyField(editable=False, verbose_name=_('taxless total'), default=0)
     display_currency = models.CharField(max_length=4, blank=True)
     display_currency_rate = models.DecimalField(max_digits=36, decimal_places=9, default=1)
 

--- a/shoop/core/models/product_shops.py
+++ b/shoop/core/models/product_shops.py
@@ -14,7 +14,7 @@ from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumIntegerField
 
 from shoop.core.excs import ProductNotOrderableProblem, ProductNotVisibleProblem
-from shoop.core.fields import QuantityField, UnsavedForeignKey
+from shoop.core.fields import MoneyField, QuantityField, UnsavedForeignKey
 from shoop.core.models.product_media import ProductMediaKind
 from shoop.core.models.products import ProductVisibility, StockBehavior
 from shoop.core.signals import get_orderability_errors, get_visibility_errors
@@ -55,6 +55,10 @@ class ShopProduct(models.Model):
     shop_primary_image = models.ForeignKey(
         "ProductMedia", null=True, blank=True, related_name="primary_image_for_shop_products", on_delete=models.SET_NULL
     )
+
+    # the default price of this product in the shop, taxfulness is determined in
+    # `Shop.prices_include_tax`
+    default_price = MoneyField(verbose_name=_("Default price"), null=True, blank=True)
 
     class Meta:
         unique_together = (("shop", "product",),)

--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -197,8 +197,8 @@ class Product(AttributableMixin, TranslatableModel):
     gross_weight = MeasurementField(unit="g", verbose_name=_('gross weight (g)'))
 
     # Misc.
-    purchase_price = MoneyField(verbose_name=_('purchase price'))
-    suggested_retail_price = MoneyField(verbose_name=_('suggested retail price'))
+    purchase_price = MoneyField(verbose_name=_('purchase price'), blank=True, null=True)
+    suggested_retail_price = MoneyField(verbose_name=_('suggested retail price'), blank=True, null=True)
     manufacturer = models.ForeignKey("Manufacturer", blank=True, null=True, verbose_name=_('manufacturer'))
     primary_image = models.ForeignKey(
         "ProductMedia", null=True, blank=True,

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -28,6 +28,7 @@ class Shop(TranslatableModel):
     status = EnumIntegerField(ShopStatus, default=ShopStatus.DISABLED)
     owner = models.ForeignKey("Contact", blank=True, null=True)
     options = JSONField(blank=True, null=True)
+    prices_include_tax = models.BooleanField(default=True)
 
     translations = TranslatedFields(
         name=models.CharField(max_length=64)

--- a/shoop/core/models/supplied_products.py
+++ b/shoop/core/models/supplied_products.py
@@ -16,8 +16,8 @@ class SuppliedProduct(models.Model):
     product = models.ForeignKey("Product")
     sku = models.CharField(db_index=True, max_length=128, verbose_name=_('SKU'))
     alert_limit = models.IntegerField(default=0, verbose_name=_('alert limit'))
-    purchase_price = MoneyField(verbose_name=_('purchase price'))
-    suggested_retail_price = MoneyField(verbose_name=_('suggested retail price'))
+    purchase_price = MoneyField(verbose_name=_('purchase price'), blank=True, null=True)
+    suggested_retail_price = MoneyField(verbose_name=_('suggested retail price'), blank=True, null=True)
     physical_count = QuantityField(editable=False, verbose_name=_('physical stock count'))
     logical_count = QuantityField(editable=False, verbose_name=_('logical stock count'))
 

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.core.models import ShopProduct
+from shoop.core.pricing import PriceInfo, PricingContext, PricingModule, TaxfulPrice, TaxlessPrice
+
+
+class DefaultPricingContext(PricingContext):
+    REQUIRED_VALUES = ["shop"]
+    shop = None
+
+
+class DefaultPricingModule(PricingModule):
+    identifier = "default_pricing"
+    name = _("Default Pricing")
+
+    pricing_context_class = DefaultPricingContext
+
+    def get_context_from_request(self, request):
+        """
+        Inject shop into pricing context.
+
+        Shop information is used to find correct `ShopProduct`
+        in `self.get_price_info`
+        """
+        return self.pricing_context_class(shop=request.shop)
+
+    def get_price_info(self, context, product, quantity=1):
+        """
+        Return a `PriceInfo` calculated from `ShopProduct.default_price`
+
+        Since `ShopProduct.default_price` can be `None` it will
+        be set to zero (0) if `None`.
+        """
+        shop_product = ShopProduct.objects.get(product=product, shop=context.shop)
+
+        default_price = (shop_product.default_price or 0)
+
+        price_cls = (TaxfulPrice if context.shop.prices_include_tax else TaxlessPrice)
+        return PriceInfo(
+            price=price_cls(default_price),
+            base_price=price_cls(default_price)
+        )

--- a/shoop/core/pricing/price_info.py
+++ b/shoop/core/pricing/price_info.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from shoop.core.pricing import Price
+
+
+class PriceInfo(object):
+    def __init__(self, price, base_price, expires_on=None):
+        """
+        Initialize PriceInfo with two given Price objects.
+
+        Given prices can be taxful or taxless, but their types must match.
+
+        :param price: Price of the product that is calculated in the pricing module
+        :type price: shoop.core.pricing.Price
+        :param base_price: Base price of the product, discounts are calculated based on this.
+        :type base_price: shoop.core.pricing.Price
+        """
+
+        assert isinstance(price, Price)
+        assert isinstance(base_price, Price)
+        assert price._units_match(base_price)
+        self.price = price
+        self.base_price = base_price
+        self.expires_on = expires_on
+
+    @property
+    def includes_tax(self):
+        return self.price.includes_tax
+
+    @property
+    def discount_amount(self):
+        return (self.base_price - self.price)
+
+    @property
+    def discount_percentage(self):
+        return (1 - (self.price / self.base_price)) * 100
+
+    @property
+    def is_discounted(self):
+        return (self.price < self.base_price)

--- a/shoop/core/shortcuts/__init__.py
+++ b/shoop/core/shortcuts/__init__.py
@@ -18,7 +18,6 @@ def update_order_line_from_product(request, order_line, product, quantity=1, sup
         raise Exception("set_from_product may not be used on saved lines")
 
     if not product:  # pragma: no cover
-
         raise Exception("set_from_product may not be used without product")
 
     # TODO: (TAX) Taxes in update_order_line_from_product

--- a/shoop/front/templates/shoop/front/macros.jinja
+++ b/shoop/front/templates/shoop/front/macros.jinja
@@ -1,5 +1,6 @@
 {% macro product_box(product, show_image=True, show_description=False, class="product-box", thumbnail_size=(300,300), shop=None) %}
     {% set u = url("shoop:product", pk=product.pk, slug=product.slug) %}
+    {% set price_info = product.get_price_info(request) %}
     <a href="{{ u }}" rel="product-detail" class="thumbnail product {{ class }}" id="product-{{ product.id }}">
         {% if show_image %}
             <div class="product-image">
@@ -13,7 +14,12 @@
         <div class="caption">
             <h4 class="name">{{ product.name }}</h4>
             {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-            <p class="price">{{ product.get_price(request)|home_currency }}</p>
+            <p class="price">
+                {{ price_info.price|home_currency }}
+                {% if price_info.is_discounted %}
+                    ({{price_info.base_price|home_currency}}) <span class="discount-percent">{{ -price_info.discount_percentage|int }}%</span>
+                {% endif %}
+            </p>
             {% if show_description %}
                 {{ product.description|striptags|truncate(140)|safe }}
             {% endif %}
@@ -33,7 +39,8 @@
                                 <span class="image">{{ product.primary_image|thumbnail(size=(220, 230))|default(STATIC_URL + "site/img/no_image.png") }}</span>
                                 <span class="name">{{ product.name }}</span>
                                 {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-                                <span class="price inverse big">{{ product.get_price(request)|home_currency }}</span>
+                                {% set price_info = product.get_price_info(request) %}
+                                <span class="price inverse big">{{ price_info.price|home_currency }}</span>
                                 <span class="shop">{{ product.shop.name }}</span>
                             </a>
                         {% else %}

--- a/shoop/front/templates/shoop/front/product/_detail_order_section.jinja
+++ b/shoop/front/templates/shoop/front/product/_detail_order_section.jinja
@@ -60,7 +60,8 @@
                         <h4>
                             <small>Total: </small>
                             <span id="product-price-placeholder">
-                                {{ product.get_price(request)|home_currency }}
+                                {% set price_info = product.get_price(request) %}
+                                {{ price_info.price|home_currency }}
                             </span>
                             <span class="sales-unit">
                                 {{ product.sales_unit.short_name }}

--- a/shoop/front/templates/shoop/front/product/detail.jinja
+++ b/shoop/front/templates/shoop/front/product/detail.jinja
@@ -65,10 +65,10 @@
             <h1>{{ product.name }}</h1>
             <p>{% trans %}SKU{% endtrans %}: {{ product.sku }}</p>
             {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-            {% set price = product.get_price(request) %}
+            {% set price_info = product.get_price_info(request) %}
             <h3>
-                {{ price|home_currency }}
-                {% if price.includes_tax %}(incl. tax){% else %}(excl. tax){% endif %}
+                {{ price_info.price|home_currency }}
+                {% if price_info.includes_tax %}(incl. tax){% else %}(excl. tax){% endif %}
                 <small>/ {{ product.sales_unit.short_name }}</small>
             </h3>
 

--- a/shoop/simple_pricing/__init__.py
+++ b/shoop/simple_pricing/__init__.py
@@ -8,6 +8,7 @@
 from shoop.apps import AppConfig
 
 
+# TODO: Document how to create custom pricing modules (Refs SHOOP-514)
 class ShoopSimplePricingAppConfig(AppConfig):
     name = "shoop.simple_pricing"
     verbose_name = "Shoop Simple Pricing"

--- a/shoop/simple_pricing/admin_form_part.py
+++ b/shoop/simple_pricing/admin_form_part.py
@@ -26,8 +26,8 @@ class SimplePricingForm(forms.Form):
             self._build_fields()
 
     def _build_fields(self):
-        self.shops = [None] + list(Shop.objects.all())
-        self.groups = [None] + list(ContactGroup.objects.filter(
+        self.shops = list(Shop.objects.all())
+        self.groups = list(ContactGroup.objects.filter(
             Q(show_pricing=True) |
             Q(
                 id__in=SimpleProductPrice.objects.filter(product=self.product)
@@ -40,6 +40,7 @@ class SimplePricingForm(forms.Form):
             in SimpleProductPrice.objects.filter(product=self.product)
             .values_list("shop_id", "group_id", "price")
         )
+
         for group in self.groups:
             for shop in self.shops:
                 shop_group_id_tuple = self._get_id_tuple(shop, group)

--- a/shoop/simple_pricing/migrations/0002_remove_simpleproductprice_includes_tax.py
+++ b/shoop/simple_pricing/migrations/0002_remove_simpleproductprice_includes_tax.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('simple_pricing', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='simpleproductprice',
+            name='includes_tax',
+        ),
+    ]

--- a/shoop/simple_pricing/migrations/0003_remove_groupless_prices.py
+++ b/shoop/simple_pricing/migrations/0003_remove_groupless_prices.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.db.models import Q
+
+
+def remove_groupless_prices(apps, schema_editor):
+    model = apps.get_model("simple_pricing", "SimpleProductPrice")
+    objs = model.objects.filter(Q(group_id__isnull=True) | Q(shop_id__isnull=True))
+    if objs.count():
+        print("** Removing %d groupless or shopless SimpleProductPrices **" % objs.count())
+        objs.delete()
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('simple_pricing', '0002_remove_simpleproductprice_includes_tax'),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_groupless_prices, migrations.RunPython.noop),
+
+        migrations.AlterField(
+            model_name='simpleproductprice',
+            name='group',
+            field=models.ForeignKey(to='shoop.ContactGroup'),
+        ),
+        migrations.AlterField(
+            model_name='simpleproductprice',
+            name='shop',
+            field=models.ForeignKey(to='shoop.Shop'),
+        ),
+    ]

--- a/shoop/simple_pricing/models.py
+++ b/shoop/simple_pricing/models.py
@@ -15,10 +15,9 @@ from shoop.core.fields import MoneyField
 
 class SimpleProductPrice(models.Model):
     product = models.ForeignKey("shoop.Product", related_name="+")
-    shop = models.ForeignKey("shoop.Shop", blank=True, null=True, db_index=True)
-    group = models.ForeignKey("shoop.ContactGroup", blank=True, null=True, db_index=True)
-    price = MoneyField(default=0)
-    includes_tax = models.BooleanField(default=True)
+    shop = models.ForeignKey("shoop.Shop", db_index=True)
+    group = models.ForeignKey("shoop.ContactGroup", db_index=True)
+    price = MoneyField()
 
     # TODO: (TAX) Check includes_tax consistency (see below)
     #
@@ -34,10 +33,9 @@ class SimpleProductPrice(models.Model):
         verbose_name_plural = _(u"product prices")
 
     def __repr__(self):
-        return "<SimpleProductPrice (p%s,s%s,g%s): price %s (taxfull %s)>" % (
+        return "<SimpleProductPrice (p%s,s%s,g%s): price %s" % (
             self.product_id,
             self.shop_id,
             self.group_id,
             self.price,
-            self.includes_tax,
         )

--- a/shoop/simple_pricing/module.py
+++ b/shoop/simple_pricing/module.py
@@ -5,18 +5,20 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import six
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.core.pricing import PricingContext, PricingModule, TaxfulPrice, TaxlessPrice
+from shoop.core.models import ShopProduct
+from shoop.core.pricing import PriceInfo, PricingContext, PricingModule, TaxfulPrice, TaxlessPrice
 
 from .models import SimpleProductPrice
 
 
 class SimplePricingContext(PricingContext):
-    REQUIRED_VALUES = ("customer_group_ids", "shop_id")
+    REQUIRED_VALUES = ("customer_group_ids", "shop")
     customer_group_ids = ()
-    shop_id = None
+    shop = None
 
 
 class SimplePricingModule(PricingModule):
@@ -27,7 +29,6 @@ class SimplePricingModule(PricingModule):
 
     def get_context_from_request(self, request):
         customer = getattr(request, "customer", None)
-        shop = getattr(request, "shop", None)
 
         if not customer or customer.is_anonymous:
             customer_group_ids = []
@@ -35,44 +36,44 @@ class SimplePricingModule(PricingModule):
             customer_group_ids = sorted(customer.groups.all().values_list("id", flat=True))
 
         return self.pricing_context_class(
-            shop_id=(shop.pk if shop else None),
+            shop=request.shop,
             customer_group_ids=customer_group_ids
         )
 
-    def get_price(self, context, product_id, quantity=1):
-        # TODO: SimplePricingModule: Implement caching that works
+    def get_price_info(self, context, product, quantity=1):
 
-        filter = Q(price__gt=0, product_id=product_id)
+        if isinstance(product, six.integer_types):
+            product_id = product
+            shop_product = ShopProduct.objects.get(product_id=product_id, shop_id=context.shop.pk)
+        else:
+            shop_product = product.get_shop_instance(context.shop)
+            product_id = product.pk
+
+        default_price = (shop_product.default_price or 0)
+
+        includes_tax = context.shop.prices_include_tax
 
         if context.customer_group_ids:
-            filter &= (Q(group__id__in=context.customer_group_ids) | Q(group__isnull=True))
+            filter = Q(price__gt=0, product=product_id, shop=context.shop, group__in=context.customer_group_ids)
+            result = (
+                SimpleProductPrice.objects.filter(filter)
+                .order_by("price")[:1]
+                .values_list("price", flat=True)
+            )
         else:
-            filter &= Q(group__isnull=True)
+            result = None
 
-        if context.shop_id:
-            filter &= (Q(shop_id=context.shop_id) | Q(shop__isnull=True))
+        if result:
+            price = result[0]
+            if default_price > 0:
+                price = min([default_price, price])
         else:
-            filter &= Q(shop__isnull=True)
+            price = default_price
 
-        result = (
-            SimpleProductPrice.objects.filter(filter)
-            .order_by("price")[:1]
-            .values_list("price", "includes_tax")
+        base_price = price
+
+        price_cls = (TaxfulPrice if includes_tax else TaxlessPrice)
+        return PriceInfo(
+            price=price_cls(price),
+            base_price=price_cls(base_price)
         )
-
-        (price, includes_tax) = result[0] if result else (0, False)
-        return _create_price(price, includes_tax)
-
-    def get_base_price(self, product):
-        product_price_model = SimpleProductPrice.objects.filter(product=product, group=None).first()
-        if product_price_model:
-            return _create_price(product_price_model.price, product_price_model.includes_tax)
-
-        return _create_price(0, includes_tax=False)
-
-
-def _create_price(price, includes_tax):
-    if includes_tax:
-        return TaxfulPrice(price)
-    else:
-        return TaxlessPrice(price)

--- a/shoop/simple_pricing/templates/shoop/admin/simple_pricing/form_part.jinja
+++ b/shoop/simple_pricing/templates/shoop/admin/simple_pricing/form_part.jinja
@@ -1,13 +1,13 @@
 {% from "shoop/admin/macros/general.jinja" import content_block with context %}
 {% set sp_form = form["simple_pricing"] %}
-{% call content_block(_("Pricing"), "fa-money") %}
+{% call content_block(_("Customer Group Pricing"), "fa-money") %}
     <div class="table-responsive">
         <table class="table table-bordered table-condensed table-striped">
             <tbody>
             <tr>
-                <th>Prices</th>
+                <th></th>
                 {% for group in sp_form.groups %}
-                    <th scope="col">{% if group %}{{ group }}{% else %}<i>other groups</i>{% endif %}</th>
+                    <th scope="col">{% if group %}{{ group }}{% else %}<i>Default price</i>{% endif %}</th>
                 {% endfor %}
             </tr>
             {% for shop in sp_form.shops %}

--- a/shoop/testing/mock_population.py
+++ b/shoop/testing/mock_population.py
@@ -13,8 +13,8 @@ from django.utils import translation
 from shoop.core.models import Category, Product, ShopProduct
 
 from .factories import (
-    CategoryFactory, ProductFactory, create_default_order_statuses, get_default_payment_method,
-    get_default_shipping_method, get_default_shop
+    CategoryFactory, ProductFactory, create_default_order_statuses, get_default_customer_group,
+    get_default_payment_method, get_default_shipping_method, get_default_shop
 )
 
 
@@ -48,7 +48,8 @@ class Populator:
             SimpleProductPrice.objects.create(
                 product=product,
                 price=random.randint(15, 340),
-                includes_tax=False,
+                shop=get_default_shop(),
+                group=get_default_customer_group()
             )
 
     def populate_if_required(self):

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -15,7 +15,8 @@ from shoop.core.models.order_lines import OrderLineTax
 from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 from shoop.core.shortcuts import update_order_line_from_product
 from shoop.testing.factories import get_address, get_default_payment_method, get_default_shipping_method, \
-    get_default_supplier, get_default_product, get_default_shop, get_initial_order_status, get_default_tax
+    get_default_supplier, get_default_product, get_default_shop, get_initial_order_status, get_default_tax, \
+    get_default_customer_group
 from shoop.simple_pricing.models import SimpleProductPrice
 
 def create_order(request, creator, customer, product):
@@ -69,9 +70,13 @@ def create_order(request, creator, customer, product):
 
 @pytest.mark.django_db
 def test_basic_order(rf, admin_user):
+    shop = get_default_shop()
+    group = get_default_customer_group()
+
     request = rf.get('/')
+    request.shop = shop
     product = get_default_product()
-    SimpleProductPrice.objects.create(product=product, group=None, price=Decimal("100.00"), includes_tax=False)
+    SimpleProductPrice.objects.create(product=product, group=group, shop=shop, price=Decimal("100.00"))
     customer = get_person_contact(admin_user)
     for x in range(10):
         create_order(request, creator=admin_user, customer=customer, product=product)

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -5,19 +5,16 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from decimal import Decimal
 from django.utils.timezone import now
 
 import pytest
-from shoop.core import taxing
-from shoop.core.models import Order, OrderLine, OrderLineType, get_person_contact, OrderStatus
+from shoop.core.models import Order, OrderLine, OrderLineType, get_person_contact
 from shoop.core.models.order_lines import OrderLineTax
 from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 from shoop.core.shortcuts import update_order_line_from_product
 from shoop.testing.factories import get_address, get_default_payment_method, get_default_shipping_method, \
-    get_default_supplier, get_default_product, get_default_shop, get_initial_order_status, get_default_tax, \
-    get_default_customer_group
-from shoop.simple_pricing.models import SimpleProductPrice
+    get_default_supplier, get_default_product, get_default_shop, get_initial_order_status, get_default_tax
+
 
 def create_order(request, creator, customer, product):
     billing_address = get_address()
@@ -71,12 +68,10 @@ def create_order(request, creator, customer, product):
 @pytest.mark.django_db
 def test_basic_order(rf, admin_user):
     shop = get_default_shop()
-    group = get_default_customer_group()
 
     request = rf.get('/')
     request.shop = shop
     product = get_default_product()
-    SimpleProductPrice.objects.create(product=product, group=group, shop=shop, price=Decimal("100.00"))
     customer = get_person_contact(admin_user)
     for x in range(10):
         create_order(request, creator=admin_user, customer=customer, product=product)

--- a/shoop_tests/core/test_default_pricing.py
+++ b/shoop_tests/core/test_default_pricing.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+import pytest
+from shoop.core.pricing import TaxlessPrice, get_pricing_module
+from shoop.core.pricing.default_pricing import DefaultPricingModule
+from shoop.testing.factories import create_product, get_default_shop, create_random_person, get_default_customer_group
+
+original_pricing_module = settings.SHOOP_PRICING_MODULE
+
+
+def setup_module(module):
+    settings.SHOOP_PRICING_MODULE = "default_pricing"
+
+
+def teardown_module(module):
+    settings.SHOOP_PRICING_MODULE = original_pricing_module
+
+
+def get_shop_with_tax(include_tax):
+    shop = get_default_shop()
+    shop.prices_include_tax = include_tax
+    shop.save()
+    return shop
+
+
+def initialize_test(rf, include_tax=False):
+    shop = get_shop_with_tax(include_tax=include_tax)
+
+    group = get_default_customer_group()
+    customer = create_random_person()
+    customer.groups.add(group)
+    customer.save()
+
+    request = rf.get("/")
+    request.shop = shop
+    request.customer = customer
+    return request, shop, group
+
+
+def test_module_is_active():  # this test is because we want to make sure `SimplePricing` is active
+    module = get_pricing_module()
+    assert isinstance(module, DefaultPricingModule)
+
+
+@pytest.mark.django_db
+def test_default_price_none_allowed(rf):
+    request, shop, group = initialize_test(rf, False)
+    shop = get_default_shop()
+    product = create_product("test-product", shop=shop, default_price=None)
+    assert product.get_price(request) == TaxlessPrice(0)
+
+
+@pytest.mark.django_db
+def test_default_price_zero_allowed(rf):
+    request, shop, group = initialize_test(rf, False)
+    shop = get_default_shop()
+    product = create_product("test-product", shop=shop, default_price=0)
+    assert product.get_price(request) == TaxlessPrice(0)
+
+
+@pytest.mark.django_db
+def test_default_price_value_allowed(rf):
+    request, shop, group = initialize_test(rf, False)
+    shop = get_default_shop()
+    product = create_product("test-product", shop=shop, default_price=100)
+    assert product.get_price(request) == TaxlessPrice(100)

--- a/shoop_tests/core/test_price_info.py
+++ b/shoop_tests/core/test_price_info.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from shoop.core.pricing import TaxlessPrice
+from shoop.core.pricing.price_info import PriceInfo
+
+
+def test_price_info_no_discount():
+    pi = PriceInfo(price=TaxlessPrice(100), base_price=TaxlessPrice(100))
+    assert not pi.is_discounted
+    assert pi.discount_percentage == 0
+    assert pi.discount_amount == TaxlessPrice(0)
+
+
+def test_price_info_discounts():
+    pi = PriceInfo(price=TaxlessPrice(75), base_price=TaxlessPrice(100))
+    assert pi.is_discounted
+    assert pi.discount_percentage == 25
+    assert pi.discount_amount == TaxlessPrice(25)

--- a/shoop_tests/core/test_product_packages.py
+++ b/shoop_tests/core/test_product_packages.py
@@ -5,13 +5,15 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from django.test import RequestFactory
 
 import pytest
-from shoop.core.models import OrderLineType, AnonymousContact, ProductMode
+from shoop.core.models import OrderLineType, AnonymousContact, ProductMode, Shop
 from shoop.core.order_creator import OrderCreator
 from shoop.core.order_creator.source import SourceLine
 from shoop.core.pricing import TaxlessPrice
 from shoop.testing.factories import create_product, get_default_shop, get_default_supplier, get_initial_order_status
+from shoop_tests.utils import apply_request_middleware
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 import six
 
@@ -46,7 +48,10 @@ def test_package():
 
     source.shop = get_default_shop()
     source.status = get_initial_order_status()
-    creator = OrderCreator(request=None)
+
+    request = apply_request_middleware(RequestFactory().get("/"))
+
+    creator = OrderCreator(request)
     order = creator.create_order(source)
     pids_to_quantities = order.get_product_ids_and_quantities()
     for child, quantity in six.iteritems(package_def):

--- a/shoop_tests/front/test_basket.py
+++ b/shoop_tests/front/test_basket.py
@@ -27,10 +27,7 @@ def test_basket(rf, storage):
     supplier = get_default_supplier()
     products_and_quantities = []
     for quantity in quantities:
-        product = create_product(printable_gibberish(), shop=shop, supplier=supplier)
-        SimpleProductPrice.objects.get_or_create(
-            shop=shop, product=product, defaults={"price": 50, "includes_tax": False}
-        )
+        product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=50)
         products_and_quantities.append((product, quantity))
 
     is_database = (storage == "shoop.front.basket.storage:DatabaseBasketStorage")

--- a/shoop_tests/simple_supplier/test_simple_supplier.py
+++ b/shoop_tests/simple_supplier/test_simple_supplier.py
@@ -8,7 +8,7 @@
 import pytest
 import random
 from shoop.core.models.suppliers import Supplier
-from shoop.testing.factories import create_product, create_order_with_product
+from shoop.testing.factories import create_product, create_order_with_product, get_default_shop
 
 IDENTIFIER = "test_simple_supplier"
 
@@ -25,7 +25,8 @@ def get_simple_supplier():
 @pytest.mark.django_db
 def test_simple_supplier(rf):
     supplier = get_simple_supplier()
-    product = create_product("simple-test-product")
+    shop = get_default_shop()
+    product = create_product("simple-test-product", shop)
     ss = supplier.get_stock_status(product.pk)
     assert ss.product == product
     assert ss.logical_count == 0

--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -30,7 +30,6 @@ INSTALLED_APPS = add_enabled_addons(SHOOP_ENABLED_ADDONS_FILE, (
     'filer',
     'easy_thumbnails',
     'shoop.core',
-    'shoop.simple_pricing',
     'shoop.simple_supplier',
     'shoop.default_tax',
     'shoop.front',
@@ -153,7 +152,7 @@ TEMPLATES = [
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
-SHOOP_PRICING_MODULE = "simple_pricing"
+SHOOP_PRICING_MODULE = "default_pricing"
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',


### PR DESCRIPTION
Add `PriceInfo` to simplify price handling
Add `prices_include_tax` into `Shop`

The idea behind this change is that `ShopProduct` determines the default price
of the product. Templates should only use `PriceInfo` the pricing module
offers thru `Product`. `SimplePricing` adds Customer Group Specific pricing on
top of that.

`SimplePricing` continues to return lowest possible price for `ShopProduct`

NOTE: The changes in `Product.get_base_price` will cause backwards incompability.

Refs SHOOP-514