### PR TITLE
Classic Gray search: Use render_field instead of bs3 in select

### DIFF
--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/simple_search/search.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/simple_search/search.jinja
@@ -13,7 +13,7 @@
                     </div>
                 </div>
             </div>
-            <div class="col-sm-6 col-md-4">{{ bs3.field(form.sort) }}</div>
+            <div class="col-sm-6 col-md-4">{{ macros.render_field(form.sort) }}</div>
         </div>
         <hr>
     </form>


### PR DESCRIPTION
render_field has selectpickers enabled so use it in classic gray's
search select field.