### PR TITLE
Prunes, manifests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,11 @@ recursive-include shoop_tests *.jinja
 # included still, since it's a Python package.
 # recursive-include shoop_workbench ...
 
-prune shoop/admin/static_src/*/bower_components
-prune shoop/admin/modules/*/bower_components
+prune shoop/*/bower_components
+prune shoop/*/*/bower_components
+prune shoop/*/*/*/bower_components
+prune shoop/*/*/*/*/bower_components
+prune shoop/*/*/*/*/node_modules
+prune shoop/*/*/*/node_modules
+prune shoop/*/*/node_modules
 prune shoop/*/node_modules


### PR DESCRIPTION
Add multiple levels of bower_components and node_modules to be pruned out of builds.

Refs SHOOP-1470
Refs SHOOP-1535