### PR TITLE
Fix shoop.core.migrations.0006

### DIFF
--- a/shoop/core/migrations/0006_shop_add_logo_and_public_name.py
+++ b/shoop/core/migrations/0006_shop_add_logo_and_public_name.py
@@ -5,11 +5,10 @@ from django.conf import settings
 from django.db import models, migrations
 import filer.fields.image
 
-from shoop.core.models import Shop
-
 
 def copy_names(apps, schema_editor):
-    for shop in Shop.objects.all():
+    shop_model = apps.get_model("shoop", "Shop")
+    for shop in shop_model.objects.all():
         for lang_code, lang_name in settings.LANGUAGES:
             shop.set_current_language(lang_code)
             shop.public_name = shop.name


### PR DESCRIPTION
Do not import Shop models directly from shoop.core.models, but use the
apps.get_model instead.  This is needed, because importing Shop
directly will use the newest version of the model, not the version of
the previous migration level and that makes it impossible e.g. to add
fields to Shop.

Refs SHOOP-1153 / SHOOP-1502