### PR TITLE
Enable Classic Gray theme (SHOOP-1194)

### DIFF
--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = add_enabled_addons(SHOOP_ENABLED_ADDONS_FILE, (
     'shoop.api',
     'shoop.core',
     'shoop.default_tax',
+    'shoop.themes.classic_gray',
     'shoop.front',
     'shoop.front.apps.auth',
     'shoop.front.apps.customer_information',


### PR DESCRIPTION
Add shoop.themes.classic_gray to INSTALLED_APPS to make it available for
theme selection in the Shop Admin.