### PR TITLE
Fixes

### DIFF
--- a/shoop/admin/modules/orders/views/shipment.py
+++ b/shoop/admin/modules/orders/views/shipment.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
+from shoop.admin.utils.forms import add_form_errors_as_messages
 
 import six
 from django import forms
@@ -73,6 +74,10 @@ class OrderCreateShipmentView(UpdateView):
             form.fields["q_%s" % product_id] = field
 
         return form
+
+    def form_invalid(self, form):
+        add_form_errors_as_messages(self.request, form)
+        return super(OrderCreateShipmentView, self).form_invalid(form)
 
     def form_valid(self, form):
         product_ids_to_quantities = dict(

--- a/shoop/admin/modules/products/views/edit.py
+++ b/shoop/admin/modules/products/views/edit.py
@@ -161,3 +161,20 @@ class ProductEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
 
     def get_toolbar(self):
         return EditProductToolbar(view=self)
+
+    def get_context_data(self, **kwargs):
+        context = super(ProductEditView, self).get_context_data(**kwargs)
+        orderability_errors = []
+
+        if self.object.pk:
+            for shop in Shop.objects.all():
+                shop_product = self.object.get_shop_instance(shop)
+                orderability_errors.extend(
+                    ["%s: %s" % (shop.name, msg.message)
+                     for msg in shop_product.get_orderability_errors(
+                        supplier=None,
+                        quantity=shop_product.minimum_purchase_quantity,
+                        customer=None)])
+
+        context["orderability_errors"] = orderability_errors
+        return context

--- a/shoop/admin/modules/products/views/forms.py
+++ b/shoop/admin/modules/products/views/forms.py
@@ -84,6 +84,11 @@ class ShopProductForm(forms.ModelForm):
             # TODO: "shop_primary_image",
         )
 
+    def __init__(self, **kwargs):
+        if not kwargs["instance"].pk:
+            kwargs["instance"].visible = False
+        super(ShopProductForm, self).__init__(**kwargs)
+
     # TODO: Move this to model
     def clean_minimum_purchase_quantity(self):
         minimum_purchase_quantity = self.cleaned_data.get("minimum_purchase_quantity")

--- a/shoop/admin/modules/products/views/forms.py
+++ b/shoop/admin/modules/products/views/forms.py
@@ -41,7 +41,6 @@ class ProductBaseForm(MultiLanguageModelForm):
             "sales_unit",
             "shipping_mode",
             "sku",
-            "stock_behavior",
             "suggested_retail_price",
             "tax_class",
             "type",

--- a/shoop/admin/templates/shoop/admin/orders/create_shipment.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/create_shipment.jinja
@@ -36,9 +36,21 @@
                     </tfoot>
                     <tbody>
                     {% for product_id, info in form.product_summary.items() %}
+                        {% set field = form["q_" ~ product_id] %}
                         <tr>
                             <td>{{ form.product_names.get(product_id) }}</td>
-                            <td class="text-right quantity-column">{{ form["q_" ~ product_id] }}</td>
+                            <td class="text-right quantity-column">
+                                <div class="{% if field.errors %}has-error{% endif %}">
+                                    {{ field }}
+                                    {% if field.errors %}
+                                        <div class="help-text text-danger">
+                                        {% for error in field.errors %}
+                                            {{ error }}<br>
+                                        {% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </td>
                             <td class="text-right hidden-xs">{{ info.ordered|number }}</td>
                             <td class="text-right hidden-xs">{{ info.shipped|number }}</td>
                             <td class="text-right hidden-xs">{{ info.unshipped|number }}</td>

--- a/shoop/admin/templates/shoop/admin/products/_edit_base_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_base_form.jinja
@@ -15,7 +15,12 @@
     {{ bs3.field(product_form.barcode) }}
     {{ bs3.field(product_form.gtin) }}
     {{ bs3.field(product_form.category) }}
-    {{ bs3.field(product_form.stock_behavior) }}
+    {# TODO: This should be enabled in near future. #}
+    {#  bs3.field(product_form.stock_behavior) #}
+    <div class="form-group">
+        <label class="control-label" for="id_stock">{% trans %}Stock{% endtrans %}</label>
+        <input class="form-control" id="id_stock" maxlength="40" name="base-stock" value="{% trans %}Unstocked{% endtrans %}" disabled="disabled" type="text">
+     </div>
     {{ bs3.field(product_form.shipping_mode) }}
     {% call(form, language, map) language_dependent_content_tabs(product_form, tab_id_prefix="additional-language") %}
         {{ bs3.field(product_form[map.variation_name]) }}

--- a/shoop/admin/templates/shoop/admin/products/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/products/edit.jinja
@@ -2,6 +2,14 @@
 {% block content %}
     <div class="container-fluid">
         <div class="row">
+            {% if orderability_errors %}
+                <div class="clearfix">
+                {# TODO: FIX THIS FOR MOBILE SCREEN SIZES #}
+                    <p class="pull-right" data-toggle="tooltip" data-title="{% for error in orderability_errors %}{{ error }} {% endfor %}" data-placement="bottom">
+                        <i class="fa fa-info-circle text-info"></i> {% trans %}This product is currently not orderable.{% endtrans %}
+                    </p>
+                </div>
+            {% endif %}
             <div class="col-md-3 section-navigation" data-navigatee="product_form"></div>
             <div class="col-md-9">
                 <form method="post" id="product_form">

--- a/shoop/core/models/product_shops.py
+++ b/shoop/core/models/product_shops.py
@@ -135,6 +135,15 @@ class ShopProduct(models.Model):
         for error in self.get_visibility_errors(customer):
             yield error
 
+        if supplier is None and not self.suppliers.exists():
+            # `ShopProduct` must have at least one `Supplier`.
+            # If supplier is not given and the `ShopProduct` itself
+            # doesn't have suppliers we cannot sell this product.
+            yield ValidationError(
+                _('The product has no supplier.'),
+                code="no_supplier"
+            )
+
         if not ignore_minimum and quantity < self.minimum_purchase_quantity:
             yield ValidationError(
                 _('The purchase quantity needs to be at least %d for this product.') % self.minimum_purchase_quantity,

--- a/shoop/front/views/product.py
+++ b/shoop/front/views/product.py
@@ -12,7 +12,7 @@ from django.views.generic import DetailView
 
 from shoop.core.models import Product, ProductMode
 from shoop.front.utils.views import cache_product_things
-from shoop.utils.excs import Problem
+from shoop.utils.excs import Problem, extract_messages
 from shoop.utils.numbers import get_string_sort_order
 
 
@@ -91,6 +91,6 @@ class ProductDetailView(DetailView):
         errors = list(shop_product.get_visibility_errors(customer=request.customer))
 
         if errors:
-            raise Problem("\n".join(errors))
+            raise Problem("\n".join(extract_messages(errors)))
 
         return super(ProductDetailView, self).get(request, *args, **kwargs)

--- a/shoop/themes/classic_gray/static_src/js/custom.js
+++ b/shoop/themes/classic_gray/static_src/js/custom.js
@@ -83,10 +83,12 @@ function updatePrice() {
         jQuery("#product-price-div").replaceWith($content);
         if($content.find("#no-price").length > 0)
         {
-            $("#add-to-cart-button").attr("disabled", true);
+            $("#add-to-cart-button").prop("disabled", true);
         }
         else
-            $("#add-to-cart-button").attr("disabled", false);
+        {
+            $("#add-to-cart-button").not(".not-orderable").prop("disabled", false);
+        }
     });
 }
 

--- a/shoop/themes/classic_gray/static_src/js/custom.js
+++ b/shoop/themes/classic_gray/static_src/js/custom.js
@@ -15,6 +15,8 @@ function showPreview(productId) {
         success: function(data) {
             $("body").append(data);
             $(modal_select).modal("show");
+            updatePrice();
+            $(".selectpicker").selectpicker();
         }
     });
 }
@@ -61,6 +63,7 @@ function updatePrice() {
     if ($quantity.length === 0 || !$quantity.is(":valid")) {
         return;
     }
+
     var data = {
         id: $("input[name=product_id]").val(),
         quantity: $quantity.val()
@@ -78,6 +81,12 @@ function updatePrice() {
     jQuery.ajax({url: "/xtheme/product_price", dataType: "html", data: data}).done(function(responseText) {
         var $content = jQuery("<div>").append(jQuery.parseHTML(responseText)).find("#product-price-div");
         jQuery("#product-price-div").replaceWith($content);
+        if($content.find("#no-price").length > 0)
+        {
+            $("#add-to-cart-button").attr("disabled", true);
+        }
+        else
+            $("#add-to-cart-button").attr("disabled", false);
     });
 }
 

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product-card.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product-card.less
@@ -91,6 +91,9 @@
         font-weight: bold;
         margin: 10px 0px;
         color: @brand-primary;
+        .lead {
+            font-size: 1.6rem;
+        }
         .original {
             color: @text-muted;
             text-decoration: line-through;

--- a/shoop/themes/classic_gray/templates/classic_gray/add_product_to_basket.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/add_product_to_basket.jinja
@@ -25,6 +25,18 @@
         });
     }
 
+    // TODO: Show error message?
+    function handleError(cover) {
+        setTimeout(function() {
+            // Hide the loader and change to error message
+            cover.removeClass("loading").addClass('error');
+            setTimeout(function() {
+                // Hide the error message and the modal
+                cover.removeClass("error in");
+            }, 1750);
+        }, 500);
+    }
+
     function addToBasket(form) {
         var cover = $(".cover-wrap");
         cover.addClass("in loading");
@@ -33,6 +45,11 @@
             method: "POST",
             data: form.serializeArray(),
             success: function(response) {
+                if(response.error) {
+                    handleError(cover);
+                    return;
+                }
+
                 updateNavigationBasket();
                 setTimeout(function() {
                     // Hide the loader and show the message
@@ -46,16 +63,12 @@
                         }, 250);
                     }, 1500);
                 }, 500);
+
+
             },
             error: function() {
-                setTimeout(function() {
-                    // Hide the loader and change to error message
-                    cover.removeClass("loading").addClass('error');
-                    setTimeout(function() {
-                        // Hide the error message and the modal
-                        cover.removeClass("error in");
-                    }, 1750);
-                }, 500);
+                handleError(cover);
+
             }
         });
     }

--- a/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
@@ -1,3 +1,4 @@
+{%- import "shoop/front/macros.jinja" as macros with context -%}
 {% set product_url = url("shoop:product", pk=product.pk, slug=product.slug) %}
 {% set priceinfo = product.get_price_info(request) %}
 <div class="product-preview-modal fade" id="product-{{ product.id }}-modal" tabindex="-1" role="dialog" aria-labelledby="product-{{ product.id }}-preview">
@@ -22,16 +23,7 @@
                     <h2>{{ product.name }}</h2>
                     {% if product.description %}<p class="description">{{ product.description|safe|truncate(150, False) }}</p>{% endif %}
                     <div class="product-price">
-                        {% if priceinfo.is_discounted %}
-                            <div class="price-line">
-                                <span class="lead">
-                                    <small class="text-muted original-price"><s>{{ priceinfo.base_price|floatformat(2)|home_currency }}</s></small>
-                                    <strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small>
-                                </span>
-                            </div>
-                        {% else %}
-                            <div class="price-line"><span class="lead"><strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small></span></div>
-                        {% endif %}
+                        {{ macros.render_product_price(product, priceinfo) }}
                     </div>
                     <hr>
                     {% include "shoop/front/product/_detail_order_section.jinja" with context %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/default_basket.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/default_basket.jinja
@@ -9,17 +9,16 @@
         <hr>
         <a href="/xtheme/products" class="btn btn-primary"><i class="fa fa-angle-double-left"></i> {% trans %}Back to Products{% endtrans %}</a>
     {% else %}
+        {% if errors %}
+            <p class="text-danger">There were errors on following items:</p>
+            {% for error in errors %}
+                <p>{{ error.message }}</p>
+            {% endfor %}
+            <hr>
+        {% endif %}
         {% include "shoop/front/basket/partials/_basket_content.jinja" %}
         {% if errors %}
-            <hr>
-            <div class="alert alert-danger">
-                <p><strong>{% trans %}Errors{% endtrans %}</strong></p>
-                <ul>
-                    {% for error in errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+            <p class="lead text-right"><i class="fa fa-exclamation-triangle text-danger"></i> You are unable to proceed to checkout!</p>
         {% else %}
             <a href="/xtheme/products" class="text-muted btn continue-shopping hidden-xs"><i class="fa fa-angle-double-left"></i> {% trans %}Continue Shopping{% endtrans %}</a>
             <a href="{{ url("shoop:checkout") }}" class="btn btn-primary pull-right btn-checkout">

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -1,6 +1,10 @@
 {% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(500,500), shop=None) %}
     {% set u = url("shoop:product", pk=product.pk, slug=product.slug) %}
-    {% set price_info = product.get_price_info(request) %}
+    {% if product.is_variation_parent()  %}
+        {% set price_info = product.get_cheapest_child_price_info(request) %}
+    {% else %}
+        {% set price_info = product.get_price_info(request) %}
+    {% endif %}
     <div class="product-card {{ class }}" id="product-{{ product.id }}">
         {% if price_info.is_discounted %}
             <div class="labels">
@@ -21,10 +25,7 @@
             {% if shop %}<p class="shop">{{ shop }}</p>{% endif %}
             {# TODO: (TAX) Check following line (gets taxful price of product)  #}
             <div class="price">
-                {{ price_info.price|home_currency }}
-                {% if price_info.is_discounted %}
-                    <span class="original">{{price_info.base_price|home_currency}}</span>
-                {% endif %}
+                {{ render_product_price(product, price_info, show_units=False) }}
             </div>
             <div class="actions clearfix">
                 <div class="col-xs-6">
@@ -273,4 +274,28 @@
             {% endif %}
         </ul>
     </nav>
+{% endmacro %}
+
+
+{% macro render_product_price(product, price_info, show_units=True) %}
+<div class="price-line">
+    <span class="lead">
+    {% if product.is_variation_parent() %}
+        {% set min_price, max_price = product.get_child_price_range(request) %}
+        {% if min_price == max_price %}
+            <strong>{{ min_price|home_currency }}</strong>
+        {% else %}
+            <strong>{{ min_price|home_currency }} - {{ max_price|home_currency }}</strong>
+        {% endif %}
+    {% else %}
+        {% if price_info.is_discounted %}
+            <small class="text-muted original-price original"><s>{{ price_info.base_price|floatformat(2)|home_currency }}</s></small>
+        {% endif %}
+        <strong>{{ price_info.price|floatformat(2)|home_currency }}</strong>
+    {% endif %}
+    {% if show_units %}
+    <small> / {{ product.sales_unit.short_name }}</small>
+    {% endif %}
+    </span>
+</div>
 {% endmacro %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
@@ -16,7 +16,7 @@
 
 {% macro add_to_cart_btn() %}
     <div class="clearfix btn-add-to-cart">
-        <button type="submit" class="btn btn-primary btn-block btn-lg"><i class="fa fa-shopping-cart"></i> {% trans %}Add to cart{% endtrans %}</button>
+        <button type="submit" class="btn btn-primary btn-block btn-lg" id="add-to-cart-button"><i class="fa fa-shopping-cart"></i> {% trans %}Add to cart{% endtrans %}</button>
     </div>
 {% endmacro %}
 
@@ -59,8 +59,10 @@
             <span id="product-price"><strong>{{ price_info.price|home_currency }}</strong></span>
         </h2>
         <span class="small text-muted">
+            {% if price_info.is_discounted %}
+            (<s>{{ price_info.unit_base_price|home_currency }}</s>)
+            {% endif %}
             {{ price_info.unit_price|home_currency }}/{{ product.sales_unit.short_name }}
-            {# TODO: (TAX) Add tax percentages or amount etc #}
         </span>
     </div>
 {% endmacro %}
@@ -123,7 +125,8 @@
 {% endmacro %}
 
 <form role="form" method="post" action="{{ url("shoop:basket") }}" class="add-to-basket">
-    <input type="hidden" name="return" value="{{ request.path }}">
+    {% set return_path = return_url if return_url else request.path %}
+    <input type="hidden" name="return" value="{{ return_path }}">
     {% if unorderability_reason %}
         <p class="text-warning not-orderable">{{ unorderability_reason }}</p>
     {% elif variation_variables %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section.jinja
@@ -14,10 +14,17 @@
     {% set quantity = shop_product.rounded_minimum_purchase_quantity %}
 {% endif %}
 
-{% macro add_to_cart_btn() %}
+{% macro add_to_cart_btn(is_orderable) %}
+    {% if is_orderable %}
     <div class="clearfix btn-add-to-cart">
         <button type="submit" class="btn btn-primary btn-block btn-lg" id="add-to-cart-button"><i class="fa fa-shopping-cart"></i> {% trans %}Add to cart{% endtrans %}</button>
     </div>
+    {% else %}
+    <div class="clearfix btn-add-to-cart">
+        <button type="submit" class="btn btn-primary btn-block btn-lg not-orderable" id="add-to-cart-button" disabled><i class="fa fa-shopping-cart"></i> {% trans %}Add to cart{% endtrans %}</button>
+        <p class="text-right text-muted"><i class="fa fa-info-circle text-info"></i> {% trans %}Product is not orderable.{% endtrans %}</p>
+    </div>
+    {% endif %}
 {% endmacro %}
 
 {% macro quantity_box() %}
@@ -38,7 +45,7 @@
     </div>
 {% endmacro %}
 
-{% macro product_order_section(product, quantity) %}
+{% macro product_order_section(product, quantity, is_orderable) %}
     <div class="row">
         <div class="col-sm-6">
             {{ quantity_box() }}
@@ -47,7 +54,7 @@
             {{ product_price_div(product, quantity) }}
         </div>
     </div>
-    {{ add_to_cart_btn() }}
+    {{ add_to_cart_btn(is_orderable) }}
 {% endmacro %}
 
 {% macro product_price_div(product, quantity) %}
@@ -81,30 +88,27 @@
                 </select>
             </div>
         {% endfor %}
-        {{ product_order_section(product, quantity) }}
+        {{ product_order_section(product, quantity, True) }}
     </div>
 {% endmacro %}
 
 {% macro simple_variation_form() %}
-    {% if not orderable_variation_children %}
-        <p class="not-orderable">{% trans %}Product is not orderable{% endtrans %}</p>
-    {% else %}
-        <div class="product-variations">
-            <input type="hidden" name="command" value="add">
-            <div class="form-group">
-                <label for="product-variations">{% trans %}Select product{% endtrans %}</label>
-                <select name="product_id" id="product-variations" class="form-control selectpicker">
-                    {% for p in orderable_variation_children %}
-                        {% set price_info = p.get_price_info(request, quantity) %}
-                        <option value="{{ p.id }}"{% if selected_child and selected_child == p.id %} selected{% endif %}>
-                            {{ p.variation_name or p.name }}
-                        </option>
-                    {% endfor %}
-                </select>
-            </div>
-            {{ product_order_section(product, quantity) }}
+    {% set is_orderable = bool(orderable_variation_children) %}
+    <div class="product-variations">
+        <input type="hidden" name="command" value="add">
+        <div class="form-group">
+            <label for="product-variations">{% trans %}Select product{% endtrans %}</label>
+            <select name="product_id" id="product-variations" class="form-control selectpicker">
+                {% for p in orderable_variation_children %}
+                    {% set price_info = p.get_price_info(request, quantity) %}
+                    <option value="{{ p.id }}"{% if selected_child and selected_child == p.id %} selected{% endif %}>
+                        {{ p.variation_name or p.name }}
+                    </option>
+                {% endfor %}
+            </select>
         </div>
-    {% endif %}
+        {{ product_order_section(product, quantity, is_orderable) }}
+    </div>
 {% endmacro %}
 
 {% macro simple_product_form() %}
@@ -112,15 +116,7 @@
     <input type="hidden" name="product_id" value="{{ product.id }}">
     {% set is_orderable=shop_product.is_orderable(supplier=None, customer=request.customer, quantity=quantity) %}
     <div class="prices">
-        {% if is_orderable %}
-            {{ product_order_section(product, quantity) }}
-        {% else %}
-            <div class="row">
-                <div class="col-sm-12">
-                    <p><i class="fa fa-info-circle text-info"></i> {% trans %}Product is not orderable{% endtrans %}</p>
-                </div>
-            </div>
-        {% endif %}
+        {{ product_order_section(product, quantity, is_orderable) }}
     </div>
 {% endmacro %}
 

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section_no_product.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/_detail_order_section_no_product.jinja
@@ -1,0 +1,7 @@
+<div class="price text-right" id="product-price-div">
+    <h2 id="no-price">
+        <small class="text-muted">Total:</small>
+        <span id="product-price"><strong>--</strong></span>
+    </h2>
+    <span class="small text-muted">{% trans %}Combination not available{% endtrans %}</span>
+</div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -1,5 +1,10 @@
 {% extends "shoop/front/base.jinja" %}
-{% set priceinfo = product.get_price_info(request) %}
+
+{% if product.is_variation_parent()  %}
+    {% set priceinfo = product.get_cheapest_child_price_info(request) %}
+{% else %}
+    {% set priceinfo = product.get_price_info(request) %}
+{% endif %}
 
 {% block extrameta %}
     <meta property="og:site_name" content="{{ request.shop }}">
@@ -39,17 +44,7 @@
                     <p class="product-short-description">{{ product.description|safe|truncate(150, False) }}</p>
                 {% endif %}
                 <div class="product-price">
-                    {% if priceinfo.is_discounted %}
-                        <div class="price-line">
-                            <h4 class="visible-xs">{% trans %}Price{% endtrans %}</h4>
-                            <span class="lead">
-                                <small class="text-muted original-price"><s>{{ priceinfo.base_price|floatformat(2)|home_currency }}</s></small>
-                                <strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small>
-                            </span>
-                        </div>
-                    {% else %}
-                        <div class="price-line"><span class="lead"><strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small></span></div>
-                    {% endif %}
+                    {{ macros.render_product_price(product, priceinfo) }}
                 </div>
                 <hr>
             </div>
@@ -70,17 +65,7 @@
                     <p class="product-short-description">{{ product.description|safe|truncate(150, False) }}</p>
                 {% endif %}
                 <div class="product-price">
-                    {% if priceinfo.is_discounted %}
-                        <div class="price-line">
-                            <h4 class="visible-xs">{% trans %}Price{% endtrans %}</h4>
-                            <span class="lead">
-                                <small class="text-muted original-price"><s>{{ priceinfo.base_price|floatformat(2)|home_currency }}</s></small>
-                                <strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small>
-                            </span>
-                        </div>
-                    {% else %}
-                        <div class="price-line"><span class="lead"><strong>{{ priceinfo.price|floatformat(2)|home_currency }}</strong><small> / {{ product.sales_unit.short_name }}</small></span></div>
-                    {% endif %}
+                    {{ macros.render_product_price(product, priceinfo) }}
                 </div>
             </div>
             <hr>

--- a/shoop/themes/classic_gray/views/product_preview.py
+++ b/shoop/themes/classic_gray/views/product_preview.py
@@ -8,7 +8,21 @@
 from shoop.front.views.product import ProductDetailView
 
 
+class ProductPreviewView(ProductDetailView):
+    template_name = "classic_gray/product_preview.jinja"
+
+    def get_context_data(self, **kwargs):
+        # By default the template rendering the basket add form
+        # uses the `request.path` as its' `next` value.
+        # This is fine if you are on product page but here in
+        # preview, we cannot redirect back to `/xtheme/product_preview`.
+
+        context = super(ProductPreviewView, self).get_context_data(**kwargs)
+        # Add `return_url` to context to avoid usage of `request.path` in
+        # `classic_gray/shoop/front/product/_detail_order_section.jinja`
+        context["return_url"] = "/xtheme/products"
+        return context
+
+
 def product_preview(request):
-    return ProductDetailView.as_view(template_name="classic_gray/product_preview.jinja")(
-        request, pk=request.GET["id"]
-    )
+    return ProductPreviewView.as_view()(request, pk=request.GET["id"])

--- a/shoop/themes/classic_gray/views/product_price.py
+++ b/shoop/themes/classic_gray/views/product_price.py
@@ -18,6 +18,8 @@ class ProductPriceView(ProductDetailView):
         vars = self.get_variation_variables()
         if vars:  # complex variation variables detected
             context["product"] = ProductVariationResult.resolve(context["product"], vars)
+            if not context["product"]:
+                self.template_name = "shoop/front/product/_detail_order_section_no_product.jinja"
         context["quantity"] = self.request.GET.get("quantity")
 
         if context["product"]:  # Might be null from ProductVariationResult resolution

--- a/shoop/utils/excs.py
+++ b/shoop/utils/excs.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
 
 
@@ -43,3 +44,27 @@ class ExceptionalResponse(Exception):
     def __init__(self, response):
         self.response = response
         super(ExceptionalResponse, self).__init__(force_text(response))
+
+
+def extract_messages(obj_list):
+    """
+    Extract "messages" from a list of exceptions or other objects.
+
+    For ValidationErrors, `messages` are flattened into the output.
+    For Exceptions, `args[0]` is added into the output.
+    For other objects, `force_text` is called.
+
+    :param obj_list: List of exceptions etc.
+    :type obj_list: Iterable[object]
+    :rtype: Iterable[str]
+    """
+    for obj in obj_list:
+        if isinstance(obj, ValidationError):
+            for msg in obj.messages:
+                yield force_text(msg)
+            continue
+        if isinstance(obj, Exception):
+            if len(obj.args):
+                yield force_text(obj.args[0])
+                continue
+        yield force_text(obj)

--- a/shoop_tests/core/test_product_variation_child_pricing.py
+++ b/shoop_tests/core/test_product_variation_child_pricing.py
@@ -1,0 +1,66 @@
+import pytest
+from shoop.core.pricing import TaxlessPrice, TaxfulPrice
+from shoop.testing.factories import get_default_product, get_default_shop, create_product
+
+
+def init_test(request, shop, prices):
+    parent = create_product("parent_product", shop=shop)
+    children = [create_product("child-%d" % price, shop=shop, default_price=price) for price in prices]
+    for child in children:
+        child.link_to_parent(parent)
+    return parent
+
+@pytest.mark.django_db
+def test_simple_product_works(rf):
+    product = get_default_product()
+    request = rf.get("/")
+    assert product.get_child_price_range(request) == (None, None)
+    assert product.get_cheapest_child_price_info(request) is None
+    assert product.get_cheapest_child_price(request) is None
+
+
+@pytest.mark.django_db
+def test_cheapest_price_found(rf):
+    prices = [100,20,50,80,90]
+
+    shop = get_default_shop()
+    request = rf.get("/")
+    request.shop = shop
+    parent = init_test(request, shop, prices)
+
+    tax_cls = TaxfulPrice if shop.prices_include_tax else TaxlessPrice
+    assert parent.get_cheapest_child_price(request) == tax_cls(min(prices))
+
+    price_info = parent.get_cheapest_child_price_info(request)
+    assert price_info.price == tax_cls(min(prices))
+
+
+@pytest.mark.django_db
+def test_correct_range_found(rf):
+    prices = [100,20,50,80,90]
+
+    shop = get_default_shop()
+    request = rf.get("/")
+    request.shop = shop
+    parent = init_test(request, shop, prices)
+
+    tax_cls = TaxfulPrice if shop.prices_include_tax else TaxlessPrice
+    assert parent.get_child_price_range(request) == (tax_cls(min(prices)), tax_cls(max(prices)))
+
+
+@pytest.mark.django_db
+def test_only_one_variation_child(rf):
+    prices = [20]
+
+    shop = get_default_shop()
+    request = rf.get("/")
+    request.shop = shop
+    parent = init_test(request, shop, prices)
+
+    price_info = parent.get_cheapest_child_price_info(request)
+
+    tax_cls = TaxfulPrice if shop.prices_include_tax else TaxlessPrice
+
+    assert parent.get_cheapest_child_price(request) == tax_cls(min(prices))
+    assert parent.get_child_price_range(request) == (tax_cls(min(prices)), tax_cls(max(prices)))
+    assert price_info.price == tax_cls(min(prices))


### PR DESCRIPTION
Classic Gray fixes:
* Adding product to basket should now work as expected
  * If error is returned from ajax request, show error information
* Product preview
  * Adding product to basket should now function properly
  * Complex variations are working
  * Return URL is now pointing to `/xtheme/products` instead of preview view
  * etc
* Product Page
  * If no price is available for complex variation, show proper information and disable the add to cart
  * Removed `.is(":valid")` check to remove the error it caused
  * Prices should now be properly shown
  * Product not purchaseable if no supplier (addable to basket)
  * Properly disable "Add to basket" button if product is not purchaseable
* Category Page:
  * Prices should now be properly shown
* General changes:
  * Product price has been unified to a single macro called `render_product_price(product, price_info, show_units)`
  * Show errors properly on basket

General fixes:
* Front: Variation children are no longer visible in listings
* Admin: Disabled `Stock` field for now
* Admin: Show errors properly on shipment creation page
* Admin: Make visibles off by default
* Admin: Add info why product is not buyable / visible