### PR TITLE
Add logo and name for classic gray

### DIFF
--- a/shoop/themes/classic_gray/bower.json
+++ b/shoop/themes/classic_gray/bower.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "bootstrap": "~3.3.5",
-    "font-awesome": "~4.4.0"
+    "font-awesome": "~4.4.0",
+    "bootstrap-select": "~1.6.4"
   }
 }

--- a/shoop/themes/classic_gray/gulpfile.js
+++ b/shoop/themes/classic_gray/gulpfile.js
@@ -29,7 +29,7 @@ gulp.task("js", function() {
     return gulp.src([
         "bower_components/jquery/dist/jquery.js",
         "bower_components/bootstrap/dist/js/bootstrap.js",
-        "bower_components/bootstrap-select/js/bootstrap-select.js",
+        "bower_components/bootstrap-select/dist/js/bootstrap-select.js",
         "static_src/js/custom.js"
     ])
         .pipe(plumber({}))

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
@@ -9,7 +9,7 @@
     {% block extrameta %}{% endblock %}
 
     {# Page Title #}
-    <title>{{ request.shop }} &ndash; {% block title %}{% endblock %}</title>
+    <title>{{ request.shop.public_name }} &ndash; {% block title %}{% endblock %}</title>
 
     {# Include Favicon #}
     <link rel="icon" type="image/x-icon" href="{{ STATIC_URL }}classic_gray/img/favicon.ico">

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
@@ -145,15 +145,12 @@
 </div>
 <div class="bottom-nav">
     <div class="container">
-        {# TODO: Check if logo exists and add class "no-image" based on that #}
-        <div class="logo no-image">
-            {# TODO: Get the actual logo and logo url #}
-            {% if request.shop_logo %}
-                {% set logo_cropped = request.shop_logo|thumbnail(size(500,500))%}
-                <a href="/" class="image" style="background-image:url('{{ logo_cropped }}')"></a>
-                }
+        {% set cropped_logo = request.shop.logo|thumbnail(size=(500,500)) %}
+        <div class="logo {% if not cropped_logo %}no-image{% endif %}">
+            {% if cropped_logo %}
+                <a href="/" class="image" style="background-image:url('{{ cropped_logo }}')"></a>
             {% else %}
-                <a href="/" class="text"><h4>{{ request.shop }}</h4></a>
+                <a href="/" class="text"><h4>{{ request.shop.public_name }}</h4></a>
             {% endif %}
         </div>
         <button class="toggle-mobile-nav">

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/index.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/index.jinja
@@ -1,7 +1,7 @@
 {% extends "shoop/front/base.jinja" %}
 
 {% block title %}{% trans %}Home{% endtrans %}{% endblock %}
-{% block content_title %}{% trans %}Welcome to {% endtrans %}{{ request.shop }}!{% endblock %}
+{% block content_title %}{% trans %}Welcome to {% endtrans %}{{ request.shop.public_name }}!{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Classic gray theme: Add missing bootstrap-select to bower.json
Classic gray theme: Use shop logo and public name in templates

Refs SHOOP-1178