### PR TITLE
Front: Fix issue with variation children being listed for admin user

### DIFF
--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -117,7 +117,8 @@ class ProductQuerySet(TranslatableQuerySet):
         root = (self.language(language) if language else self)
 
         if customer and customer.is_all_seeing:
-            qs = root.all().exclude(deleted=True).filter(shop_products__shop=shop)
+            exclude_q = Q(deleted=True) | Q(mode=ProductMode.VARIATION_CHILD)
+            qs = root.all().exclude(exclude_q).filter(shop_products__shop=shop)
         else:
             qs = root.all().exclude(deleted=True).filter(
                 shop_products__shop=shop,


### PR DESCRIPTION
Customer with `is_all_seeing` `True` could see variation children in product
listings and this caused multiple problems and was not intented.

Refs SHOOP-1596