### PR TITLE
Admin: Fix issue where visibility errors caused an error

### DIFF
--- a/shoop/core/models/product_shops.py
+++ b/shoop/core/models/product_shops.py
@@ -90,6 +90,7 @@ class ShopProduct(MoneyPropped, models.Model):
     def get_visibility_errors(self, customer):
         if self.product.deleted:
             yield ValidationError(_('This product has been deleted.'), code="product_deleted")
+
         if customer and customer.is_all_seeing:  # None of the further conditions matter for omniscient customers.
             return
 
@@ -103,7 +104,7 @@ class ShopProduct(MoneyPropped, models.Model):
                 _('The Product is invisible to users not logged in.'),
                 code="product_not_visible_to_anonymous")
 
-        if self.visibility_limit == ProductVisibility.VISIBLE_TO_GROUPS:
+        if is_logged_in and self.visibility_limit == ProductVisibility.VISIBLE_TO_GROUPS:
             # TODO: Optimization
             user_groups = set(customer.groups.all().values_list("pk", flat=True))
             my_groups = set(self.visibility_groups.values_list("pk", flat=True))

--- a/shoop_tests/admin/test_product_module.py
+++ b/shoop_tests/admin/test_product_module.py
@@ -5,16 +5,16 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.http import HttpResponse
 import pytest
 from shoop.admin.module_registry import replace_modules
 from shoop.admin.modules.products import ProductModule
 from shoop.admin.modules.products.views.edit import ProductEditView
 from shoop.admin.utils.urls import get_model_url
 from shoop.admin.views.search import get_search_results
+from shoop.core.models import ProductVisibility
 from shoop_tests.admin.utils import admin_only_urls
 from shoop_tests.utils import empty_iterable, apply_request_middleware
-from shoop.testing.factories import get_default_product, get_default_shop
+from shoop.testing.factories import get_default_product, get_default_shop, create_product
 
 
 @pytest.mark.django_db
@@ -34,14 +34,17 @@ def test_product_module_search(rf, admin_user):
 
 @pytest.mark.django_db
 def test_product_edit_view_works_at_all(rf, admin_user):
-    get_default_shop()
+    shop = get_default_shop()
+    product = create_product("test-product", shop, default_price=200)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.visibility_limit = ProductVisibility.VISIBLE_TO_GROUPS
+    shop_product.save()
     request = apply_request_middleware(rf.get("/"), user=admin_user)
 
     with replace_modules([ProductModule]):
         with admin_only_urls():
-            default_product = get_default_product()
             view_func = ProductEditView.as_view()
-            response = view_func(request, pk=default_product.pk)
-            assert (default_product.sku in response.rendered_content)  # it's probable the SKU is there
+            response = view_func(request, pk=product.pk)
+            assert (product.sku in response.rendered_content)  # it's probable the SKU is there
             response = view_func(request, pk=None)  # "new mode"
             assert response.rendered_content  # yeah, something gets rendered


### PR DESCRIPTION
Admin has no customer, therefore the visibility cannot be checked the same way
as in frontend.

SHOOP-1604