### PR TITLE
Fix PriceInfo usage with non-one quantities (SHOOP-1462)

### DIFF
--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -260,10 +260,11 @@ class Product(AttributableMixin, TranslatableModel):
 
     def get_price_info(self, context, quantity=1):
         """
-        returns a `PriceInfo` object for product
+        Get `PriceInfo` object for the product in given context.
 
-        Returned `PriceInfo` object contains calculated `price` and `base_price`.
-        The calculation of prices is handled in the current pricing module.
+        Returned `PriceInfo` object contains calculated `price` and
+        `base_price`.  The calculation of prices is handled in the
+        current pricing module.
 
         :type context: shoop.core.contexts.PriceTaxContext
         :rtype: shoop.core.pricing.PriceInfo
@@ -275,26 +276,31 @@ class Product(AttributableMixin, TranslatableModel):
 
     def get_price(self, context, quantity=1):
         """
-        Returns `price` of the product calculated in the current pricing module.
+        Get price of the product within given context.
+
+        .. note::
+
+           When the current pricing module implements pricing steps, it
+           is possible that ``p.get_price(ctx) * 123`` is not equal to
+           ``p.get_price(ctx, quantity=123)``, since there could be
+           quantity discounts in effect, but usually they are equal.
 
         :type context: shoop.core.contexts.PriceTaxContext
         :rtype: shoop.core.pricing.Price
         """
         return self.get_price_info(context, quantity).price
 
-    def get_base_price(self, context):
+    def get_base_price(self, context, quantity=1):
         """
-        Returns `base_price` of the product calculated in the current pricing module.
+        Get base price of the product within given context.
 
-        `base_price` defaults to `price` but the pricing module can decide what the value is.
-
-        For example in `SimplePricing` this value is `ShopProduct.default_price` or calculated `price`
-        based on customer groups.
+        Base price differs from the (effective) price when there are
+        discounts in effect.
 
         :type context: shoop.core.contexts.PriceTaxContext
         :rtype: shoop.core.pricing.Price
         """
-        return self.get_price_info(context, quantity=1).base_price
+        return self.get_price_info(context, quantity=quantity).base_price
 
     def get_taxed_price(self, context, quantity=1):
         """

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -16,6 +16,7 @@ from jsonfield import JSONField
 from parler.models import TranslatableModel, TranslatedFields
 
 from shoop.core.fields import InternalIdentifierField
+from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 
 
 class ShopStatus(Enum):
@@ -40,3 +41,18 @@ class Shop(TranslatableModel):
 
     def __str__(self):
         return self.safe_translation_getter("name", default="Shop %d" % self.pk)
+
+    def create_price(self, value):
+        """
+        Create a price with given value and settings of this shop.
+
+        Takes the ``prices_include_tax`` setting into account, and in
+        future might also do the same for a currency setting.
+
+        :type value: decimal.Decimal
+        :rtype: shoop.core.pricing.Price
+        """
+        if self.prices_include_tax:
+            return TaxfulPrice(value)
+        else:
+            return TaxlessPrice(value)

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -161,7 +161,8 @@ class PricingModule(six.with_metaclass(abc.ABCMeta)):
             for product_id in product_ids
         }
 
-    def get_pricing_steps_for_products(self, context, product_ids):
+    def get_pricing_steps_for_products(self, context, products):
+        product_ids = [getattr(x, "pk", x) for x in products]
         return {
             product_id: self.get_pricing_steps(context, product_id=product_id)
             for product_id in product_ids

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -29,8 +29,8 @@ prices for a product with the module's
 :func:`~PricingModule.get_price_info` method.
 (:class:`~shoop.core.models.products.Product` objects contain the
 convenience methods
+:func:`~shoop.core.models.products.Product.get_price_info`,
 :func:`~shoop.core.models.products.Product.get_price`,
-:func:`~shoop.core.models.products.Product.get_base_price`,
 and :func:`~shoop.core.models.products.Product.get_base_price`
 which do these steps for you.)
 

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -131,26 +131,34 @@ class PricingModule(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def get_pricing_steps(self, context, product_id):
+    def get_pricing_steps(self, context, product):
         """
         Get context-specific list pricing steps for the given product.
 
-        Returns a list of tuples
+        Returns a list of PriceInfos ``[pi0, pi1, pi2, ...]`` where each
+        PriceInfo object is at the border unit price change: unit price
+        for ``0 <= quantity < pi1.quantity1`` is ``pi0.unit_price``, and
+        unit price for ``pi1.quantity <= quantity < pi2.quantity`` is
+        ``pi1.unit_price``, and so on.
 
-        [(0, price0), (quantity1, price1), (quantity2, price2), ...]
+        If there are "no steps", the return value will be a list of single
+        PriceInfo object with the constant price, i.e. ``[price_info]``.
 
-        where price for 0 <= quantity < quantity1 is price0, and price
-        for quantity1 <= quantity < quantity2 is price1, and so on.
-
-        If there are "no steps", the return value will be a list of
-        single step with the constant price, i.e. [(0, price)].
-
-        :rtype: list[tuple[Decimal,Price]]
+        :param product: Product or product id
+        :type product: shoop.core.models.Product|int
+        :rtype: list[PriceInfo]
         """
-        return [(0, TaxlessPrice(0))]
+        return [self.get_price_info(context, product, quantity=1)]
 
     def get_price_infos(self, context, products, quantity=1):
         """
+        Get PriceInfo objects for a bunch of products.
+
+        Returns a dict with product id as key and PriceInfo as value.
+
+        May be faster than doing :func:`get_price_info` for each product
+        separately, since inheriting class may override this.
+
         :param products: a list of `Product`s or id's
         :type products:  Iterable[shoop.core.models.Product|int]
         :rtype: dict[int,PriceInfo]
@@ -162,6 +170,19 @@ class PricingModule(six.with_metaclass(abc.ABCMeta)):
         }
 
     def get_pricing_steps_for_products(self, context, products):
+        """
+        Get pricing steps for a bunch of products.
+
+        Returns a dict with product id as key and step data (as list of
+        PriceInfos) as values.
+
+        May be faster than doing :func:`get_pricing_steps` for each
+        product separately, since inheriting class may override this.
+
+        :param products: a list of `Product`s or id's
+        :type products:  Iterable[shoop.core.models.Product|int]
+        :rtype: dict[int,list[PriceInfo]]
+        """
         product_ids = [getattr(x, "pk", x) for x in products]
         return {
             product_id: self.get_pricing_steps(context, product_id=product_id)

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -8,7 +8,7 @@
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import ShopProduct
-from shoop.core.pricing import PriceInfo, PricingContext, PricingModule, TaxfulPrice, TaxlessPrice
+from shoop.core.pricing import PriceInfo, PricingContext, PricingModule
 
 
 class DefaultPricingContext(PricingContext):
@@ -38,13 +38,13 @@ class DefaultPricingModule(PricingModule):
         Since `ShopProduct.default_price` can be `None` it will
         be set to zero (0) if `None`.
         """
+        shop = context.shop
         shop_product = ShopProduct.objects.get(product=product, shop=context.shop)
 
         default_price = (shop_product.default_price or 0)
 
-        price_cls = (TaxfulPrice if context.shop.prices_include_tax else TaxlessPrice)
         return PriceInfo(
-            price=price_cls(default_price * quantity),
-            base_price=price_cls(default_price * quantity),
+            price=shop.create_price(default_price * quantity),
+            base_price=shop.create_price(default_price * quantity),
             quantity=quantity,
         )

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -44,6 +44,6 @@ class DefaultPricingModule(PricingModule):
 
         price_cls = (TaxfulPrice if context.shop.prices_include_tax else TaxlessPrice)
         return PriceInfo(
-            price=price_cls(default_price),
-            base_price=price_cls(default_price)
+            price=price_cls(default_price * quantity),
+            base_price=price_cls(default_price * quantity),
         )

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -39,7 +39,7 @@ class DefaultPricingModule(PricingModule):
         be set to zero (0) if `None`.
         """
         shop = context.shop
-        shop_product = ShopProduct.objects.get(product=product, shop=context.shop)
+        shop_product = ShopProduct.objects.get(product=product, shop=shop)
 
         default_price = (shop_product.default_price or 0)
 

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -46,4 +46,5 @@ class DefaultPricingModule(PricingModule):
         return PriceInfo(
             price=price_cls(default_price * quantity),
             base_price=price_cls(default_price * quantity),
+            quantity=quantity,
         )

--- a/shoop/core/pricing/price.py
+++ b/shoop/core/pricing/price.py
@@ -17,8 +17,8 @@ class Price(Money):
             raise TypeError('Do not create direct instances of Price')
         return super(Price, cls).__new__(cls, value, *args, **kwargs)
 
-    def _units_match(self, other):
-        if not super(Price, self)._units_match(other):
+    def unit_matches_with(self, other):
+        if not super(Price, self).unit_matches_with(other):
             return False
         self_includes_tax = getattr(self, 'includes_tax', None)
         other_includes_tax = getattr(other, 'includes_tax', None)

--- a/shoop/core/pricing/price_info.py
+++ b/shoop/core/pricing/price_info.py
@@ -6,28 +6,54 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+import decimal
+import numbers
+
 from shoop.core.pricing import Price
 
 
 class PriceInfo(object):
-    def __init__(self, price, base_price, expires_on=None):
+    """
+    Object for passing around pricing data of an item.
+    """
+    def __init__(self, price, base_price, quantity, expires_on=None):
         """
-        Initialize PriceInfo with two given Price objects.
+        Initialize PriceInfo with prices and other parameters.
 
-        Given prices can be taxful or taxless, but their types must match.
+        Prices can be taxful or taxless, but their types must match.
 
-        :param price: Price of the product that is calculated in the pricing module
-        :type price: shoop.core.pricing.Price
-        :param base_price: Base price of the product, discounts are calculated based on this.
-        :type base_price: shoop.core.pricing.Price
+        :param Price price:
+          Effective price for the specified quantity.
+        :param Price base_price:
+          Base price for the specified quantity.  Discounts are
+          calculated based on this.
+        :param numbers.Number quantity:
+          Quantity that the given price is for.  Unit price is
+          calculated by ``unit_price = price / quantity``.
+          Note: Quantity could be non-integral (i.e. decimal).
+        :param numbers.Number|None expires_on:
+          Timestamp, comparable to values returned by :func:`time.time`,
+          determining the point in time when the prices are no longer
+          valid, or None if no expire time is set (which could mean
+          indefinitely, but in reality, it just means undefined).
         """
-
         assert isinstance(price, Price)
         assert isinstance(base_price, Price)
         assert price.unit_matches_with(base_price)
+        assert isinstance(quantity, numbers.Number)
+        assert expires_on is None or isinstance(expires_on, numbers.Number)
+
         self.price = price
         self.base_price = base_price
+        self.quantity = quantity
         self.expires_on = expires_on
+
+    def __repr__(self):
+        expire_str = '' if self.expires_on is None else(
+            ', expires_on=%r' % (self.expires_on,))
+        return "%s(%r, %r, %r%s)" % (
+            type(self).__name__, self.price, self.base_price, self.quantity,
+            expire_str)
 
     @property
     def includes_tax(self):
@@ -35,12 +61,42 @@ class PriceInfo(object):
 
     @property
     def discount_amount(self):
+        """
+        Amount of discount for the total quantity.
+
+        :rtype: Price
+        """
         return (self.base_price - self.price)
 
     @property
     def discount_percentage(self):
+        """
+        Discount percentage, 100 meaning totally discounted.
+
+        Note: Could be negative, when base price is smaller than
+        effective price.  Could also be greater than 100, when effective
+        price is negative.
+
+        If base price is 0, will return 0.
+
+        :rtype: decimal.Decimal
+        """
+        if not self.base_price:
+            return decimal.Decimal(0)
         return (1 - (self.price / self.base_price)) * 100
 
     @property
     def is_discounted(self):
         return (self.price < self.base_price)
+
+    @property
+    def unit_price(self):
+        return self.price / self.quantity
+
+    @property
+    def unit_base_price(self):
+        return self.base_price / self.quantity
+
+    @property
+    def unit_discount_amount(self):
+        return self.discount_amount / self.quantity

--- a/shoop/core/pricing/price_info.py
+++ b/shoop/core/pricing/price_info.py
@@ -24,7 +24,7 @@ class PriceInfo(object):
 
         assert isinstance(price, Price)
         assert isinstance(base_price, Price)
-        assert price._units_match(base_price)
+        assert price.unit_matches_with(base_price)
         self.price = price
         self.base_price = base_price
         self.expires_on = expires_on

--- a/shoop/core/pricing/price_info.py
+++ b/shoop/core/pricing/price_info.py
@@ -56,10 +56,6 @@ class PriceInfo(object):
             expire_str)
 
     @property
-    def includes_tax(self):
-        return self.price.includes_tax
-
-    @property
     def discount_amount(self):
         """
         Amount of discount for the total quantity.

--- a/shoop/core/shortcuts/__init__.py
+++ b/shoop/core/shortcuts/__init__.py
@@ -22,7 +22,7 @@ def update_order_line_from_product(request, order_line, product, quantity=1, sup
 
     # TODO: (TAX) Taxes in update_order_line_from_product
     context = PriceTaxContext.from_request(request)
-    price = product.get_price(context, quantity=quantity)
+    price_info = product.get_price_info(context, quantity=quantity)
     order_line.supplier = supplier
     order_line.type = OrderLineType.PRODUCT
     order_line.product = product
@@ -32,4 +32,6 @@ def update_order_line_from_product(request, order_line, product, quantity=1, sup
     order_line.accounting_identifier = product.accounting_identifier
     order_line.require_verification = bool(getattr(product, "require_verification", False))
     order_line.verified = False
-    order_line.unit_price = price
+    order_line.unit_price = price_info.unit_base_price
+    order_line.total_discount = price_info.discount_amount
+    assert order_line.total_price == price_info.price

--- a/shoop/discount_pricing/module.py
+++ b/shoop/discount_pricing/module.py
@@ -75,4 +75,5 @@ class DiscountPricingModule(PricingModule):
         return PriceInfo(
             price=price_cls(price * quantity),
             base_price=price_cls(default_price * quantity),
+            quantity=quantity,
         )

--- a/shoop/discount_pricing/module.py
+++ b/shoop/discount_pricing/module.py
@@ -73,6 +73,6 @@ class DiscountPricingModule(PricingModule):
 
         price_cls = (TaxfulPrice if includes_tax else TaxlessPrice)
         return PriceInfo(
-            price=price_cls(price),
-            base_price=price_cls(default_price)
+            price=price_cls(price * quantity),
+            base_price=price_cls(default_price * quantity),
         )

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -44,8 +44,10 @@ class BasketLine(SourceLine):
     def cache_info(self, request):
         product = self.product
         # TODO: ensure shop identity?
-        price = product.get_price(request, quantity=(self.quantity or 1))
-        self.unit_price = price
+        price_info = product.get_price_info(request, quantity=self.quantity)
+        self.unit_price = price_info.unit_base_price
+        self.total_discount = price_info.discount_amount
+        assert self.total_price == price_info.price
         # TODO: (TAX) Cache also taxes for BasketLine? (with product.get_taxed_price)
         self.net_weight = product.net_weight
         self.gross_weight = product.gross_weight

--- a/shoop/simple_pricing/module.py
+++ b/shoop/simple_pricing/module.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import ShopProduct
-from shoop.core.pricing import PriceInfo, PricingContext, PricingModule, TaxfulPrice, TaxlessPrice
+from shoop.core.pricing import PriceInfo, PricingContext, PricingModule
 
 from .models import SimpleProductPrice
 
@@ -51,8 +51,6 @@ class SimplePricingModule(PricingModule):
 
         default_price = (shop_product.default_price or 0)
 
-        includes_tax = context.shop.prices_include_tax
-
         if context.customer_group_ids:
             filter = Q(price__gt=0, product=product_id, shop=context.shop, group__in=context.customer_group_ids)
             result = (
@@ -70,9 +68,8 @@ class SimplePricingModule(PricingModule):
         else:
             price = default_price
 
-        price_cls = (TaxfulPrice if includes_tax else TaxlessPrice)
         return PriceInfo(
-            price=price_cls(price * quantity),
-            base_price=price_cls(price * quantity),
+            price=shop.create_price(price * quantity),
+            base_price=shop.create_price(price * quantity),
             quantity=quantity,
         )

--- a/shoop/simple_pricing/module.py
+++ b/shoop/simple_pricing/module.py
@@ -74,4 +74,5 @@ class SimplePricingModule(PricingModule):
         return PriceInfo(
             price=price_cls(price * quantity),
             base_price=price_cls(price * quantity),
+            quantity=quantity,
         )

--- a/shoop/simple_pricing/module.py
+++ b/shoop/simple_pricing/module.py
@@ -70,10 +70,8 @@ class SimplePricingModule(PricingModule):
         else:
             price = default_price
 
-        base_price = price
-
         price_cls = (TaxfulPrice if includes_tax else TaxlessPrice)
         return PriceInfo(
-            price=price_cls(price),
-            base_price=price_cls(base_price)
+            price=price_cls(price * quantity),
+            base_price=price_cls(price * quantity),
         )

--- a/shoop/simple_pricing/module.py
+++ b/shoop/simple_pricing/module.py
@@ -41,18 +41,21 @@ class SimplePricingModule(PricingModule):
         )
 
     def get_price_info(self, context, product, quantity=1):
+        shop = context.shop
 
         if isinstance(product, six.integer_types):
             product_id = product
-            shop_product = ShopProduct.objects.get(product_id=product_id, shop_id=context.shop.pk)
+            shop_product = ShopProduct.objects.get(product_id=product_id, shop=shop)
         else:
-            shop_product = product.get_shop_instance(context.shop)
+            shop_product = product.get_shop_instance(shop)
             product_id = product.pk
 
         default_price = (shop_product.default_price or 0)
 
         if context.customer_group_ids:
-            filter = Q(price__gt=0, product=product_id, shop=context.shop, group__in=context.customer_group_ids)
+            filter = Q(
+                price__gt=0, product=product_id, shop=shop,
+                group__in=context.customer_group_ids)
             result = (
                 SimpleProductPrice.objects.filter(filter)
                 .order_by("price")[:1]

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -602,7 +602,7 @@ def create_random_order(customer=None, products=(), completion_probability=0):
     for i in range(random.randint(3, 10)):
         product = random.choice(products)
         quantity = random.randint(1, 5)
-        price = product.get_price(context, quantity=quantity)
+        price_info = product.get_price_info(context, quantity=quantity)
         shop_product = product.get_shop_instance(source.shop)
         supplier = shop_product.suppliers.first()
         line = SourceLine(
@@ -610,10 +610,12 @@ def create_random_order(customer=None, products=(), completion_probability=0):
             product=product,
             supplier=supplier,
             quantity=quantity,
-            unit_price=price,
+            unit_price=price_info.unit_base_price,
+            total_discount=price_info.discount_amount,
             sku=product.sku,
             text=product.safe_translation_getter("name", any_language=True)
         )
+        assert line.total_price == price_info.price
         source.lines.append(line)
     with atomic():
         oc = OrderCreator(request)

--- a/shoop/themes/default_theme/templates/default/shoop/front/product/detail.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/product/detail.jinja
@@ -65,10 +65,10 @@
             <h1>{{ product.name }}</h1>
             <p>{% trans %}SKU{% endtrans %}: {{ product.sku }}</p>
             {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-            {% set price_info = product.get_price_info(request) %}
+            {% set price = product.get_price(request) %}
             <h3>
-                {{ price_info.price|home_currency }}
-                {% if price_info.includes_tax %}(incl. tax){% else %}(excl. tax){% endif %}
+                {{ price|home_currency }}
+                {% if price.includes_tax %}(incl. tax){% else %}(excl. tax){% endif %}
                 <small>/ {{ product.sales_unit.short_name }}</small>
             </h3>
 

--- a/shoop/utils/_united_decimal.py
+++ b/shoop/utils/_united_decimal.py
@@ -26,11 +26,16 @@ class UnitedDecimal(decimal.Decimal):
         decimal_repr = super(UnitedDecimal, self).__repr__()
         return decimal_repr.replace('Decimal', type(self).__name__)
 
-    def _units_match(self, other):
+    def unit_matches_with(self, other):
+        """
+        Test if self and other have matching units.
+
+        :rtype: bool
+        """
         raise NotImplementedError()
 
     def _check_units_match(self, other):
-        if not self._units_match(other):
+        if not self.unit_matches_with(other):
             raise UnitMixupError(self, other)
 
     def __lt__(self, other, **kwargs):
@@ -50,12 +55,12 @@ class UnitedDecimal(decimal.Decimal):
         return super(UnitedDecimal, self).__ge__(other, **kwargs)
 
     def __eq__(self, other, *args, **kwargs):
-        if not self._units_match(other):
+        if not self.unit_matches_with(other):
             return False
         return super(UnitedDecimal, self).__eq__(other, **kwargs)
 
     def __ne__(self, other, *args, **kwargs):
-        if not self._units_match(other):
+        if not self.unit_matches_with(other):
             return True
         return super(UnitedDecimal, self).__ne__(other, **kwargs)
 

--- a/shoop/utils/money.py
+++ b/shoop/utils/money.py
@@ -20,7 +20,7 @@ class Money(numbers.UnitedDecimal):
     def currency(self):
         return (self._currency or settings.SHOOP_HOME_CURRENCY)
 
-    def _units_match(self, other):
+    def unit_matches_with(self, other):
         return (
             (isinstance(other, Money) and self._currency == other._currency)
             or

--- a/shoop_tests/core/test_default_pricing.py
+++ b/shoop_tests/core/test_default_pricing.py
@@ -70,3 +70,11 @@ def test_default_price_value_allowed(rf):
     shop = get_default_shop()
     product = create_product("test-product", shop=shop, default_price=100)
     assert product.get_price(request) == TaxlessPrice(100)
+
+
+@pytest.mark.django_db
+def test_non_one_quantity(rf):
+    request, shop, group = initialize_test(rf, False)
+    shop = get_default_shop()
+    product = create_product("test-product", shop=shop, default_price=100)
+    assert product.get_price(request, quantity=5) == TaxlessPrice(500)

--- a/shoop_tests/core/test_price_info.py
+++ b/shoop_tests/core/test_price_info.py
@@ -6,19 +6,63 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+from decimal import Decimal
+
 from shoop.core.pricing import TaxlessPrice
 from shoop.core.pricing.price_info import PriceInfo
 
 
-def test_price_info_no_discount():
-    pi = PriceInfo(price=TaxlessPrice(100), base_price=TaxlessPrice(100))
+def test_no_discount():
+    pi = PriceInfo(TaxlessPrice(100), TaxlessPrice(100), 1)
     assert not pi.is_discounted
     assert pi.discount_percentage == 0
     assert pi.discount_amount == TaxlessPrice(0)
 
 
-def test_price_info_discounts():
-    pi = PriceInfo(price=TaxlessPrice(75), base_price=TaxlessPrice(100))
+def test_with_discounts():
+    pi = PriceInfo(TaxlessPrice(75), TaxlessPrice(100), 1)
     assert pi.is_discounted
     assert pi.discount_percentage == 25
     assert pi.discount_amount == TaxlessPrice(25)
+
+
+def test_quantity_not_one_without_discounts():
+    pi = PriceInfo(TaxlessPrice(123), TaxlessPrice(123), 10)
+    assert pi.price == TaxlessPrice(123)
+    assert pi.base_price == TaxlessPrice(123)
+    assert pi.discount_amount == TaxlessPrice(0)
+    assert pi.discount_percentage == 0
+    assert pi.unit_price == TaxlessPrice('12.3')
+    assert pi.unit_base_price == TaxlessPrice('12.3')
+    assert pi.unit_discount_amount == TaxlessPrice(0)
+
+
+def test_quantity_not_one_with_discounts():
+    pi = PriceInfo(TaxlessPrice('27.5'), TaxlessPrice(100), Decimal(2.5))
+    assert pi.price == TaxlessPrice('27.5')
+    assert pi.base_price == TaxlessPrice(100)
+    assert pi.discount_amount == TaxlessPrice('72.5')
+    assert pi.discount_percentage == Decimal('72.5')
+    assert pi.unit_price == TaxlessPrice(11)
+    assert pi.unit_base_price == TaxlessPrice(40)
+    assert pi.unit_discount_amount == TaxlessPrice(29)
+
+
+def test_discount_percentage_special_cases():
+    pi1 = PriceInfo(TaxlessPrice(10), TaxlessPrice(0), quantity=1)
+    assert pi1.discount_percentage == 0
+
+
+def test_repr():
+    pi1 = PriceInfo(TaxlessPrice('0.3'), TaxlessPrice(42), Decimal('1.3'))
+    r1 = "PriceInfo(TaxlessPrice('0.3'), TaxlessPrice('42'), Decimal('1.3'))"
+    assert repr(pi1) == r1
+
+    pi2 = PriceInfo(
+        TaxlessPrice('1.3'), TaxlessPrice(42),
+        Decimal('1.3'), expires_on=1483272000)
+    r2 = (
+        "PriceInfo("
+        "TaxlessPrice('1.3'), TaxlessPrice('42'),"
+        " Decimal('1.3'), expires_on=1483272000)")
+    assert repr(pi2) == r2

--- a/shoop_tests/discount_pricing/test_discount_pricing.py
+++ b/shoop_tests/discount_pricing/test_discount_pricing.py
@@ -144,11 +144,9 @@ def test_set_taxful_price_works(rf):
     price_info = product.get_price_info(pricing_context, quantity=1)
 
     assert price_info.price == TaxfulPrice(250)
-    assert price_info.includes_tax
 
     pp = product.get_price(pricing_context, quantity=1)
 
-    assert pp.includes_tax
     assert pp == TaxfulPrice("250")
 
 
@@ -167,11 +165,9 @@ def test_set_taxful_price_works_with_product_id(rf):
     price_info = dpm.get_price_info(pricing_context, product=product.pk, quantity=1)
 
     assert price_info.price == TaxfulPrice(250)
-    assert price_info.includes_tax
 
     pp = product.get_price(pricing_context, quantity=1)
 
-    assert pp.includes_tax
     assert pp == TaxfulPrice("250")
 
 

--- a/shoop_tests/simple_pricing/test_simple_pricing.py
+++ b/shoop_tests/simple_pricing/test_simple_pricing.py
@@ -98,11 +98,9 @@ def test_set_taxful_price_works(rf):
     price_info = product.get_price_info(pricing_context, quantity=1)
 
     assert price_info.price == TaxfulPrice(250)
-    assert price_info.includes_tax
 
     pp = product.get_price(pricing_context, quantity=1)
 
-    assert pp.includes_tax
     assert pp == TaxfulPrice("250")
 
 
@@ -121,11 +119,9 @@ def test_set_taxful_price_works_with_product_id(rf):
     price_info = spm.get_price_info(pricing_context, product=product.pk, quantity=1)
 
     assert price_info.price == TaxfulPrice(250)
-    assert price_info.includes_tax
 
     pp = product.get_price(pricing_context, quantity=1)
 
-    assert pp.includes_tax
     assert pp == TaxfulPrice("250")
 
 

--- a/shoop_tests/utils/test_money.py
+++ b/shoop_tests/utils/test_money.py
@@ -33,6 +33,6 @@ def test_units_match():
     m3._currency = 'XXX'
     m4 = XxxMoney(4)
 
-    assert m1._units_match(m2)
-    assert not m1._units_match(m3)
-    assert m3._units_match(m4)
+    assert m1.unit_matches_with(m2)
+    assert not m1.unit_matches_with(m3)
+    assert m3.unit_matches_with(m4)

--- a/shoop_tests/utils/test_united_decimal.py
+++ b/shoop_tests/utils/test_united_decimal.py
@@ -15,7 +15,7 @@ from shoop.utils.numbers import UnitedDecimal
 class BaseDecimal(UnitedDecimal):
     unit = None
 
-    def _units_match(self, other):
+    def unit_matches_with(self, other):
         return self.unit == getattr(other, 'unit', None)
 
 
@@ -109,7 +109,7 @@ def test_invalid_power():
 
 def test_base_class_units_match_unimplemented():
     with pytest.raises(NotImplementedError):
-        UnitedDecimal()._units_match(UnitedDecimal())
+        UnitedDecimal().unit_matches_with(UnitedDecimal())
 
 
 def test_floordiv():


### PR DESCRIPTION
Also set the correct discount amounts for SourceLine, BasketLine and
OrderLine when they are created.

Refs SHOOP-975 / SHOOP-1462