### PR TITLE
Customer URL now requires login

### DIFF
--- a/shoop/front/apps/auth/templates/shoop/user/login.jinja
+++ b/shoop/front/apps/auth/templates/shoop/user/login.jinja
@@ -22,7 +22,7 @@
             <div class="well">
                 <form role="form" method="post" action="{{ request.path }}">
                     {% csrf_token %}
-                    <input type="hidden" name="next" value="{{ next|default("") }}">
+                    {% for f in form.hidden_fields() %}{{ f }}{% endfor %}
                     {{ render_field(form.username) }}
                     {{ render_field(form.password) }}
                     <button type="submit" class="btn btn-primary btn-block"><i class="glyphicon glyphicon-log-in"></i> {% trans %}Log in{% endtrans %}</button>

--- a/shoop/front/apps/auth/views.py
+++ b/shoop/front/apps/auth/views.py
@@ -30,6 +30,15 @@ class LoginView(FormView):
     template_name = 'shoop/user/login.jinja'
     form_class = AuthenticationForm
 
+    def get_form(self, form_class=None):
+        form = super(LoginView, self).get_form(form_class)
+        form.fields[REDIRECT_FIELD_NAME] = forms.CharField(
+            widget=forms.HiddenInput,
+            required=False,
+            initial=self.request.REQUEST.get(REDIRECT_FIELD_NAME)
+        )
+        return form
+
     def form_valid(self, form):
         user = form.get_user()
         login(self.request, user)

--- a/shoop/front/apps/customer_information/urls.py
+++ b/shoop/front/apps/customer_information/urls.py
@@ -8,9 +8,10 @@
 from django.conf.urls import patterns, url
 
 from . import views
+from django.contrib.auth.decorators import login_required
 
 urlpatterns = patterns(
     '',
-    url(r'^customer/$', views.CustomerEditView.as_view(),
+    url(r'^customer/$', login_required(views.CustomerEditView.as_view()),
         name='customer_edit'),
 )

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/user/login.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/user/login.jinja
@@ -30,7 +30,7 @@
                     {% endfor %}
                     <form role="form" method="post" action="{{ request.path }}">
                         {% csrf_token %}
-                        <input type="hidden" name="next" value="{{ next|default("") }}">
+                        {% for f in form.hidden_fields() %}{{ f }}{% endfor %}
                         {{ render_field(form.username) }}
                         {{ render_field(form.password) }}
                         <button type="submit" class="btn btn-primary btn-block"><i class="fa fa-sign-in"></i> {% trans %}Log in{% endtrans %}</button>

--- a/shoop_tests/front/test_auth.py
+++ b/shoop_tests/front/test_auth.py
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.conf import settings
-from django.contrib.auth import get_user
+from django.contrib.auth import get_user, REDIRECT_FIELD_NAME
 from django.core.urlresolvers import reverse
 from shoop.testing.factories import get_default_shop
 from shoop_tests.utils.fixtures import REGULAR_USER_PASSWORD, regular_user
@@ -29,10 +29,16 @@ def test_login_logs_the_user_in(client, regular_user, rf):
 
     get_default_shop()
     prepare_user(regular_user)
-    client.post(reverse("shoop:login"), data={
+    redirect_target = "/redirect-success/"
+    response = client.post(reverse("shoop:login"), data={
         "username": regular_user.username,
         "password": REGULAR_USER_PASSWORD,
+        REDIRECT_FIELD_NAME: redirect_target
     })
+
+    assert response.get("location")
+    assert response.get("location").endswith(redirect_target)
+
     request = rf.get("/")
     request.session = client.session
     assert get_user(request) == regular_user, "User is logged in"

--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -162,6 +162,8 @@ TEMPLATES = [
     },
 ]
 
+# set login url here because of `login_required` decorators
+LOGIN_URL = "/login"
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 


### PR DESCRIPTION
Front Auth: Ensure `next` is transferred through login flow
Front: view `/customer/` now requires login
`LOGIN_URL` now defined in workbench settings

Refs SHOOP-1514