### PR TITLE
Classic gray theme: Reload product prices with AJAX in quantity change

### DIFF
--- a/shoop/themes/classic_gray/static_src/js/custom.js
+++ b/shoop/themes/classic_gray/static_src/js/custom.js
@@ -56,6 +56,29 @@ function reloadProducts() {
     $("#ajax_content").load(location.pathname + filterString);
 }
 
+function updateProductPrice(productId) {
+    var $quantity = $("#product-quantity");
+    if (!$quantity.is(":valid")) {
+        return;
+    }
+    var data = {
+        id: productId,
+        quantity: $quantity.val()
+    };
+    var $selectedChild = $("#product-variations");
+    if ($selectedChild.length > 0) {
+        data.child = $selectedChild.val();
+    }
+    $.ajax({
+        url: "/xtheme/product_price",
+        method: "GET",
+        data: data,
+        success: function(html) {
+            $("#product-price-section").html(html);
+        }
+    });
+}
+
 $(function() {
     $("#search-modal").on("show.bs.modal", function() {
         setTimeout(function(){

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
@@ -10,6 +10,10 @@
     </script>
 {% endif %}
 
+{% if not quantity %}
+    {% set quantity = shop_product.rounded_minimum_purchase_quantity %}
+{% endif %}
+
 {% macro quantity_box() %}
     <div class="form-group amount">
         <label for="product-quantity">{% trans %}Quantity{% endtrans %}</label>
@@ -20,8 +24,9 @@
             name="quantity"
             id="product-quantity"
             step="{{ shop_product.quantity_step }}"
-            value="{{ shop_product.rounded_minimum_purchase_quantity }}"
-            min="{{ shop_product.rounded_minimum_purchase_quantity }}">
+            value="{{ quantity }}"
+            min="{{ shop_product.rounded_minimum_purchase_quantity }}"
+            onchange="updateProductPrice('{{ product.pk }}')">
             <span class="input-group-addon sales-unit">{{ product.sales_unit.short_name }}</span>
         </div>
     </div>
@@ -41,13 +46,12 @@
                 <div class="form-group">
                     <select name="product_id" id="product-variations" class="form-control">
                         {% for p in orderable_variation_children %}
-                            {% set price = p.get_price(request) %}
-                            <option value="{{ p.id }}">
+                            {% set price_info = p.get_price_info(request, quantity) %}
+                            <option value="{{ p.id }}"{% if selected_child and selected_child == p.id %} selected{% endif %}>
                                 {{ p.variation_name or p.name }}
                                 {# TODO: Tax rendering of variation children #}
-                                {# TODO: Remove hard coded euro in rendering of variation children prices #}
-                                ({{ price.taxful_price|floatformat(2) }} &euro; {% trans %}incl. VAT{% endtrans %} {{ product.get_tax_value_display() }}%,
-                                {{ price.taxless_price|floatformat(2)}} &euro; {% trans %}VAT{% endtrans %} 0%)
+                                {{ price_info.price|home_currency }}
+                                ({{ price_info.unit_price|home_currency }}/{{ product.sales_unit.short_name }})
                             </option>
                         {% endfor %}
                     </select>
@@ -58,7 +62,7 @@
         </div>
     {% endif %}
 {% else %}
-    {% set is_orderable=shop_product.is_orderable(supplier=None, customer=request.customer, quantity=1) %}
+    {% set is_orderable=shop_product.is_orderable(supplier=None, customer=request.customer, quantity=quantity) %}
     <div class="prices">
         {% if is_orderable %}
             <form role="form" method="post" action="{{ url("shoop:basket") }}" class="form-inline add-to-basket">
@@ -68,23 +72,23 @@
                         <input type="hidden" name="command" value="add">
                         <input type="hidden" name="product_id" value="{{ product.id }}">
                         {{ quantity_box() }}
-                        {#
-                        TODO: This should be dynamically updated from the backend with AJAX
-                        TODO: (TAX) Check following line (gets taxful price of product)
-                        #}
+                        {# TODO: (TAX) Check following line (gets taxful price of product) #}
                     </div>
                     <div class="col-sm-6">
                         <div class="price text-right">
+                            {% set price_info = product.get_price_info(request, quantity) %}
                             Total<br>
                             <h4>
                                 <span id="product-price-placeholder">
-                                    {% set price_info = product.get_price_info(request) %}
                                     {{ price_info.price|home_currency }}
                                 </span>
                                 <span class="sales-unit">
                                     {{ product.sales_unit.short_name }}
                                 </span>
                             </h4>
+                            <span class="small">
+                                {{ price_info.unit_price|home_currency }}/{{ product.sales_unit.short_name }}
+                            </span>
                         </div>
                     </div>
                 </div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -70,7 +70,7 @@
                 {% endif %}
             </div>
             <hr>
-            <div class="well">
+            <div class="well" id="product-price-section">
                 {% include "shoop/front/product/_detail_order_section.jinja" with context %}
             </div>
         </div>

--- a/shoop/themes/classic_gray/views/__init__.py
+++ b/shoop/themes/classic_gray/views/__init__.py
@@ -7,6 +7,7 @@
 
 from .basket import basket_partial  # noqa
 from .product_preview import product_preview  # noqa
+from .product_price import product_price  # noqa
 from .products_view import products  # noqa
 
-__all__ = ["basket_partial", "product_preview", "products"]
+__all__ = ["basket_partial", "product_preview", "products", "product_price"]

--- a/shoop/themes/classic_gray/views/product_price.py
+++ b/shoop/themes/classic_gray/views/product_price.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from shoop.front.views.product import ProductDetailView
+
+
+class ProductPriceView(ProductDetailView):
+    template_name = "shoop/front/product/_detail_order_section.jinja"
+
+    def get_context_data(self, **kwargs):
+        context = super(ProductPriceView, self).get_context_data(**kwargs)
+        product = context["product"]
+        context["quantity"] = product.sales_unit.round(self.request.GET.get("quantity"))
+        context["selected_child"] = int(self.request.GET.get("child") or 0)
+        return context
+
+
+def product_price(request):
+    return ProductPriceView.as_view()(request, pk=request.GET["id"])


### PR DESCRIPTION
* Create custom product_prices view for classic gray theme
* Call product_prices view with AJAX, with product id, quantity and
optional child id parameters
* Render correct prices at _detail_order_section template based on
previous parameters

Refs SHOOP-1356