### PR TITLE
Add a margin after every placeholder in xtheme editor

### DIFF
--- a/shoop/xtheme/static_src/injection/style.less
+++ b/shoop/xtheme/static_src/injection/style.less
@@ -23,6 +23,7 @@
     min-height: 20px;
     cursor: pointer;
     padding: 0.2rem;
+    margin-bottom: 10px;
     &>* {
         pointer-events: none;
     }


### PR DESCRIPTION
Placeholders were collapsing over each other so for better
readability and usability, add a 10px margin after every
editable placeholder in xtheme editor.