### PR TITLE
Classic gray product images

### DIFF
--- a/shoop/themes/classic_gray/gulpfile.js
+++ b/shoop/themes/classic_gray/gulpfile.js
@@ -9,7 +9,7 @@ var PRODUCTION = gutil.env.production || process.env.NODE_ENV == "production";
 
 gulp.task("less", function() {
     return gulp.src([
-        "bower_components/dist/assets/owl.carousel.css",
+        "bower_components/owl.carousel/dist/assets/owl.carousel.css",
         "static_src/less/style.less"
     ])
         .pipe(plumber({}))
@@ -33,6 +33,7 @@ gulp.task("js", function() {
         "bower_components/bootstrap-select/dist/js/bootstrap-select.js",
         "bower_components/jquery.easing/js/jquery.easing.js",
         "bower_components/owl.carousel/dist/owl.carousel.js",
+        "static_src/js/vendor/imagelightbox.js",
         "static_src/js/custom.js"
     ])
         .pipe(plumber({}))

--- a/shoop/themes/classic_gray/static_src/js/vendor/imagelightbox.js
+++ b/shoop/themes/classic_gray/static_src/js/vendor/imagelightbox.js
@@ -311,3 +311,84 @@
         return this;
     };
 })( jQuery, window, document );
+
+
+// ACTIVITY INDICATOR
+var activityIndicatorOn = function() {
+    $('<div id="imagelightbox-loading"><i class="fa fa-spinner fa-spin"></i></div>').appendTo('body');
+},
+activityIndicatorOff = function() {
+    $('#imagelightbox-loading').remove();
+},
+
+// OVERLAY
+overlayOn = function() {
+    $('<div id="imagelightbox-overlay"></div>').appendTo('body');
+},
+overlayOff = function() {
+    $('#imagelightbox-overlay').remove();
+},
+
+// CLOSE BUTTON
+closeButtonOn = function(instance) {
+    $('<button type="button" id="imagelightbox-close" title="Close"><i class="fa fa-times"></i></button>')
+        .appendTo('body').on('click touchend', function() {
+            $(this).remove();
+            instance.quitImageLightbox();
+            return false;
+        }
+    );
+},
+closeButtonOff = function() {
+    $('#imagelightbox-close').remove();
+},
+
+// ARROWS
+arrowsOn = function(instance, selector) {
+    var $arrows = $('<button type="button" class="imagelightbox-arrow imagelightbox-arrow-left"><i class="fa fa-chevron-left"></i></button><button type="button" class="imagelightbox-arrow imagelightbox-arrow-right"><i class="fa fa-chevron-right"></i></button>');
+
+    $arrows.appendTo('body');
+
+    $arrows.on('click touchend', function(e) {
+        e.preventDefault();
+
+        var $this   = $(this),
+            $target = $(selector + '[href="' + $('#imagelightbox').attr('src') + '"]'),
+            index   = $target.index(selector);
+
+        if ($this.hasClass('imagelightbox-arrow-left')) {
+            index = index - 1;
+            if (!$(selector).eq(index).length)
+                index = $(selector).length;
+        } else {
+            index = index + 1;
+            if (!$(selector).eq(index).length)
+                index = 0;
+        }
+
+        instance.switchImageLightbox(index);
+        return false;
+    });
+},
+arrowsOff = function() {
+    $('.imagelightbox-arrow').remove();
+},
+
+// CAPTION
+captionOn = function() {
+    var title = $('a[href="' + $('#imagelightbox').attr('src') + '"] .image').attr('data-title');
+    var description = $('a[href="' + $('#imagelightbox').attr('src') + '"] .image').attr('data-description');
+    if (description.length && title.length > 0) {
+        $('<div id="imagelightbox-caption"><div class="container"><strong>' + title + '</strong> - ' + description + '</div></div>').appendTo('body');
+    } else {
+        if (title.length > 0) {
+            $('<div id="imagelightbox-caption"><div class="container"><strong>' + title + '</strong></div></div>').appendTo('body');
+        }
+        if (description.length > 0) {
+            $('<div id="imagelightbox-caption"><div class="container">' + description + '</div></div>').appendTo('body');
+        }
+    }
+},
+captionOff = function() {
+    $('#imagelightbox-caption').remove();
+};

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product.less
@@ -1,3 +1,105 @@
+.product-image {
+    .product-carousel {
+        margin-bottom: 10px;
+
+        &:hover {
+            .carousel-arrow {
+                opacity: 1;
+            }
+        }
+        &.fade {
+            opacity: 1;
+
+            .item {
+                .transition(opacity 0.5s);
+                left: 0 !important;
+                opacity: 0;
+                top: 0;
+                position: absolute;
+                width: 100%;
+                display: block !important;
+                z-index: 1;
+                padding: 0;
+                height: 100%;
+                &:first-child {
+                    top: auto;
+                    position: relative;
+                    padding: 0;
+                }
+                &.active {
+                    height: 100%;
+                    opacity: 1;
+                    .transition(opacity 0.5s ease-in-out);
+                    z-index:2;
+                }
+                .image {
+                    background-position: 50%;
+                    background-size: contain;
+                    background-repeat: no-repeat;
+                    &:before {
+                        display: block;
+                        content: "";
+                        padding-top: 100%;
+                    }
+                }
+            }
+        }
+    }
+
+    .wrap-thumbnails {
+        padding: 0px 30px;
+
+        .owl-item {
+            .thumbnail {
+                margin-bottom: 2px;
+                margin-right: 2px;
+            }
+            .image {
+                background-position: 50%;
+                background-size: contain;
+                background-repeat: no-repeat;
+                &:before {
+                    display: block;
+                    content: "";
+                    padding-top: 100%;
+                }
+            }
+        }
+        .owl-stage-outer {
+            z-index: 2;
+        }
+        .carousel-thumbnails {
+            position: relative;
+        }
+        .owl-nav {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            top: 0;
+            .owl-prev, .owl-next {
+                position: absolute;
+                top: 0;
+                text-align: center;
+                height: 100%;
+                padding: 0px 5px;
+                display: flex;
+                flex-flow: wrap;
+                i {
+                    align-self: center;
+                }
+            }
+            .owl-prev {
+                left: 0;
+                margin-left: -30px;
+            }
+            .owl-next {
+                right: 0;
+                margin-right: -30px;
+            }
+        }
+    }
+}
+
 .btn-add-to-cart {
     .clearfix;
     margin: 25px 0px;

--- a/shoop/themes/classic_gray/static_src/less/vendor/imagelightbox.less
+++ b/shoop/themes/classic_gray/static_src/less/vendor/imagelightbox.less
@@ -8,7 +8,7 @@
 .imagelightbox-arrow {
     width: 3.75em;
     height: 7.5em;
-    background-color: @brand-primary;
+    background-color: @gray;
     color: #fff;
     vertical-align: middle;
     display: none;
@@ -29,12 +29,24 @@
     }
 }
 
-#imagelightbox-overlay, #imagelightbox-close, .imagelightbox-arrow {
-    animation: 0.25s linear 0s normal none 1 running fade-in;
+#imagelightbox-overlay,
+#imagelightbox-close,
+.imagelightbox-arrow,
+#imagelightbox-caption {
+    -webkit-animation: fade-imagelightbox-in .25s linear;
+    animation: fade-imagelightbox-in .25s linear;
+}
+@-webkit-keyframes fade-imagelightbox-in {
+    from    { opacity: 0; }
+    to      { opacity: 1; }
+}
+@keyframes fade-imagelightbox-in {
+    from    { opacity: 0; }
+    to      { opacity: 1; }
 }
 
 #imagelightbox-overlay {
-    background-color: rgba(255, 255, 255, 0.85);
+    background-color: fade(@body-bg, 95%);
     position: fixed;
     z-index: 9998;
     top: 0px;
@@ -70,4 +82,17 @@
         font-size: 52px;
         padding: 20px;
     }
+}
+
+#imagelightbox-caption {
+    text-align: center;
+    color: @text-color;
+    background: fade(@body-bg, 80%);
+    position: fixed;
+    z-index: 10001;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 1.5rem 0;
+    transition: all 0.1s;
 }

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -38,39 +38,6 @@
     </div>
 {% endmacro %}
 
-{% macro product_carousel(products, id) %}
-    <div class="carousel slide col-md-6" id="{{ id }}">
-        <div class="carousel-inner">
-            {% for slide in products|batch(3) %}
-                <div class="item{% if loop.first %} active{% endif %}">
-                    {% for product in slide %}
-                        {% if product %}
-                            <a href="{{ product.get_absolute_url() }}" class="span-third text-center recommended-product">
-                                <span class="image">{{ product.primary_image|thumbnail(size=(220, 230))|default(STATIC_URL + "site/img/no_image.png") }}</span>
-                                <span class="name">{{ product.name }}</span>
-                                {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-                                {% set price_info = product.get_price_info(request) %}
-                                <span class="price inverse big">{{ price_info.price|home_currency }}</span>
-                                <span class="shop">{{ product.shop.name }}</span>
-                            </a>
-                        {% else %}
-                            <a href="#" class="span-third text-center recommended-product">
-                                <span class="image">&nbsp;</span>
-                                <span class="name">&nbsp;</span>
-                                <span class="shop">&nbsp;</span>
-                            </a>
-                        {% endif %}
-                    {% endfor %}
-                </div>
-            {% endfor %}
-        </div>
-
-        {# Carousel nav #}
-        <a class="carousel-control left" href="#{{ id }}" data-slide="prev">&lsaquo;</a>
-        <a class="carousel-control right" href="#{{ id }}" data-slide="next">&rsaquo;</a>
-    </div>
-{% endmacro %}
-
 {% macro render_cross_sell_products(product, relation_type="", title="") %}
     {%- set cross_sell_products = shoop.product.get_product_cross_sells(product, relation_type) %}
     {% if cross_sell_products %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_product_images.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_product_images.jinja
@@ -1,0 +1,36 @@
+<div id="carousel_product_{{ product.id }}" class="product-carousel carousel fade" data-ride="carousel" data-interval="false">
+    <div class="carousel-inner">
+        {% for product_image in images %}
+            <div class="item{% if product_image == primary_image %} active{% endif %}">
+                {% set product_image_cropped = product_image|thumbnail(size=(700, 700)) %}
+                {% if loop|count > 1 %}
+                    <a data-imagelightbox="image-multiple" href="{{ product_image.url }}" rel="gallery" class="thumbnail">
+                        <div class="image" style="background-image:url('{{ product_image_cropped }}')" data-title="{% if product_image.title %}{{ product_image.title }}{% endif %}" data-description="{% if product_image.description %}{{ product_image.description }}{% endif %}"></div>
+                    </a>
+                {% else %}
+                    <a data-imagelightbox="image" href="{{ product_image.url }}" rel="gallery" class="thumbnail">
+                        <div class="image" style="background-image:url('{{ product_image_cropped }}')" data-title="{% if product_image.title %}{{ product_image.title }}{% endif %}" data-description="{% if product_image.description %}{{ product_image.description }}{% endif %}"></div>
+                    </a>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="item active">
+                <div class="thumbnail" rel="gallery1">
+                    <img class="img-responsive no-image" alt="{{ product.name }}" src="{{ STATIC_URL }}classic_gray/img/no_image.png">
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+</div>
+<div class="wrap-thumbnails">
+    <div class="carousel-thumbnails owl-carousel">
+        {% for product_image in images %}
+            {% if loop|count > 1 %}
+                {% set product_image_thumbnail = product_image|thumbnail(size=(300, 300)) %}
+                <a href="#carousel_product_{{ product.id }}" class="thumbnail" data-slide-to="{{ loop.index0 }}">
+                    <div class="image" style="background-image:url('{{ product_image_thumbnail }}')"></div>
+                </a>
+            {% endif %}
+        {% endfor %}
+    </div>
+</div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -29,52 +29,19 @@
 {% block content %}
 
     <div class="row product-main">
-
         <div class="product-image col-sm-5">
-            <div id="carousel_product_{{ product.id }}" class="product-carousel carousel slide" data-ride="carousel" data-interval="false">
-                <div class="carousel-inner">
-                    {% for product_image in images %}
-                        <div class="item{% if product_image == primary_image %} active{% endif %}">
-                            <a href="{{ product_image.url }}" class="thumbnail" rel="gallery1">
-                                <img class="img-responsive" src="{{ product_image|thumbnail(size=(600, 600), crop="smart", upscale=True) }}" alt="{{ product.name }}">
-                            </a>
-                        </div>
-                    {% else %}
-                        <div class="item active">
-                            <div class="thumbnail" rel="gallery1">
-                                <img class="img-responsive no-image" alt="{{ product.name }}" src="{{ STATIC_URL }}classic_gray/img/no_image.png">
-                            </div>
-                        </div>
-                    {% endfor %}
-                </div>
-            </div>
-            <div class="row carousel-thumbnails">
-                {% for product_image in images %}
-                    {% if loop|count > 1 %}
-                        <div class="col-xs-4 col-md-3">
-                            <a href="#carousel_product_{{ product.id }}" data-slide-to="{{ loop.index0 }}" class="thumbnail">
-                                <img src="{{ product_image|thumbnail(size=(300, 300), crop="smart", upscale=True)}}" class="img-responsive" alt="{{ product.name }}">
-                            </a>
-                        </div>
-                    {% endif %}
-                {% endfor %}
-            </div>
+            {% include "shoop/front/product/_product_images.jinja" %}
         </div>
-
-        <div class="col-sm-7">
+        <div class="product-basic-details col-sm-7">
             <h1>{{ product.name }}</h1>
             <p>{% trans %}SKU{% endtrans %}: {{ product.sku }}</p>
             <hr>
-
             <div class="well">
                 {% include "shoop/front/product/_detail_order_section.jinja" with context %}
             </div>
         </div>
-
     </div>
-
     <hr>
-
     {% if product.description %}
         <div class="product-description clearfix">
             <div class="panel panel-default">
@@ -134,4 +101,69 @@
         product, relation_type="computed", title=_("Users who bought this product also bought")
     ) }}
 
+{% endblock %}
+
+{% block extrajs %}
+<script>
+    // Set up owl carousel for product page's slider thumbnails.
+    $(".owl-carousel.carousel-thumbnails").owlCarousel({
+        margin: 10,
+        nav: $(".carousel-thumbnails .thumbnail").length > 4,
+        navText: [
+            "<i class='fa fa-chevron-left'></i>",
+            "<i class='fa fa-chevron-right'></i>"
+        ],
+        responsiveClass: true,
+        items: 4
+    });
+
+    // Enable lightbox for products with multiple images. Uses arrows to
+    // navigate through images.
+    var selector_multiple = "a[data-imagelightbox='image-multiple']";
+    var instance_multiple = $(selector_multiple).imageLightbox({
+        "onStart": function() {
+            overlayOn();
+            closeButtonOn(instance_multiple);
+            arrowsOn(instance_multiple, selector_multiple);
+        },
+        "onEnd": function() {
+            overlayOff();
+            closeButtonOff();
+            arrowsOff();
+            captionOff();
+        },
+        "onLoadStart": function() {
+            activityIndicatorOn();
+            captionOff();
+        },
+        "onLoadEnd": function() {
+            $(".imagelightbox-arrow").css("display", "block");
+            activityIndicatorOff();
+            captionOn();
+        }
+    });
+
+    // Enable lightbox for products with only one image.
+    var selector = "a[data-imagelightbox='image']";
+    var instance = $(selector).imageLightbox({
+        "onStart": function() {
+            overlayOn();
+            closeButtonOn(instance);
+        },
+        "onEnd": function() {
+            overlayOff();
+            closeButtonOff();
+            captionOff();
+        },
+        "onLoadStart": function() {
+            activityIndicatorOn();
+            captionOff();
+        },
+        "onLoadEnd": function() {
+            $(".imagelightbox-arrow").css("display", "block");
+            activityIndicatorOff();
+            captionOn();
+        }
+    });
+</script>
 {% endblock %}


### PR DESCRIPTION
* Remove image carousel from macros since it is not used anywhere
* Update Gulp to include lightbox and fix path for owl carousel
* Update product page template for product images:
  * Move product image to it's own file
  * Provide image titles and descriptions as data-attributes
  * Use background images instead of images so that every aspect ratio images can be used without the need of cropping every image to square
  * Thumbnails now use owl carousel
* Add styles for images on product page and lightbox
* Update lightbox javascript
  * Add overlay, loader icon, close button and arrows
  * Support for image titles and descriptions

![classic_gray_image_lightbox](https://cloud.githubusercontent.com/assets/7901266/9905350/2f407da6-5c8d-11e5-8ce7-b6b0cfb71390.JPG)
![screen shot 2015-09-16 at 15 40 11](https://cloud.githubusercontent.com/assets/7901266/9905351/2f673982-5c8d-11e5-82e3-94738ba982fa.png)
