### PR TITLE
Fix `get_root_categories` performance

### DIFF
--- a/shoop/front/template_helpers/general.py
+++ b/shoop/front/template_helpers/general.py
@@ -12,6 +12,7 @@ from mptt.templatetags.mptt_tags import cache_tree_children
 from shoop.core.models import Category, Manufacturer, Product
 from shoop.front.utils.product_statistics import get_best_selling_product_info
 from shoop.front.utils.views import cache_product_things
+from shoop.utils.translation import cache_translations_for_tree
 
 
 def _get_list_products(request):
@@ -87,4 +88,5 @@ def get_root_categories(context):
     roots = cache_tree_children(
         Category.objects.all_visible(
             customer=request.customer, shop=request.shop, language=language))
+    cache_translations_for_tree(roots, languages=[language])
     return roots

--- a/shoop/utils/iterables.py
+++ b/shoop/utils/iterables.py
@@ -8,6 +8,47 @@
 
 
 def first(iterable, default=None):
+    """
+    Get the first item from the iterable, if possible, or return `default`.
+
+    The iterable is, naturally, iterated for one value.
+
+    :param iterable: An iterable.
+    :type iterable: Iterable
+    :param default: Default value
+    :type default: object
+    :return: The first item from the iterable, or `default`
+    :rtype: object
+    """
     for x in iterable:
         return x
     return default
+
+
+def batch(iterable, count):
+    """
+    Yield batches of `count` items from the given iterable.
+
+    >>> for x in batch([1, 2, 3, 4, 5, 6, 7], 3):
+    >>>   print(x)
+    [1, 2, 3]
+    [4, 5, 6]
+    [7]
+
+    :param iterable: An iterable
+    :type iterable: Iterable
+    :param count: Number of items per batch. If <= 0, nothing is yielded.
+    :type count: int
+    :return: Iterable of lists of items
+    :rtype: Iterable[list[object]]
+    """
+    if count <= 0:
+        return
+    current_batch = []
+    for item in iterable:
+        if len(current_batch) == count:
+            yield current_batch
+            current_batch = []
+        current_batch.append(item)
+    if current_batch:
+        yield current_batch

--- a/shoop/utils/translation.py
+++ b/shoop/utils/translation.py
@@ -36,3 +36,23 @@ def cache_translations(objects, languages=None, meta=None):
             master._translations_cache[xlate_model][translation.language_code] = translation
             setattr(translation, translation.__class__.master.cache_name, master)
     return objects
+
+
+def cache_translations_for_tree(root_objects, languages=None):
+    """
+    Cache translation objects in given languages, iterating MPTT trees.
+
+    :param root_objects: List of MPTT models
+    :type root_objects: Iterable[model]
+    :param languages: List of languages
+    :type languages: Iterable[str]
+    """
+    all_objects = {}
+
+    def walk(object_list):
+        for object in object_list:
+            all_objects[object.pk] = object
+            walk(object.get_children())
+
+    walk(root_objects)
+    cache_translations(list(all_objects.values()), languages=languages)

--- a/shoop/utils/translation.py
+++ b/shoop/utils/translation.py
@@ -7,10 +7,11 @@
 # LICENSE file in the root directory of this source tree.
 
 
-def cache_translations(objects, languages=None):
+def cache_translations(objects, languages=None, meta=None):
     """
     Cache translation objects in given languages to the objects in one fell swoop.
     This will iterate a queryset, if one is passed!
+
     :param objects: List or queryset of Translatable models
     :param languages: Iterable of languages to fetch. In addition, all "_current_language"s will be fetched
     :return: objects
@@ -18,11 +19,15 @@ def cache_translations(objects, languages=None):
     if not objects:
         return objects
     languages = set(languages or ())
-    xlate_model = objects[0]._parler_meta.root_model
+    if meta is None:
+        meta = objects[0]._parler_meta.root  # work on base model by default
+    xlate_model = meta.model
+
     object_map = dict((object.pk, object) for object in objects)
     languages.update(set(object._current_language for object in objects))
-    for translation in xlate_model.objects.filter(master_id__in=object_map.keys(), language_code__in=languages):
+    master_ids = object_map.keys()
+    for translation in xlate_model.objects.filter(master_id__in=master_ids, language_code__in=languages):
         master = object_map[translation.master_id]
-        master._translations_cache[translation.language_code] = translation
+        master._translations_cache[xlate_model][translation.language_code] = translation
         setattr(translation, translation.__class__.master.cache_name, master)
     return objects

--- a/shoop_tests/admin/test_media_module.py
+++ b/shoop_tests/admin/test_media_module.py
@@ -21,7 +21,7 @@ def test_media_view_images(rf):
     file = File.objects.create(name="normalfile", folder=folder)
     img = Image.objects.create(name="imagefile", folder=folder)
 
-    request = apply_request_middleware(rf.get("/sa/media", {"filter": "images", "action": "folder", "id": folder.id}))
+    request = apply_request_middleware(rf.get("/", {"filter": "images", "action": "folder", "id": folder.id}))
     view_func = MediaBrowserView.as_view()
     response = view_func(request)
     assert isinstance(response, JsonResponse)

--- a/shoop_tests/front/test_general_template_helpers.py
+++ b/shoop_tests/front/test_general_template_helpers.py
@@ -10,6 +10,7 @@ from shoop.front.template_helpers import general
 from shoop.testing.mock_population import populate_if_required
 from shoop_tests.front.fixtures import get_jinja_context
 
+
 @pytest.mark.django_db
 def test_get_root_categories():
     populate_if_required()
@@ -17,11 +18,13 @@ def test_get_root_categories():
     for root in general.get_root_categories(context=context):
         assert not root.parent_id
 
+
 @pytest.mark.django_db
 def test_get_newest_products():
     populate_if_required()
     context = get_jinja_context()
     assert len(list(general.get_newest_products(context, n_products=4))) == 4
+
 
 @pytest.mark.django_db
 def test_get_random_products():
@@ -29,15 +32,10 @@ def test_get_random_products():
     context = get_jinja_context()
     assert len(list(general.get_random_products(context, n_products=4))) == 4
 
+
 @pytest.mark.django_db
 def test_get_all_manufacturers():
     populate_if_required()
     context = get_jinja_context()
     # TODO: This is not a good test
     assert len(general.get_all_manufacturers(context)) == 0
-
-@pytest.mark.django_db
-def test_get_root_categories():
-    populate_if_required()
-    context = get_jinja_context()
-    general.get_root_categories(context)


### PR DESCRIPTION
10,000 Categories.
One Index Page.

Left: new hotness. Right: old and busted.

![image](https://cloud.githubusercontent.com/assets/58669/9903077/e0a858e6-5c7b-11e5-9742-f5ca3b5f19ec.png)

---

Now that `cache_translations` works again, this PR will likely speed up other, unrelated parts of Shoop as well. Yayness!
