### PR TITLE
Translated fields to tabs

### DIFF
--- a/shoop/admin/templates/shoop/admin/attributes/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/attributes/edit.jinja
@@ -1,6 +1,10 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
 {% block title %}{{ attribute.name or _("New Attribute") }}{% endblock %}
 {% block content %}
-    {{ single_section_form("attribute_form", form) }}
+    {% call single_section_form("attribute_form", form) %}
+        {{ language_dependent_content_tabs(form) }}
+        {{ render_monolingual_fields(form) }}
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
@@ -1,5 +1,6 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
 {% block content %}
     <div class="container-fluid">
         <div class="row">
@@ -8,9 +9,8 @@
                 <form method="post" id="contact_group_form">
                     {% csrf_token %}
                     {% call content_block(_("General information"), "fa-info-circle") %}
-                        {% for field in form %}
-                            {{ bs3.field(field) }}
-                        {% endfor %}
+                        {{ language_dependent_content_tabs(form) }}
+                        {{ render_monolingual_fields(form) }}
                     {% endcall %}
                     {% if contact_group.pk %}
                         {% call content_block(_("Members"), "fa-users") %}

--- a/shoop/admin/templates/shoop/admin/macros/multilanguage.jinja
+++ b/shoop/admin/templates/shoop/admin/macros/multilanguage.jinja
@@ -2,6 +2,7 @@
 Render a "language-dependent content" tab block.
 May be called
 * with `field_names` (a list of field names to render within each tab)
+* leaving `field_names` empty renders all translated fields
 * or using a `call(form, language, map) ...` block, where `map` is the `trans_name_map` for
   the given language.
 
@@ -27,12 +28,34 @@ When using multiple language_dependent_content_tabs in a single page, do remembe
                 {% if caller %}
                     {{ caller(form, language, map) }}
                 {% else %}
-                    {% for field_name in field_names %}
-                        {{ bs3.field(form[map[field_name]]) }}
-                    {% endfor %}
+                    {% if field_names %}
+                        {% for field_name in field_names %}
+                            {{ bs3.field(form[map[field_name]]) }}
+                        {% endfor %}
+                    {% else %}
+                        {% for field_name in map %}
+                            {{ bs3.field(form[map[field_name]]) }}
+                        {% endfor %}
+                    {% endif %}
                 {% endif %}
             </div>
         {% endfor %}
     </div>
 </div>
+{% endmacro %}
+
+{#
+Render fields that is not translated for MultiLanguageModelForm.
+Optional `field_names` parameter to render only specific fields.
+#}
+{% macro render_monolingual_fields(form, field_names=[]) %}
+    {% for field in form %}
+        {% if field.name not in form.translated_field_names %}
+            {% if field_names and field.name not in field_names %}
+                {% continue %}
+            {% else %}
+                {{ bs3.field(field) }}
+            {% endif %}
+        {% endif %}
+    {% endfor %}
 {% endmacro %}

--- a/shoop/admin/templates/shoop/admin/methods/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/methods/edit.jinja
@@ -1,5 +1,6 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
 
 {% block content %}
     <div class="container-fluid">
@@ -10,9 +11,7 @@
                     {% csrf_token %}
                     {% call content_block(_("General information"), "fa-info-circle") %}
                         {{ bs3.field(form.module_identifier) }}
-                        {% for language in form.languages %}
-                        {{ bs3.field(form["name__" ~ language]) }}
-                        {% endfor %}
+                        {{ language_dependent_content_tabs(form) }}
                         {{ bs3.field(form.status) }}
                         {{ bs3.field(form.tax_class) }}
                         <div class="row">

--- a/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
@@ -1,7 +1,7 @@
 {% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
 {% set attr_form = form[form_def.name] %}
 {% call content_block(_("Attributes"), "fa-tags") %}
-    {% for field in attr_form %}
-        {{ bs3.field(field) }}
-    {% endfor %}
+	{{ language_dependent_content_tabs(attr_form, tab_id_prefix="attributes") }}
+	{{ render_monolingual_fields(attr_form) }}
 {% endcall %}

--- a/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
@@ -2,6 +2,6 @@
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
 {% set attr_form = form[form_def.name] %}
 {% call content_block(_("Attributes"), "fa-tags") %}
-	{{ language_dependent_content_tabs(attr_form, tab_id_prefix="attributes") }}
-	{{ render_monolingual_fields(attr_form) }}
+    {{ language_dependent_content_tabs(attr_form, tab_id_prefix="attributes") }}
+    {{ render_monolingual_fields(attr_form) }}
 {% endcall %}

--- a/shoop/admin/templates/shoop/admin/shops/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/shops/edit.jinja
@@ -1,5 +1,9 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
 {% block content %}
-    {{ single_section_form("shop_form", form) }}
+    {% call single_section_form("shop_form", form) %}
+        {{ language_dependent_content_tabs(form) }}
+        {{ render_monolingual_fields(form) }}
+    {% endcall %}
 {% endblock %}

--- a/shoop/utils/multilanguage_model_form.py
+++ b/shoop/utils/multilanguage_model_form.py
@@ -51,6 +51,7 @@ class MultiLanguageModelForm(TranslatableModelForm):
         ]
         self.trans_field_map = defaultdict(dict)
         self.trans_name_map = defaultdict(dict)
+        self.translated_field_names = []
         self.non_default_languages = sorted(set(self.languages) - set([self.default_language]))
         self.language_names = dict((lang, get_language_name(lang)) for lang in self.languages)
 
@@ -66,6 +67,7 @@ class MultiLanguageModelForm(TranslatableModelForm):
                 self.base_fields[language_field_name] = language_field
                 self.trans_field_map[lang][language_field_name] = f
                 self.trans_name_map[lang][f.name] = language_field_name
+                self.translated_field_names.append(language_field_name)
 
         instance = kwargs.get("instance")
         initial = kwargs.get("initial")


### PR DESCRIPTION
Add more tools to render language dependent content
Use these tools to render translated fields for attributes, product attributes, contact groups, methods and shops correctly.

Refs SHOOP-1049