### PR TITLE
Fix checking of duplicate settings

### DIFF
--- a/shoop/apps/settings.py
+++ b/shoop/apps/settings.py
@@ -33,7 +33,7 @@ def collect_settings(app_name, settings_module):
 
 def _declare_setting(app_name, module, name, default):
     if name in _KNOWN_SETTINGS:
-        other_app = _KNOWN_SETTINGS[name].get('app_name')
+        other_app = _KNOWN_SETTINGS[name].app_name
         raise ImproperlyConfigured(
             'Apps %s and %s define same setting %s' % (
                 other_app, app_name, name))


### PR DESCRIPTION
Currently shoop.apps.settings module tries to check that no setting is
declared in two separate apps.  It should raise ImproperlyConfigured
exception when that happens, but the code was left in broken state on
refactoring and therefore AttributeError was raised instead.

Fix the code to provide more info about which apps are declaring the
conflicting setting.

Refs SHOOP-1277