### PR TITLE
Prevent `Shop` being deleted when image was deleted

### DIFF
--- a/shoop/core/migrations/0010_fk_on_delete.py
+++ b/shoop/core/migrations/0010_fk_on_delete.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+import filer.fields.image
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0009_tax_price_currency'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='category',
+            name='image',
+            field=filer.fields.image.FilerImageField(on_delete=django.db.models.deletion.SET_NULL, to='filer.Image', null=True, blank=True, verbose_name='image'),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='default_payment_method',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to='shoop.PaymentMethod', null=True, blank=True, verbose_name='default payment method'),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='default_shipping_method',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to='shoop.ShippingMethod', null=True, blank=True, verbose_name='default shipping method'),
+        ),
+        migrations.AlterField(
+            model_name='contact',
+            name='tax_group',
+            field=models.ForeignKey(to='shoop.CustomerTaxGroup', null=True, blank=True, on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='creator',
+            field=shoop.core.fields.UnsavedForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='orders_created', to=settings.AUTH_USER_MODEL, null=True, blank=True, verbose_name='creating user'),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='customer',
+            field=shoop.core.fields.UnsavedForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='customer_orders', to='shoop.Contact', null=True, blank=True, verbose_name='customer'),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='orderer',
+            field=shoop.core.fields.UnsavedForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='orderer_orders', to='shoop.PersonContact', null=True, blank=True, verbose_name='orderer'),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='shop',
+            field=shoop.core.fields.UnsavedForeignKey(to='shoop.Shop', on_delete=django.db.models.deletion.PROTECT),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='status',
+            field=shoop.core.fields.UnsavedForeignKey(to='shoop.OrderStatus', on_delete=django.db.models.deletion.PROTECT, verbose_name='status'),
+        ),
+        migrations.AlterField(
+            model_name='paymentmethod',
+            name='tax_class',
+            field=models.ForeignKey(to='shoop.TaxClass', on_delete=django.db.models.deletion.PROTECT, verbose_name='tax class'),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='category',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, help_text='only used for administration and reporting', related_name='primary_products', to='shoop.Category', blank=True, verbose_name='primary category', null=True),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='manufacturer',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='shoop.Manufacturer', null=True, blank=True, verbose_name='manufacturer'),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='sales_unit',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, to='shoop.SalesUnit', null=True, blank=True, verbose_name='unit'),
+        ),
+        migrations.AlterField(
+            model_name='product',
+            name='tax_class',
+            field=models.ForeignKey(to='shoop.TaxClass', on_delete=django.db.models.deletion.PROTECT, verbose_name='tax class'),
+        ),
+        migrations.AlterField(
+            model_name='shippingmethod',
+            name='tax_class',
+            field=models.ForeignKey(to='shoop.TaxClass', on_delete=django.db.models.deletion.PROTECT, verbose_name='tax class'),
+        ),
+        migrations.AlterField(
+            model_name='shop',
+            name='logo',
+            field=filer.fields.image.FilerImageField(on_delete=django.db.models.deletion.SET_NULL, to='filer.Image', null=True, blank=True, verbose_name='logo'),
+        ),
+        migrations.AlterField(
+            model_name='shop',
+            name='owner',
+            field=models.ForeignKey(to='shoop.Contact', null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL),
+        ),
+        migrations.AlterField(
+            model_name='shopproduct',
+            name='primary_category',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='primary_shop_products', to='shoop.Category', null=True, blank=True, verbose_name='primary category'),
+        ),
+    ]

--- a/shoop/core/models/addresses.py
+++ b/shoop/core/models/addresses.py
@@ -194,8 +194,9 @@ class SavedAddress(models.Model):
     """
     Model for saving multiple addresses in an 'address book' of sorts.
     """
-    owner = models.ForeignKey("Contact")
-    address = models.ForeignKey(Address, verbose_name=_('address'), related_name="saved_addresses")
+    owner = models.ForeignKey("Contact", on_delete=models.CASCADE)
+    address = models.ForeignKey(
+        Address, verbose_name=_('address'), related_name="saved_addresses", on_delete=models.CASCADE)
     role = EnumIntegerField(SavedAddressRole, verbose_name=_('role'), default=SavedAddressRole.SHIPPING)
     status = EnumIntegerField(SavedAddressStatus, default=SavedAddressStatus.ENABLED, verbose_name=_('status'))
     title = models.CharField(max_length=255, blank=True, verbose_name=_('title'))

--- a/shoop/core/models/attributes.py
+++ b/shoop/core/models/attributes.py
@@ -192,7 +192,7 @@ class Attribute(TranslatableModel):
 class AppliedAttribute(TranslatableModel):
     _applied_fk_field = None  # Used by the `repr` implementation
 
-    attribute = models.ForeignKey(Attribute)
+    attribute = models.ForeignKey(Attribute, on_delete=models.CASCADE)
 
     numeric_value = models.DecimalField(null=True, blank=True, max_digits=36, decimal_places=9)
     datetime_value = models.DateTimeField(auto_now_add=False, editable=True, null=True, blank=True)

--- a/shoop/core/models/categories.py
+++ b/shoop/core/models/categories.py
@@ -72,7 +72,9 @@ class CategoryManager(TranslatableManager, TreeManager):
 
 @python_2_unicode_compatible
 class Category(MPTTModel, TranslatableModel):
-    parent = TreeForeignKey('self', null=True, blank=True, related_name='children', verbose_name=_('parent category'))
+    parent = TreeForeignKey(
+        'self', null=True, blank=True, related_name='children',
+        verbose_name=_('parent category'), on_delete=models.CASCADE)
     shops = models.ManyToManyField("Shop", blank=True, related_name="categories")
     identifier = InternalIdentifierField(unique=True)
     status = EnumIntegerField(CategoryStatus, db_index=True, verbose_name=_('status'), default=CategoryStatus.INVISIBLE)

--- a/shoop/core/models/categories.py
+++ b/shoop/core/models/categories.py
@@ -76,7 +76,7 @@ class Category(MPTTModel, TranslatableModel):
     shops = models.ManyToManyField("Shop", blank=True, related_name="categories")
     identifier = InternalIdentifierField(unique=True)
     status = EnumIntegerField(CategoryStatus, db_index=True, verbose_name=_('status'), default=CategoryStatus.INVISIBLE)
-    image = FilerImageField(verbose_name=_('image'), blank=True, null=True)
+    image = FilerImageField(verbose_name=_('image'), blank=True, null=True, on_delete=models.SET_NULL)
     ordering = models.IntegerField(default=0, verbose_name=_('ordering'))
     visibility = EnumIntegerField(
         CategoryVisibility, db_index=True, default=CategoryVisibility.VISIBLE_TO_ALL,

--- a/shoop/core/models/contacts.py
+++ b/shoop/core/models/contacts.py
@@ -56,10 +56,10 @@ class Contact(NameMixin, PolymorphicModel):
         on_delete=models.PROTECT
     )
     default_shipping_method = models.ForeignKey(
-        "ShippingMethod", verbose_name=_('default shipping method'), blank=True, null=True
+        "ShippingMethod", verbose_name=_('default shipping method'), blank=True, null=True, on_delete=models.SET_NULL
     )
     default_payment_method = models.ForeignKey(
-        "PaymentMethod", verbose_name=_('default payment method'), blank=True, null=True
+        "PaymentMethod", verbose_name=_('default payment method'), blank=True, null=True, on_delete=models.SET_NULL
     )
 
     language = LanguageField(verbose_name=_('language'), blank=True)
@@ -73,7 +73,7 @@ class Contact(NameMixin, PolymorphicModel):
     name_ext = models.CharField(max_length=256, blank=True, verbose_name=_('name extension'))
     email = models.EmailField(max_length=256, blank=True, verbose_name=_('email'))
 
-    tax_group = models.ForeignKey("CustomerTaxGroup", blank=True, null=True)
+    tax_group = models.ForeignKey("CustomerTaxGroup", blank=True, null=True, on_delete=models.PROTECT)
 
     def __str__(self):
         return self.full_name

--- a/shoop/core/models/methods.py
+++ b/shoop/core/models/methods.py
@@ -84,7 +84,7 @@ class MethodQuerySet(TranslatableQuerySet):
 
 @python_2_unicode_compatible
 class Method(TaxableItem, ModuleInterface, TranslatableModel):
-    tax_class = models.ForeignKey("TaxClass", verbose_name=_('tax class'))
+    tax_class = models.ForeignKey("TaxClass", verbose_name=_('tax class'), on_delete=models.PROTECT)
     status = EnumIntegerField(MethodStatus, db_index=True, default=MethodStatus.ENABLED, verbose_name=_('status'))
     identifier = InternalIdentifierField(unique=True)
     module_identifier = models.CharField(max_length=64, blank=True, verbose_name=_('module'))

--- a/shoop/core/models/orders.py
+++ b/shoop/core/models/orders.py
@@ -153,7 +153,7 @@ class OrderQuerySet(models.QuerySet):
 @python_2_unicode_compatible
 class Order(models.Model):
     # Identification
-    shop = UnsavedForeignKey("Shop")
+    shop = UnsavedForeignKey("Shop", on_delete=models.PROTECT)
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
     identifier = InternalIdentifierField(unique=True, db_index=True, verbose_name=_('order identifier'))
     # TODO: label is actually a choice field, need to check migrations/choice deconstruction
@@ -168,9 +168,11 @@ class Order(models.Model):
     # Contact information
     customer = UnsavedForeignKey(
         "Contact", related_name='customer_orders', blank=True, null=True,
+        on_delete=models.PROTECT,
         verbose_name=_('customer'))
     orderer = UnsavedForeignKey(
         "PersonContact", related_name='orderer_orders', blank=True, null=True,
+        on_delete=models.PROTECT,
         verbose_name=_('orderer'))
     billing_address = UnsavedForeignKey(
         "Address", related_name="billing_orders", blank=True, null=True,
@@ -187,9 +189,10 @@ class Order(models.Model):
     # Status
     creator = UnsavedForeignKey(
         settings.AUTH_USER_MODEL, related_name='orders_created', blank=True, null=True,
+        on_delete=models.PROTECT,
         verbose_name=_('creating user'))
     deleted = models.BooleanField(db_index=True, default=False)
-    status = UnsavedForeignKey("OrderStatus", verbose_name=_('status'))
+    status = UnsavedForeignKey("OrderStatus", verbose_name=_('status'), on_delete=models.PROTECT)
     payment_status = EnumIntegerField(
         PaymentStatus, db_index=True, default=PaymentStatus.NOT_PAID,
         verbose_name=_('payment status'))

--- a/shoop/core/models/product_media.py
+++ b/shoop/core/models/product_media.py
@@ -34,12 +34,12 @@ class ProductMediaKind(Enum):
 @python_2_unicode_compatible
 class ProductMedia(TranslatableModel):
     identifier = InternalIdentifierField(unique=True)
-    product = models.ForeignKey("Product", related_name="media")
+    product = models.ForeignKey("Product", related_name="media", on_delete=models.CASCADE)
     shops = models.ManyToManyField("Shop", related_name="product_media")
     kind = EnumIntegerField(
         ProductMediaKind, db_index=True, default=ProductMediaKind.GENERIC_FILE, verbose_name=_('kind')
     )
-    file = FilerFileField(blank=True, null=True, verbose_name=_('file'))
+    file = FilerFileField(blank=True, null=True, verbose_name=_('file'), on_delete=models.CASCADE)
     external_url = models.URLField(
         blank=True, null=True, verbose_name=u'URL',
         help_text=_("Enter URL to external file. If this field is filled, the selected media doesn't apply.")

--- a/shoop/core/models/product_packages.py
+++ b/shoop/core/models/product_packages.py
@@ -12,8 +12,8 @@ from shoop.core.fields import QuantityField
 
 
 class ProductPackageLink(models.Model):
-    parent = models.ForeignKey("Product", related_name='+')
-    child = models.ForeignKey("Product", related_name='+')
+    parent = models.ForeignKey("Product", related_name='+', on_delete=models.CASCADE)
+    child = models.ForeignKey("Product", related_name='+', on_delete=models.CASCADE)
     quantity = QuantityField(default=1)
 
     class Meta:

--- a/shoop/core/models/product_shops.py
+++ b/shoop/core/models/product_shops.py
@@ -22,8 +22,8 @@ from shoop.utils.properties import MoneyPropped, PriceProperty
 
 
 class ShopProduct(MoneyPropped, models.Model):
-    shop = models.ForeignKey("Shop", related_name="shop_products")
-    product = UnsavedForeignKey("Product", related_name="shop_products")
+    shop = models.ForeignKey("Shop", related_name="shop_products", on_delete=models.CASCADE)
+    product = UnsavedForeignKey("Product", related_name="shop_products", on_delete=models.CASCADE)
     suppliers = models.ManyToManyField("Supplier", related_name="shop_products", blank=True)
 
     visible = models.BooleanField(default=True, db_index=True)

--- a/shoop/core/models/product_shops.py
+++ b/shoop/core/models/product_shops.py
@@ -48,7 +48,8 @@ class ShopProduct(MoneyPropped, models.Model):
         "PaymentMethod", related_name='payment_products', verbose_name=_('payment methods'), blank=True
     )
     primary_category = models.ForeignKey(
-        "Category", related_name='primary_shop_products', verbose_name=_('primary category'), blank=True, null=True
+        "Category", related_name='primary_shop_products', verbose_name=_('primary category'), blank=True, null=True,
+        on_delete=models.PROTECT
     )
     categories = models.ManyToManyField(
         "Category", related_name='shop_products', verbose_name=_('categories'), blank=True

--- a/shoop/core/models/product_variation.py
+++ b/shoop/core/models/product_variation.py
@@ -36,7 +36,7 @@ class ProductVariationLinkStatus(Enum):
 
 @python_2_unicode_compatible
 class ProductVariationVariable(TranslatableModel):
-    product = models.ForeignKey("Product", related_name='variation_variables')
+    product = models.ForeignKey("Product", related_name='variation_variables', on_delete=models.CASCADE)
     identifier = InternalIdentifierField(unique=False)
     translations = TranslatedFields(
         name=models.CharField(max_length=128, verbose_name=_('name')),

--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -540,8 +540,8 @@ ProductLogEntry = define_log_model(Product)
 
 
 class ProductCrossSell(models.Model):
-    product1 = models.ForeignKey(Product, related_name="cross_sell_1")
-    product2 = models.ForeignKey(Product, related_name="cross_sell_2")
+    product1 = models.ForeignKey(Product, related_name="cross_sell_1", on_delete=models.CASCADE)
+    product2 = models.ForeignKey(Product, related_name="cross_sell_2", on_delete=models.CASCADE)
     weight = models.IntegerField(default=0)
     type = EnumIntegerField(ProductCrossSellType)
 
@@ -552,7 +552,7 @@ class ProductCrossSell(models.Model):
 
 class ProductAttribute(AppliedAttribute):
     _applied_fk_field = "product"
-    product = models.ForeignKey(Product, related_name='attributes')
+    product = models.ForeignKey(Product, related_name='attributes', on_delete=models.CASCADE)
 
     translations = TranslatedFields(
         translated_string_value=models.TextField(blank=True)

--- a/shoop/core/models/products.py
+++ b/shoop/core/models/products.py
@@ -169,8 +169,8 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         verbose_name=_('variation parent'))
     stock_behavior = EnumIntegerField(StockBehavior, default=StockBehavior.UNSTOCKED, verbose_name=_('stock'))
     shipping_mode = EnumIntegerField(ShippingMode, default=ShippingMode.NOT_SHIPPED, verbose_name=_('shipping mode'))
-    sales_unit = models.ForeignKey("SalesUnit", verbose_name=_('unit'), blank=True, null=True)
-    tax_class = models.ForeignKey("TaxClass", verbose_name=_('tax class'))
+    sales_unit = models.ForeignKey("SalesUnit", verbose_name=_('unit'), blank=True, null=True, on_delete=models.PROTECT)
+    tax_class = models.ForeignKey("TaxClass", verbose_name=_('tax class'), on_delete=models.PROTECT)
 
     # Identification
     type = models.ForeignKey(
@@ -189,7 +189,7 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
     category = models.ForeignKey(
         "Category", related_name='primary_products', blank=True, null=True,
         verbose_name=_('primary category'),
-        help_text=_("only used for administration and reporting"))
+        help_text=_("only used for administration and reporting"), on_delete=models.PROTECT)
 
     # Physical dimensions
     width = MeasurementField(unit="mm", verbose_name=_('width (mm)'))
@@ -199,7 +199,9 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
     gross_weight = MeasurementField(unit="g", verbose_name=_('gross weight (g)'))
 
     # Misc.
-    manufacturer = models.ForeignKey("Manufacturer", blank=True, null=True, verbose_name=_('manufacturer'))
+    manufacturer = models.ForeignKey(
+        "Manufacturer", blank=True, null=True,
+        verbose_name=_('manufacturer'), on_delete=models.PROTECT)
     primary_image = models.ForeignKey(
         "ProductMedia", null=True, blank=True,
         related_name="primary_image_for_products",

--- a/shoop/core/models/shipments.py
+++ b/shoop/core/models/shipments.py
@@ -74,7 +74,7 @@ class Shipment(models.Model):
 @python_2_unicode_compatible
 class ShipmentProduct(models.Model):
     shipment = models.ForeignKey(Shipment, related_name='products', on_delete=models.PROTECT)
-    product = models.ForeignKey("Product", related_name='shipments')
+    product = models.ForeignKey("Product", related_name='shipments', on_delete=models.CASCADE)
     quantity = QuantityField()
     unit_volume = MeasurementField(unit="m3")  # volume is m^3, not mm^3, because mm^3 are tiny. like ants.
     unit_weight = MeasurementField(unit="g")

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -36,11 +36,11 @@ class Shop(TranslatableShoopModel):
     identifier = InternalIdentifierField(unique=True)
     domain = models.CharField(max_length=128, blank=True, null=True, unique=True)
     status = EnumIntegerField(ShopStatus, default=ShopStatus.DISABLED)
-    owner = models.ForeignKey("Contact", blank=True, null=True)
+    owner = models.ForeignKey("Contact", blank=True, null=True, on_delete=models.SET_NULL)
     options = JSONField(blank=True, null=True)
     currency = CurrencyField(default=_get_default_currency)
     prices_include_tax = models.BooleanField(default=True)
-    logo = FilerImageField(verbose_name=_("logo"), blank=True, null=True)
+    logo = FilerImageField(verbose_name=_("logo"), blank=True, null=True, on_delete=models.SET_NULL)
     maintenance_mode = models.BooleanField(verbose_name=_("maintenance mode"), default=False)
 
     translations = TranslatedFields(

--- a/shoop/core/models/supplied_products.py
+++ b/shoop/core/models/supplied_products.py
@@ -12,8 +12,8 @@ from shoop.core.fields import QuantityField
 
 
 class SuppliedProduct(models.Model):
-    supplier = models.ForeignKey("Supplier")
-    product = models.ForeignKey("Product")
+    supplier = models.ForeignKey("Supplier", on_delete=models.CASCADE)
+    product = models.ForeignKey("Product", on_delete=models.CASCADE)
     sku = models.CharField(db_index=True, max_length=128, verbose_name=_('SKU'))
     alert_limit = models.IntegerField(default=0, verbose_name=_('alert limit'))
     physical_count = QuantityField(editable=False, verbose_name=_('physical stock count'))

--- a/shoop/default_tax/migrations/0003_fk_on_delete.py
+++ b/shoop/default_tax/migrations/0003_fk_on_delete.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_tax', '0002_tax_price_currency'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taxrule',
+            name='tax',
+            field=models.ForeignKey(to='shoop.Tax', on_delete=django.db.models.deletion.PROTECT),
+        ),
+    ]

--- a/shoop/default_tax/models.py
+++ b/shoop/default_tax/models.py
@@ -30,7 +30,7 @@ class TaxRule(models.Model):
     postal_codes_pattern = models.CharField(max_length=500, blank=True)
     # TODO: (TAX) Priority is not supported yet
     priority = models.IntegerField(default=0, help_text=PRIORITY_HELP)
-    tax = models.ForeignKey(Tax)
+    tax = models.ForeignKey(Tax, on_delete=models.PROTECT)
 
     def matches(self, taxing_context):
         if self.country_codes_pattern:

--- a/shoop/discount_pricing/models.py
+++ b/shoop/discount_pricing/models.py
@@ -15,8 +15,8 @@ from shoop.utils.properties import MoneyPropped, PriceProperty
 
 
 class DiscountedProductPrice(MoneyPropped, models.Model):
-    product = models.ForeignKey("shoop.Product", related_name="+")
-    shop = models.ForeignKey("shoop.Shop", db_index=True)
+    product = models.ForeignKey("shoop.Product", related_name="+", on_delete=models.CASCADE)
+    shop = models.ForeignKey("shoop.Shop", db_index=True, on_delete=models.CASCADE)
     price = PriceProperty("price_value", "shop.currency", "shop.prices_include_tax")
     price_value = MoneyValueField()
 

--- a/shoop/front/models/stored_basket.py
+++ b/shoop/front/models/stored_basket.py
@@ -24,16 +24,19 @@ class StoredBasket(models.Model):
     # A combination of the PK and key is used to retrieve a basket for session situations.
     key = models.CharField(max_length=32, default=generate_key)
 
-    shop = models.ForeignKey(Shop)
+    shop = models.ForeignKey(Shop, on_delete=models.CASCADE)
 
     customer = models.ForeignKey(
         Contact, blank=True, null=True,
+        on_delete=models.CASCADE,
         related_name="customer_baskets")
     orderer = models.ForeignKey(
         PersonContact, blank=True, null=True,
+        on_delete=models.CASCADE,
         related_name="orderer_baskets")
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL, blank=True, null=True,
+        on_delete=models.CASCADE,
         related_name="baskets_created")
 
     created_on = models.DateTimeField(auto_now_add=True, db_index=True, editable=False)

--- a/shoop/notify/migrations/0003_fk_on_delete.py
+++ b/shoop/notify/migrations/0003_fk_on_delete.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop_notify', '0002_notification_identifier'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notification',
+            name='marked_read_by',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, related_name='+', editable=False, null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL),
+        ),
+        migrations.AlterField(
+            model_name='notification',
+            name='recipient',
+            field=models.ForeignKey(related_name='+', to=settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL),
+        ),
+    ]

--- a/shoop/notify/models/notification.py
+++ b/shoop/notify/models/notification.py
@@ -43,7 +43,8 @@ class Notification(models.Model):
     A model for persistent notifications to be shown in the admin, etc.
     """
     recipient_type = EnumIntegerField(RecipientType, default=RecipientType.ADMINS)
-    recipient = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+")
+    recipient = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+", on_delete=models.SET_NULL)
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
     message = models.CharField(max_length=140, editable=False, default="")
     identifier = InternalIdentifierField(unique=False)
@@ -51,8 +52,8 @@ class Notification(models.Model):
     _data = JSONField(blank=True, null=True, editable=False, db_column="data")
 
     marked_read = models.BooleanField(db_index=True, editable=False, default=False)
-    marked_read_by = models.ForeignKey(settings.AUTH_USER_MODEL,
-                                       blank=True, null=True, editable=False, related_name="+")
+    marked_read_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, editable=False, related_name="+", on_delete=models.SET_NULL)
     marked_read_on = models.DateTimeField(null=True, blank=True)
 
     objects = NotificationManager()

--- a/shoop/simple_cms/migrations/0002_fk_on_delete.py
+++ b/shoop/simple_cms/migrations/0002_fk_on_delete.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop_simple_cms', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='page',
+            name='created_by',
+            field=models.ForeignKey(related_name='+', to=settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL),
+        ),
+        migrations.AlterField(
+            model_name='page',
+            name='modified_by',
+            field=models.ForeignKey(related_name='+', to=settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=django.db.models.deletion.SET_NULL),
+        ),
+    ]

--- a/shoop/simple_cms/models.py
+++ b/shoop/simple_cms/models.py
@@ -42,8 +42,10 @@ class Page(TranslatableModel):
     available_from = models.DateTimeField(null=True, blank=True)
     available_to = models.DateTimeField(null=True, blank=True)
 
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+")
-    modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+")
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+", on_delete=models.SET_NULL)
+    modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True, related_name="+", on_delete=models.SET_NULL)
 
     created_on = models.DateTimeField(auto_now_add=True, editable=False)
     modified_on = models.DateTimeField(auto_now=True, editable=False)

--- a/shoop/simple_pricing/models.py
+++ b/shoop/simple_pricing/models.py
@@ -15,9 +15,9 @@ from shoop.utils.properties import MoneyPropped, PriceProperty
 
 
 class SimpleProductPrice(MoneyPropped, models.Model):
-    product = models.ForeignKey("shoop.Product", related_name="+")
-    shop = models.ForeignKey("shoop.Shop", db_index=True)
-    group = models.ForeignKey("shoop.ContactGroup", db_index=True)
+    product = models.ForeignKey("shoop.Product", related_name="+", on_delete=models.CASCADE)
+    shop = models.ForeignKey("shoop.Shop", db_index=True, on_delete=models.CASCADE)
+    group = models.ForeignKey("shoop.ContactGroup", db_index=True, on_delete=models.CASCADE)
     price = PriceProperty("price_value", "shop.currency", "shop.prices_include_tax")
     price_value = MoneyValueField()
 

--- a/shoop/simple_supplier/migrations/0002_fk_on_delete.py
+++ b/shoop/simple_supplier/migrations/0002_fk_on_delete.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('simple_supplier', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='stockadjustment',
+            name='created_by',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=django.db.models.deletion.PROTECT),
+        ),
+    ]

--- a/shoop/simple_supplier/models.py
+++ b/shoop/simple_supplier/models.py
@@ -12,8 +12,8 @@ from shoop.core.fields import QuantityField
 
 
 class StockAdjustment(models.Model):
-    product = models.ForeignKey("shoop.Product", related_name="+")
-    supplier = models.ForeignKey("shoop.Supplier")
+    product = models.ForeignKey("shoop.Product", related_name="+", on_delete=models.CASCADE)
+    supplier = models.ForeignKey("shoop.Supplier", on_delete=models.CASCADE)
     created_on = models.DateTimeField(auto_now_add=True, editable=False, db_index=True)
     created_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.PROTECT)
     delta = QuantityField(default=0)
@@ -23,8 +23,8 @@ class StockAdjustment(models.Model):
 
 
 class StockCount(models.Model):
-    product = models.ForeignKey("shoop.Product", related_name="+", editable=False)
-    supplier = models.ForeignKey("shoop.Supplier", editable=False)
+    product = models.ForeignKey("shoop.Product", related_name="+", editable=False, on_delete=models.CASCADE)
+    supplier = models.ForeignKey("shoop.Supplier", editable=False, on_delete=models.CASCADE)
     logical_count = QuantityField(default=0, editable=False)
     physical_count = QuantityField(default=0, editable=False)
 

--- a/shoop/simple_supplier/models.py
+++ b/shoop/simple_supplier/models.py
@@ -15,7 +15,7 @@ class StockAdjustment(models.Model):
     product = models.ForeignKey("shoop.Product", related_name="+")
     supplier = models.ForeignKey("shoop.Supplier")
     created_on = models.DateTimeField(auto_now_add=True, editable=False, db_index=True)
-    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True)
+    created_by = models.ForeignKey(settings.AUTH_USER_MODEL, blank=True, null=True, on_delete=models.PROTECT)
     delta = QuantityField(default=0)
 
     class Meta:

--- a/shoop/utils/analog.py
+++ b/shoop/utils/analog.py
@@ -59,7 +59,7 @@ def define_log_model(model_class):
         abstract = False
 
     class_dict = {
-        "target": models.ForeignKey(model_class, related_name="log_entries"),
+        "target": models.ForeignKey(model_class, related_name="log_entries", on_delete=models.CASCADE),
         "__module__": model_class.__module__,
         "Meta": Meta,
         "logged_model": model_class,

--- a/shoop_tests/core/test_foreignkeys.py
+++ b/shoop_tests/core/test_foreignkeys.py
@@ -1,0 +1,140 @@
+from django.db.models import ProtectedError
+import pytest
+from shoop.core.models import Manufacturer, Product, SalesUnit, TaxClass, ShippingMethod, PaymentMethod, \
+    CustomerTaxGroup, PersonContact, ShopProduct, Shop, Tax
+from shoop.default_tax.models import TaxRule
+from shoop.testing.factories import create_product, get_default_shop, DEFAULT_NAME, get_default_category, \
+    create_order_with_product, get_test_tax, get_default_supplier
+
+
+def get_product():
+    shop = get_default_shop()
+    product = create_product("tmp", shop, default_price=200)
+    return product
+
+
+@pytest.mark.django_db
+def test_manufacturer_removal():
+    product = get_product()
+    manufacturer = Manufacturer.objects.create(name=DEFAULT_NAME)
+    product.manufacturer = manufacturer
+    product.save()
+    with pytest.raises(ProtectedError):
+        manufacturer.delete()
+    assert Product.objects.filter(pk=product.pk).exists()
+
+
+@pytest.mark.django_db
+def test_sales_unit_removal():
+    product = get_product()
+    sales_unit = SalesUnit.objects.create(name="test", short_name="te")
+    product.sales_unit = sales_unit
+    product.save()
+    with pytest.raises(ProtectedError):
+        sales_unit.delete()
+    assert Product.objects.filter(pk=product.pk).exists()
+
+
+@pytest.mark.django_db
+def test_tax_class_removal():
+    product = get_product()
+    tax_class = TaxClass.objects.create(name="test")
+    product.tax_class = tax_class
+    product.save()
+    with pytest.raises(ProtectedError):
+        tax_class.delete()
+    assert Product.objects.filter(pk=product.pk).exists()
+
+
+@pytest.mark.django_db
+def test_category_removal():
+    product = get_product()
+    category = get_default_category()
+    product.category = category
+    product.save()
+    with pytest.raises(ProtectedError):
+        category.delete()
+    assert Product.objects.filter(pk=product.pk).exists()
+
+
+# -------------- CONTACT ----------------
+@pytest.mark.django_db
+def test_shipping_method_removal():
+    tax_class = TaxClass.objects.create(name="test")
+    sm = ShippingMethod.objects.create(name="sm", tax_class=tax_class)
+    contact = PersonContact.objects.create(name="test", default_shipping_method=sm)
+    sm.delete()
+    assert PersonContact.objects.filter(pk=contact.pk).exists()
+
+
+@pytest.mark.django_db
+def test_payment_method_removal():
+    tax_class = TaxClass.objects.create(name="test")
+    pm = PaymentMethod.objects.create(name="sm", tax_class=tax_class)
+    contact = PersonContact.objects.create(name="test", default_payment_method=pm)
+    pm.delete()
+    assert PersonContact.objects.filter(pk=contact.pk).exists()
+
+
+@pytest.mark.django_db
+def test_customer_tax_group_removal():
+    ctg = CustomerTaxGroup.objects.create(name="test")
+    contact = PersonContact.objects.create(name="test", tax_group=ctg)
+    with pytest.raises(ProtectedError):
+        ctg.delete()
+    assert PersonContact.objects.filter(pk=contact.pk).exists()
+
+
+# ------------ METHODS ----------------
+@pytest.mark.django_db
+def test_method_taxclass_removal():
+    tax_class = TaxClass.objects.create(name="test")
+    pm = PaymentMethod.objects.create(name="test", tax_class=tax_class)
+    with pytest.raises(ProtectedError):
+        tax_class.delete()
+    assert PaymentMethod.objects.filter(pk=pm.id).exists()
+
+
+# ------------SHOP PRODUCT-------------
+@pytest.mark.django_db
+def test_shopproduct_primary_category_removal():
+    product = get_product()
+    category = get_default_category()
+    sp = product.get_shop_instance(get_default_shop())
+    sp.primary_category = category
+    sp.save()
+    with pytest.raises(ProtectedError):
+        category.delete()
+    assert ShopProduct.objects.filter(pk=sp.pk).exists()
+
+
+# ------------SHOP -------------
+@pytest.mark.django_db
+def test_shop_owner_removal():
+    contact = PersonContact.objects.create(name="test")
+    shop = Shop.objects.create(name="test", public_name="test", owner=contact)
+    contact.delete()
+    assert Shop.objects.filter(pk=shop.pk).exists()
+
+
+# -------- TAX ---------------
+@pytest.mark.django_db
+def test_taxrule_tax_removal():
+    tax = Tax.objects.create(rate=1)
+    taxrule = TaxRule.objects.create(tax=tax)
+    with pytest.raises(ProtectedError):
+        tax.delete()
+    assert TaxRule.objects.filter(pk=taxrule.pk).exists()
+
+@pytest.mark.django_db
+def test_orderlinetax_tax_removal():
+    #todo fix
+    product = get_product()
+    tax_rate = 1
+    order = create_order_with_product(
+        product=product, supplier=get_default_supplier(),
+        quantity=1, taxless_base_unit_price=10,
+        tax_rate=tax_rate, shop=get_default_shop())
+    tax = get_test_tax(tax_rate)
+    with pytest.raises(ProtectedError):
+        tax.delete()

--- a/shoop_tests/core/test_shops.py
+++ b/shoop_tests/core/test_shops.py
@@ -1,0 +1,23 @@
+import pytest
+from filer.models import Folder, Image
+from shoop.core.models import Shop, ShopStatus
+from shoop.testing.factories import DEFAULT_NAME, DEFAULT_IDENTIFIER
+
+
+@pytest.mark.django_db
+def test_shop_wont_be_deleted():
+    shop = Shop.objects.create(
+        name=DEFAULT_NAME,
+        identifier=DEFAULT_IDENTIFIER,
+        status=ShopStatus.ENABLED,
+        public_name=DEFAULT_NAME
+    )
+
+    folder = Folder.objects.create(name="Root")
+    img = Image.objects.create(name="imagefile", folder=folder)
+
+    shop.logo = img
+    shop.save()
+    img.delete()
+
+    Shop.objects.get(pk=1)


### PR DESCRIPTION
`Shop` and `Category` were both missing `on_delete=models.SET_NULL`. This caused them to be deleted also when attached image was deleted in media browser.

Fixes #205