### PR TITLE
Add missing migrations

### DIFF
--- a/shoop/core/migrations/0005_drop_defaults_at_moneyfields.py
+++ b/shoop/core/migrations/0005_drop_defaults_at_moneyfields.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0004_shopproduct_default_price'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='orderline',
+            name='_total_discount_amount',
+            field=shoop.core.fields.MoneyField(default=0, verbose_name='total amount of discount', max_digits=36, decimal_places=9),
+        ),
+        migrations.AlterField(
+            model_name='orderline',
+            name='_unit_price_amount',
+            field=shoop.core.fields.MoneyField(default=0, verbose_name='unit price amount', max_digits=36, decimal_places=9),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='purchase_price',
+            field=shoop.core.fields.MoneyField(null=True, verbose_name='purchase price', max_digits=36, decimal_places=9, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='suggested_retail_price',
+            field=shoop.core.fields.MoneyField(null=True, verbose_name='suggested retail price', max_digits=36, decimal_places=9, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='suppliedproduct',
+            name='purchase_price',
+            field=shoop.core.fields.MoneyField(null=True, verbose_name='purchase price', max_digits=36, decimal_places=9, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='suppliedproduct',
+            name='suggested_retail_price',
+            field=shoop.core.fields.MoneyField(null=True, verbose_name='suggested retail price', max_digits=36, decimal_places=9, blank=True),
+        ),
+    ]

--- a/shoop/notify/migrations/0002_notification_identifier.py
+++ b/shoop/notify/migrations/0002_notification_identifier.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop_notify', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notification',
+            name='identifier',
+            field=shoop.core.fields.InternalIdentifierField(unique=False, editable=False, max_length=64, blank=True, null=True),
+        ),
+    ]

--- a/shoop/simple_pricing/migrations/0004_simpleproductprice_price.py
+++ b/shoop/simple_pricing/migrations/0004_simpleproductprice_price.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('simple_pricing', '0003_remove_groupless_prices'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='simpleproductprice',
+            name='price',
+            field=shoop.core.fields.MoneyField(max_digits=36, decimal_places=9),
+        ),
+    ]


### PR DESCRIPTION
Core: Add migration to drop default values from moneyfields
Notify: Add migration to make notification identifier not unique
Simple pricing: Add migration to drop default from price