### PR TITLE
Update product card macro and styles (classic gray)

### DIFF
--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product-card.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product-card.less
@@ -4,7 +4,7 @@
     border: 1px solid #ededed;
     border-bottom: 2px solid #ddd;
     position: relative;
-    padding-bottom: 65px;
+    padding-bottom: 52px;
     width: 100%;
     max-width: 280px;
     margin-bottom: 30px;
@@ -23,6 +23,16 @@
             text-decoration: none;
         }
     }
+
+    > a {
+        padding-bottom: 10px;
+        &:hover, &:focus {
+            .name {
+                color: @brand-primary;
+            }
+        }
+    }
+
     .labels {
         position: absolute;
         left: 5px;
@@ -67,15 +77,16 @@
     }
     .actions {
         position: absolute;
-        bottom: 10px;
+        bottom: 0;
         left: 0;
         right: 0;
-        padding-top: 10px;
+        padding: 0;
         border-top: 1px solid #ededed;
+
         .btn {
             background: #fff;
             font-size: 1.2rem;
-            padding: 6px 0px;
+            padding: 15px 0px;
             &:active {
                 box-shadow: none;
             }

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/product-list.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/product-list.less
@@ -212,21 +212,26 @@
                 justify-content: center;
                 height: 100%;
                 padding: 15px;
-                padding-bottom: 45px;
             }
             .single-product {
                 width: 100%;
                 .product-card {
-                    padding-bottom: 0;
+                    padding-bottom: 42px;
                     text-align: left;
+                    > a {
+                        .clearfix;
+                        flex: 1 1 0%;
+                        height: 100%;
+                        padding-bottom: 0;
+                    }
                     .name {
                         font-size: 1.8rem;
                     }
                     .description {
                         display: block;
                     }
-                    .actions {
-                        border: 0;
+                    .actions .btn {
+                        padding: 10px 0;
                     }
                 }
             }

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -1,4 +1,4 @@
-{% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(500,500), shop=None) %}
+{% macro product_box(product, show_image=True, show_description=True, class="product-box", thumbnail_size=(500,500)) %}
     {% set u = url("shoop:product", pk=product.pk, slug=product.slug) %}
     {% if product.is_variation_parent()  %}
         {% set price_info = product.get_cheapest_child_price_info(request) %}
@@ -6,35 +6,31 @@
         {% set price_info = product.get_price_info(request) %}
     {% endif %}
     <div class="product-card {{ class }}" id="product-{{ product.id }}">
-        {% if price_info.is_discounted %}
-            <div class="labels">
-                <span class="label label-sale">{{ -price_info.discount_percentage|int }}%</span>
-            </div>
-        {% endif %}
-        {% if show_image %}
-            {% set primary_image_thumb = product.primary_image|thumbnail(size=thumbnail_size) %}
-            <div class="image-wrap">
-                <a href="{{ u }}" class="image" rel="product-detail" style="background-image:url('{% if product.primary_image %}{{ primary_image_thumb }}{% else %}{{ STATIC_URL }}classic_gray/img/no_image.png{% endif %}')" title="{{ product.name }}"></a>
-            </div>
-        {% endif %}
-        <div class="detail-wrap">
-            <a href="{{ u }}" class="name">{{ product.name }}</a>
-            {% if show_description and product.description %}
-                <p class="description">{{ product.description|striptags|truncate(180)|safe }}</p>
+        <a href="{{ u }}" rel="product-detail" title="{{ product.name }}">
+            {% if price_info.is_discounted %}
+                <div class="labels">
+                    <span class="label label-sale">{{ -price_info.discount_percentage|int }}%</span>
+                </div>
             {% endif %}
-            {% if shop %}<p class="shop">{{ shop }}</p>{% endif %}
-            {# TODO: (TAX) Check following line (gets taxful price of product)  #}
-            <div class="price">
-                {{ render_product_price(product, price_info, show_units=False) }}
-            </div>
-            <div class="actions clearfix">
-                <div class="col-xs-6">
-                    <button type="button" class="btn btn-block text-muted" onclick="javascript:showPreview('{{ product.id }}')"><i class="fa fa-eye"></i> {% trans %}Preview{% endtrans %}</button>
+            {% if show_image %}
+                {% set primary_image_thumb = product.primary_image|thumbnail(size=thumbnail_size) %}
+                <div class="image-wrap">
+                    <div class="image" style="background-image:url('{% if product.primary_image %}{{ primary_image_thumb }}{% else %}{{ STATIC_URL }}classic_gray/img/no_image.png{% endif %}')"></div>
                 </div>
-                <div class="col-xs-6">
-                    <a href="{{ u }}" class="btn btn-block text-muted"><i class="fa fa-search"></i> {% trans %}Open{% endtrans %}</a>
+            {% endif %}
+            <div class="detail-wrap">
+                <div class="name">{{ product.name }}</div>
+                {% if show_description and product.description %}
+                    <p class="description">{{ product.description|striptags|truncate(180)|safe }}</p>
+                {% endif %}
+                {# TODO: (TAX) Check following line (gets taxful price of product)  #}
+                <div class="price">
+                    {{ render_product_price(product, price_info, show_units=False) }}
                 </div>
             </div>
+        </a>
+        <div class="actions clearfix">
+            <button type="button" class="btn btn-block text-muted" onclick="javascript:showPreview('{{ product.id }}')"><i class="fa fa-eye"></i> {% trans %}Preview{% endtrans %}</button>
         </div>
     </div>
 {% endmacro %}


### PR DESCRIPTION
Product card included multiple links to product detail page on its elements.
Wrap card contents to one link instead of multiple ones so the card itself
acts as a link to the product detail page.

"Shop" is not used in classic gray so remove it from product box macro.

Since the whole product card acts now as a link, remove "open" button from
the bottom actions.