### PR TITLE
Remove CSS transition from list/grid toggler (Classic Gray)

### DIFF
--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product-list.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product-list.less
@@ -156,7 +156,6 @@
                 width: 35px;
                 height: 28px;
                 transform: translate3d(0,0,0);
-                .transition(all 0.25s cubic-bezier(0.2,0.6,0.3,0.8));
             }
         }
 


### PR DESCRIPTION
Transitions caused the list/grid view toggler (Classic Gray Theme)
to always slide from left to right even if the state itself never
changed on page reload. Remove transitions so that the toggler stays
on the right position without sliding on page load.

Refs SHOOP-1391