### PR TITLE
Use normal text color on product name (Classic Gray)

### DIFF
--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product.less
@@ -1,7 +1,6 @@
 .product-main {
     margin-bottom: 45px;
     .product-name {
-        color: @brand-primary;
         margin-top: 0;
     }
 }

--- a/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
@@ -19,7 +19,7 @@
                     {% endif %}
                 </div>
                 <div class="col-md-6 col-sm-7">
-                    <h2 class="text-primary">{{ product.name }}</h2>
+                    <h2>{{ product.name }}</h2>
                     {% if product.description %}<p class="description">{{ product.description|safe|truncate(150, False) }}</p>{% endif %}
                     <hr>
                     <div class="product-price">


### PR DESCRIPTION
Since all the other headings use the default base color,
use that for product titles as well.