### PR TITLE
Admin: Template refactoring

### DIFF
--- a/shoop/addons/templates/shoop/admin/addons/upload_confirm.jinja
+++ b/shoop/addons/templates/shoop/admin/addons/upload_confirm.jinja
@@ -1,29 +1,25 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% block title %}{% trans %}Upload Addon - Install{% endtrans %}{% endblock %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="install_form"></div>
-            <div class="col-md-9">
-                <form method="post" enctype="multipart/form-data" id="install_form">
-                    {% csrf_token %}
-                    {% call content_block(_("Package Information"), "fa-info-circle") %}
-                        {% if pkg_info %}
-                            <pre><code>{{ pkg_info }}</code></pre>
-                        {% else %}
-                            <i>{% trans %}No package information could be extracted.{% endtrans %}</i>
-                        {% endif %}
-                    {% endcall %}
-                    {% call content_block(_("File List"), "fa-files-o") %}
-                        <table class="table table-striped">
-                            {% for filename in filenames %}
-                                <tr><td>{{ filename }}</td></tr>
-                            {% endfor %}
-                        </table>
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="install_form") %}
+        <form method="post" enctype="multipart/form-data" id="install_form">
+            {% csrf_token %}
+            {% call content_block(_("Package Information"), "fa-info-circle") %}
+                {% if pkg_info %}
+                    <pre><code>{{ pkg_info }}</code></pre>
+                {% else %}
+                    <i>{% trans %}No package information could be extracted.{% endtrans %}</i>
+                {% endif %}
+            {% endcall %}
+            {% call content_block(_("File List"), "fa-files-o") %}
+                <table class="table table-striped">
+                    {% for filename in filenames %}
+                        <tr><td>{{ filename }}</td></tr>
+                    {% endfor %}
+                </table>
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/categories/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/categories/edit.jinja
@@ -1,17 +1,13 @@
 {% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_with_sidebar %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="category_form"></div>
-            <div class="col-md-9 page-content">
-                <form method="post" id="category_form">
-                    {% csrf_token %}
-                    {% for form_def in form.form_defs.values() %}
-                        {% include form_def.template_name with context %}
-                    {% endfor %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="category_form") %}
+        <form method="post" id="category_form">
+            {% csrf_token %}
+            {% for form_def in form.form_defs.values() %}
+                {% include form_def.template_name with context %}
+            {% endfor %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
@@ -1,32 +1,28 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="contact_group_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="contact_group_form">
-                    {% csrf_token %}
-                    {% call content_block(_("General information"), "fa-info-circle") %}
-                        {{ language_dependent_content_tabs(form) }}
-                        {{ render_monolingual_fields(form) }}
-                    {% endcall %}
-                    {% if contact_group.pk %}
-                        {% call content_block(_("Members"), "fa-users") %}
-                            {# TODO: This is very bare-bones; should probably have UI to add/remove members etc... #}
-                            <ul>
-                            {% for member in contact_group.members.all() %}
-                                {% set u=shoop_admin.model_url(member, default="") %}
-                                <li>{% if u %}<a href="{{ u }}">{% endif %}{{ member }}{% if u %}</a>{% endif %}</li>
-                            {% else %}
-                                <li><i>{% trans %}No members.{% endtrans %}</i></li>
-                            {% endfor %}
-                            </ul>
-                        {% endcall %}
-                    {% endif %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="contact_group_form") %}
+        <form method="post" id="contact_group_form">
+            {% csrf_token %}
+            {% call content_block(_("General information"), "fa-info-circle") %}
+                {{ language_dependent_content_tabs(form) }}
+                {{ render_monolingual_fields(form) }}
+            {% endcall %}
+            {% if contact_group.pk %}
+                {% call content_block(_("Members"), "fa-users") %}
+                    {# TODO: This is very bare-bones; should probably have UI to add/remove members etc... #}
+                    <ul>
+                    {% for member in contact_group.members.all() %}
+                        {% set u=shoop_admin.model_url(member, default="") %}
+                        <li>{% if u %}<a href="{{ u }}">{% endif %}{{ member }}{% if u %}</a>{% endif %}</li>
+                    {% else %}
+                        <li><i>{% trans %}No members.{% endtrans %}</i></li>
+                    {% endfor %}
+                    </ul>
+                {% endcall %}
+            {% endif %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/contacts/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/contacts/detail.jinja
@@ -1,52 +1,47 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+{% from "shoop/admin/macros/general.jinja" import content_block, info_row, content_with_sidebar %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="contact_details"></div>
-            <div class="col-md-9">
-                <div id="contact_details">
-                    {% call content_block(_("Basic Information"), "fa-info-circle") %}
-                        <dl class="dl-horizontal">
-                            {{ info_row(_("Full Name"), contact.full_name) }}
-                            {{ info_row(_("Phone"), contact.phone, "tel:" ~ contact.phone) }}
-                            {{ info_row(_("Email"), contact.email, "mailto:" ~ contact.email) }}
-                            {{ info_row(_("Groups"), contact.groups.all()|sort|join(", ")|default(_("No groups"), True)) }}
-                            {{ info_row(_("Bound User"), contact.user, shoop_admin.model_url(contact.user) if contact.user else None) }}
-                            </tbody>
-                        </dl>
-                    {% endcall %}
+    {% call content_with_sidebar(content_id="contact_details") %}
+        <div id="contact_details">
+            {% call content_block(_("Basic Information"), "fa-info-circle") %}
+                <dl class="dl-horizontal">
+                    {{ info_row(_("Full Name"), contact.full_name) }}
+                    {{ info_row(_("Phone"), contact.phone, "tel:" ~ contact.phone) }}
+                    {{ info_row(_("Email"), contact.email, "mailto:" ~ contact.email) }}
+                    {{ info_row(_("Groups"), contact.groups.all()|sort|join(", ")|default(_("No groups"), True)) }}
+                    {{ info_row(_("Bound User"), contact.user, shoop_admin.model_url(contact.user) if contact.user else None) }}
+                    </tbody>
+                </dl>
+            {% endcall %}
 
-                    {% if contact.default_shipping_address_id or contact.default_billing_address_id %}
-                        {% call content_block(_("Addresses"), "fa-map-marker") %}
-                            <div class="row contact-addresses">
-                                <div class="col-md-6 shipping-address">
-                                    <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                                    {% for line in contact.default_shipping_address or [] %}
-                                        <p>{{ line }}</p>
-                                    {% else %}
-                                        <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
-                                    {% endfor %}
-                                </div>
-                                <div class="col-md-6 billing-address">
-                                    <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
-                                    {% for line in contact.default_billing_address or [] %}
-                                        <p>{{ line }}</p>
-                                    {% else %}
-                                        <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        {% endcall %}
-                    {% endif %}
+            {% if contact.default_shipping_address_id or contact.default_billing_address_id %}
+                {% call content_block(_("Addresses"), "fa-map-marker") %}
+                    <div class="row contact-addresses">
+                        <div class="col-md-6 shipping-address">
+                            <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
+                            {% for line in contact.default_shipping_address or [] %}
+                                <p>{{ line }}</p>
+                            {% else %}
+                                <i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}
+                            {% endfor %}
+                        </div>
+                        <div class="col-md-6 billing-address">
+                            <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
+                            {% for line in contact.default_billing_address or [] %}
+                                <p>{{ line }}</p>
+                            {% else %}
+                                <i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endcall %}
+            {% endif %}
 
-                    {% call content_block(_("Orders"), "fa-inbox") %}
-                        {% from "shoop/admin/macros/order_view.jinja" import order_view with context %}
-                        {{ order_view(orders) }}
-                    {% endcall %}
-                </div>
-            </div>
+            {% call content_block(_("Orders"), "fa-inbox") %}
+                {% from "shoop/admin/macros/order_view.jinja" import order_view with context %}
+                {{ order_view(orders) }}
+            {% endcall %}
         </div>
-    </div>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/contacts/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/contacts/edit.jinja
@@ -1,19 +1,15 @@
 {% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_with_sidebar %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="contact_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="contact_form">
-                    {% csrf_token %}
-                    {% for form_def in form.form_defs.values() %}
-                        {% if form_def.template_name %}
-                            {% include form_def.template_name with context %}
-                        {% endif %}
-                    {% endfor %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="contact_form") %}
+        <form method="post" id="contact_form">
+            {% csrf_token %}
+            {% for form_def in form.form_defs.values() %}
+                {% if form_def.template_name %}
+                    {% include form_def.template_name with context %}
+                {% endif %}
+            {% endfor %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/macros/general.jinja
+++ b/shoop/admin/templates/shoop/admin/macros/general.jinja
@@ -9,6 +9,17 @@
     </div>
 {% endmacro %}
 
+{% macro content_with_sidebar(content_id="", extra_classes="") %}
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-md-3 section-navigation" data-navigatee="{{ content_id }}"></div>
+            <div class="col-md-9 {{ extra_classes }}">
+                {{ caller() }}
+            </div>
+        </div>
+    </div>
+{% endmacro %}
+
 {% macro content_block(heading, icon, extra_classes="") %}
     <div class="content-block">
         <div class="title">
@@ -23,6 +34,15 @@
             <div class="content">
                 {{ caller() }}
             </div>
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro text_between_fields() %}
+    <div class="row">
+        <div class="col-sm-8 col-sm-push-4 col-lg-6 col-lg-push-3">
+            {{ caller() }}
+            <br>
         </div>
     </div>
 {% endmacro %}

--- a/shoop/admin/templates/shoop/admin/methods/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/methods/edit.jinja
@@ -1,27 +1,22 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="method_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="method_form">
-                    {% csrf_token %}
-                    {% call content_block(_("General information"), "fa-info-circle") %}
-                        {{ bs3.field(form.module_identifier) }}
-                        {{ language_dependent_content_tabs(form) }}
-                        <div class="form-divider"></div>
-                        {{ bs3.field(form.status) }}
-                        {{ bs3.field(form.tax_class) }}
-                        <div class="form-divider"></div>
-                        {% for name in form.module_option_field_names %}
-                            {{ bs3.field(form[name]) }}
-                        {% endfor %}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="method_form") %}
+        <form method="post" id="method_form">
+            {% csrf_token %}
+            {% call content_block(_("General information"), "fa-info-circle") %}
+                {{ bs3.field(form.module_identifier) }}
+                {{ language_dependent_content_tabs(form) }}
+                <div class="form-divider"></div>
+                {{ bs3.field(form.status) }}
+                {{ bs3.field(form.tax_class) }}
+                <div class="form-divider"></div>
+                {% for name in form.module_option_field_names %}
+                    {{ bs3.field(form[name]) }}
+                {% endfor %}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/orders/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/detail.jinja
@@ -1,140 +1,136 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+{% from "shoop/admin/macros/general.jinja" import content_block, info_row, content_with_sidebar %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="order_details"></div>
-            <div class="col-md-9">
-                <div id="order_details">
-                    {% call content_block(_("Details & Status"), "fa-info-circle") %}
-                        <dl class="dl-horizontal">
-                            {{ info_row(_("Order Number"), order.identifier) }}
-                            {{ info_row(_("Order Date"), order.order_date|datetime) }}
-                            {{ info_row(_("Reference"), order.reference_number) }}
-                            {{ info_row(_("Label"), order.label) }}
-                            {{ info_row(_("Customer"), order.customer, "#") }}
-                            {{ info_row(_("Ordered by"), order.orderer, "#") }}
-                            {{ info_row(_("Creator"), order.creator, "#") }}
-                            {{ info_row(_("Phone"), order.phone, "tel:" ~ order.phone) }}
-                            {{ info_row(_("Email"), order.email, "mailto:" ~ order.email) }}
-                            {{ info_row(_("Tax number"), order.tax_number) }}
-                            {{ info_row(_("Total Price (taxless)"), order.taxless_total_price|money) }}
-                            {{ info_row(_("Total Price"), order.taxful_total_price|money) }}
-                        </dl>
-                        <hr>
-                        <dl class="dl-horizontal">
-                            {{ info_row(_("Order Status"), order.get_status_display()) }}
-                            {{ info_row(_("Payment Status"), order.get_payment_status_display()) }}
-                            {{ info_row(_("Shipping Status"), order.get_shipping_status_display()) }}
-                        </dl>
-                    {% endcall %}
+    {% call content_with_sidebar(content_id="order_details") %}
+        <div id="order_details">
+            {% call content_block(_("Details & Status"), "fa-info-circle") %}
+                <dl class="dl-horizontal">
+                    {{ info_row(_("Order Number"), order.identifier) }}
+                    {{ info_row(_("Order Date"), order.order_date|datetime) }}
+                    {{ info_row(_("Reference"), order.reference_number) }}
+                    {{ info_row(_("Label"), order.label) }}
+                    {{ info_row(_("Customer"), order.customer, "#") }}
+                    {{ info_row(_("Ordered by"), order.orderer, "#") }}
+                    {{ info_row(_("Creator"), order.creator, "#") }}
+                    {{ info_row(_("Phone"), order.phone, "tel:" ~ order.phone) }}
+                    {{ info_row(_("Email"), order.email, "mailto:" ~ order.email) }}
+                    {{ info_row(_("Tax number"), order.tax_number) }}
+                    {{ info_row(_("Total Price (taxless)"), order.taxless_total_price|money) }}
+                    {{ info_row(_("Total Price"), order.taxful_total_price|money) }}
+                </dl>
+                <hr>
+                <dl class="dl-horizontal">
+                    {{ info_row(_("Order Status"), order.get_status_display()) }}
+                    {{ info_row(_("Payment Status"), order.get_payment_status_display()) }}
+                    {{ info_row(_("Shipping Status"), order.get_shipping_status_display()) }}
+                </dl>
+            {% endcall %}
 
-                    {% if order.shipping_address_id or order.billing_address_id %}
-                        {% call content_block(_("Addresses"), "fa-map-marker") %}
-                            <div class="row contact-addresses">
-                                <div class="col-md-6 shipping-address">
-                                    <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
-                                    {% for line in order.shipping_address %}
-                                        <p>{{ line }}</p>
-                                    {% else %}
-                                        <p><i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}</p>
-                                    {% endfor %}
-                                </div>
-                                <div class="col-md-6 billing-address">
-                                    <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
-                                    {% for line in order.billing_address %}
-                                        <p>{{ line }}</p>
-                                    {% else %}
-                                        <p><i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}</p>
-                                    {% endfor %}
-                                </div>
-                            </div>
-                        {% endcall %}
-                    {% endif %}
-
-                    {% call content_block(_("Order Contents"), "fa-file-text") %}
-                        <div class="hidden-xs">
-                            <table class="table table-striped table-bordered">
-                                <thead>
-                                    <tr>
-                                        <th>{% trans %}SKU{% endtrans %}</th>
-                                        <th>{% trans %}Text{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Taxless Unit Price{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Quantity{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Taxless Discount{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Tax{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Taxless Total{% endtrans %}</th>
-                                        <th class="text-right">{% trans %}Total incl. Tax{% endtrans %}</th>
-                                    </tr>
-                                </thead>
-                                <tfoot>
-                                    <tr>
-                                        <th colspan="6"></th>
-                                        <th class="text-right">{{ order.taxless_total_price|money }}</th>
-                                        <th class="text-right">{{ order.taxful_total_price|money }}</th>
-                                    </tr>
-                                </tfoot>
-                                <tbody>
-                                    {% for line in order.lines.order_by("ordering") %}
-                                    <tr>
-                                        <td>{{ line.sku }}</td>
-                                        <td>{{ line.text }}</td>
-                                        <td class="text-right">{{ line.taxless_base_unit_price|money }}</td>
-                                        <td class="text-right">{{ line.quantity|number }}</td>
-                                        <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
-                                        <td class="text-right">{{ line.tax_rate|percent }}</td>
-                                        <td class="text-right">{{ line.taxless_total_price|money }}</td>
-                                        <td class="text-right">{{ line.taxful_total_price|money }}</td>
-                                    </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
+            {% if order.shipping_address_id or order.billing_address_id %}
+                {% call content_block(_("Addresses"), "fa-map-marker") %}
+                    <div class="row contact-addresses">
+                        <div class="col-md-6 shipping-address">
+                            <h4 class="underline"><i class="fa fa-truck"></i> {% trans %}Shipping address{% endtrans %}</h4>
+                            {% for line in order.shipping_address %}
+                                <p>{{ line }}</p>
+                            {% else %}
+                                <p><i class="fa fa-warning text-warning"></i> {% trans %}No shipping address defined.{% endtrans %}</p>
+                            {% endfor %}
                         </div>
-                        <div class="visible-xs mobile-list-group">
-                            <ul class="list-group">
-                                {% for line in order.lines.order_by("ordering") %}
-                                    <li class="list-group-item">
-                                        <div class="row">
-                                            <div class="col-xs-6">
-                                                <strong>{{ line.sku }}</strong>
-                                            </div>
-                                            <div class="col-xs-6 text-right">
-                                                {{ line.text }}
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-xs-6">
-                                                {{ line.quantity|number }} &times; {{ line.taxless_base_unit_price|money }} {% if line.taxless_discount_amount %}<span class="text-muted">{% trans %}Discount{% endtrans %}{{ line.taxless_discount_amount|money }}</span>{% endif %}
-                                            </div>
-                                            <div class="col-xs-6 text-right">
-                                                <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_total_price|money }}</strong>
-                                            </div>
-                                            <div class="col-xs-12 text-right text-muted">
-                                                {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_total_price|money }} {% trans %}Taxless{% endtrans %})
-                                            </div>
-                                        </div>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                            <div class="clearfix">
-                                <div class="col-xs-6"><strong>{% trans %}Taxless Total{% endtrans %}</strong></div>
-                                <div class="col-xs-6 text-right"><strong>{{ order.taxless_total_price|money }}</strong></div>
-                            </div>
-                            <div class="clearfix">
-                                <div class="col-xs-6"><strong>{% trans %}Total incl. Tax{% endtrans %}</strong></div>
-                                <div class="col-xs-6 text-right"><strong>{{ order.taxful_total_price|money }}</strong></div>
-                            </div>
+                        <div class="col-md-6 billing-address">
+                            <h4 class="underline"><i class="fa fa-file-text"></i> {% trans %}Billing address{% endtrans %}</h4>
+                            {% for line in order.billing_address %}
+                                <p>{{ line }}</p>
+                            {% else %}
+                                <p><i class="fa fa-warning text-warning"></i> {% trans %}No billing address defined.{% endtrans %}</p>
+                            {% endfor %}
                         </div>
-                    {% endcall %}
+                    </div>
+                {% endcall %}
+            {% endif %}
 
-                    {% set payments=order.payments.all() %}
-                    {% if payments %}
-                        {% call content_block(_("Payments"), "fa-dollar") %}
-                            {% include "shoop/admin/orders/_detail_payments.jinja" with context %}
-                        {% endcall %}
-                    {% endif %}
+            {% call content_block(_("Order Contents"), "fa-file-text") %}
+                <div class="hidden-xs">
+                    <table class="table table-striped table-bordered">
+                        <thead>
+                            <tr>
+                                <th>{% trans %}SKU{% endtrans %}</th>
+                                <th>{% trans %}Text{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Taxless Unit Price{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Quantity{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Taxless Discount{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Tax{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Taxless Total{% endtrans %}</th>
+                                <th class="text-right">{% trans %}Total incl. Tax{% endtrans %}</th>
+                            </tr>
+                        </thead>
+                        <tfoot>
+                            <tr>
+                                <th colspan="6"></th>
+                                <th class="text-right">{{ order.taxless_total_price|money }}</th>
+                                <th class="text-right">{{ order.taxful_total_price|money }}</th>
+                            </tr>
+                        </tfoot>
+                        <tbody>
+                            {% for line in order.lines.order_by("ordering") %}
+                            <tr>
+                                <td>{{ line.sku }}</td>
+                                <td>{{ line.text }}</td>
+                                <td class="text-right">{{ line.taxless_base_unit_price|money }}</td>
+                                <td class="text-right">{{ line.quantity|number }}</td>
+                                <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
+                                <td class="text-right">{{ line.tax_rate|percent }}</td>
+                                <td class="text-right">{{ line.taxless_total_price|money }}</td>
+                                <td class="text-right">{{ line.taxful_total_price|money }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
                 </div>
-            </div>
+                <div class="visible-xs mobile-list-group">
+                    <ul class="list-group">
+                        {% for line in order.lines.order_by("ordering") %}
+                            <li class="list-group-item">
+                                <div class="row">
+                                    <div class="col-xs-6">
+                                        <strong>{{ line.sku }}</strong>
+                                    </div>
+                                    <div class="col-xs-6 text-right">
+                                        {{ line.text }}
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-xs-6">
+                                        {{ line.quantity|number }} &times; {{ line.taxless_base_unit_price|money }} {% if line.taxless_discount_amount %}<span class="text-muted">{% trans %}Discount{% endtrans %}{{ line.taxless_discount_amount|money }}</span>{% endif %}
+                                    </div>
+                                    <div class="col-xs-6 text-right">
+                                        <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_total_price|money }}</strong>
+                                    </div>
+                                    <div class="col-xs-12 text-right text-muted">
+                                        {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_total_price|money }} {% trans %}Taxless{% endtrans %})
+                                    </div>
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                    <div class="clearfix">
+                        <div class="col-xs-6"><strong>{% trans %}Taxless Total{% endtrans %}</strong></div>
+                        <div class="col-xs-6 text-right"><strong>{{ order.taxless_total_price|money }}</strong></div>
+                    </div>
+                    <div class="clearfix">
+                        <div class="col-xs-6"><strong>{% trans %}Total incl. Tax{% endtrans %}</strong></div>
+                        <div class="col-xs-6 text-right"><strong>{{ order.taxful_total_price|money }}</strong></div>
+                    </div>
+                </div>
+            {% endcall %}
+
+            {% set payments=order.payments.all() %}
+            {% if payments %}
+                {% call content_block(_("Payments"), "fa-dollar") %}
+                    {% include "shoop/admin/orders/_detail_payments.jinja" with context %}
+                {% endcall %}
+            {% endif %}
         </div>
-    </div>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/product_types/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/product_types/edit.jinja
@@ -1,23 +1,19 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="product_type_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="product_type_form">
-                    {% csrf_token %}
-                    {% call content_block(_("General information"), "fa-info-circle") %}
-                        {% call(form, language, map) language_dependent_content_tabs(form) %}
-                            {{ bs3.field(form[map.name]) }}
-                        {% endcall %}
-                    {% endcall %}
-                    {% call content_block(_("Attributes"), "fa-tags") %}
-                        {{ bs3.field(form.attributes) }}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="product_type_form") %}
+        <form method="post" id="product_type_form">
+            {% csrf_token %}
+            {% call content_block(_("General information"), "fa-info-circle") %}
+                {% call(form, language, map) language_dependent_content_tabs(form) %}
+                    {{ bs3.field(form[map.name]) }}
+                {% endcall %}
+            {% endcall %}
+            {% call content_block(_("Attributes"), "fa-tags") %}
+                {{ bs3.field(form.attributes) }}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_attribute_form.jinja
@@ -1,6 +1,8 @@
 {% from "shoop/admin/macros/general.jinja" import content_block %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+
 {% set attr_form = form[form_def.name] %}
+
 {% call content_block(_("Attributes"), "fa-tags") %}
     {{ language_dependent_content_tabs(attr_form, tab_id_prefix="attributes") }}
     <div class="form-divider"></div>

--- a/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
@@ -2,6 +2,7 @@
 {% set shop_product_form = form[form_def.name] %}
 {% set shop_name = shop_product_form.instance.shop.name %}
 {% set shop_name_prefix = shop_product_form.instance.shop.name ~ " - " %}
+
 {% call content_block(shop_name_prefix ~ _("Visibility"), "fa-eye") %}
     {{ bs3.field(shop_product_form.visible) }}
     {{ bs3.field(shop_product_form.listed) }}

--- a/shoop/admin/templates/shoop/admin/products/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/products/edit.jinja
@@ -1,28 +1,25 @@
 {% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_with_sidebar %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            {% if orderability_errors %}
-                <div class="clearfix">
-                {# TODO: FIX THIS FOR MOBILE SCREEN SIZES #}
-                    <p class="pull-right" data-toggle="tooltip" data-title="{% for error in orderability_errors %}{{ error }} {% endfor %}" data-placement="bottom">
-                        <i class="fa fa-info-circle text-info"></i> {% trans %}This product is currently not orderable.{% endtrans %}
-                    </p>
-                </div>
-            {% endif %}
-            <div class="col-md-3 section-navigation" data-navigatee="product_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="product_form">
-                    {% csrf_token %}
-                    {% for form_def in form.form_defs.values() %}
-                        {% include form_def.template_name with context %}
-                    {% endfor %}
-                </form>
-            </div>
+    {% if orderability_errors %}
+        <div class="container-fluid">
+            {# TODO: FIX THIS FOR MOBILE SCREEN SIZES #}
+            <p class="pull-right" data-toggle="tooltip" data-title="{% for error in orderability_errors %}{{ error }} {% endfor %}" data-placement="bottom">
+                <i class="fa fa-info-circle text-info"></i> {% trans %}This product is currently not orderable.{% endtrans %}
+            </p>
         </div>
-    </div>
+    {% endif %}
+    {% call content_with_sidebar(content_id="product_form") %}
+        <form method="post" id="product_form">
+            {% csrf_token %}
+            {% for form_def in form.form_defs.values() %}
+                {% include form_def.template_name with context %}
+            {% endfor %}
+        </form>
+    {% endcall %}
 {% endblock %}
+
 {% block extra_js %}
     <script src="{{ static("shoop_admin/js/product.js") }}"></script>
 {% endblock %}
-

--- a/shoop/admin/templates/shoop/admin/products/edit_cross_sell.jinja
+++ b/shoop/admin/templates/shoop/admin/products/edit_cross_sell.jinja
@@ -1,33 +1,29 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="xsell_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="xsell_form">
-                    {% csrf_token %}
-                    {% for mf in form.management_form %}{{ mf|safe }}{% endfor %}
-                    {% call content_block(_("Cross-sells"), ("fa-exchange")) %}
-                        {% for f in form %}
-                            <div class="panel panel-default">
-                                <div class="panel-heading">
-                                    <h2 class="panel-title">{% trans %}Cross-sell{% endtrans %} {{ loop.index }}</h2>
-                                </div>
-                                <div class="panel-body">
-                                    {{ bs3.field(f.product2) }}
-                                    {{ bs3.field(f.weight) }}
-                                    {{ bs3.field(f.type) }}
-                                    {% if f.instance.pk and f.DELETE %}
-                                        {{ bs3.field(f.DELETE) }}
-                                    {% endif %}
-                                    {% for fld in f.hidden_fields() %}{{ fld|safe }}{% endfor %}
-                                </div>
-                            </div>
-                        {% endfor %}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="xsell_form") %}
+        <form method="post" id="xsell_form">
+            {% csrf_token %}
+            {% for mf in form.management_form %}{{ mf|safe }}{% endfor %}
+            {% call content_block(_("Cross-sells"), ("fa-exchange")) %}
+                {% for f in form %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h2 class="panel-title">{% trans %}Cross-sell{% endtrans %} {{ loop.index }}</h2>
+                        </div>
+                        <div class="panel-body">
+                            {{ bs3.field(f.product2) }}
+                            {{ bs3.field(f.weight) }}
+                            {{ bs3.field(f.type) }}
+                            {% if f.instance.pk and f.DELETE %}
+                                {{ bs3.field(f.DELETE) }}
+                            {% endif %}
+                            {% for fld in f.hidden_fields() %}{{ fld|safe }}{% endfor %}
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/products/edit_media.jinja
+++ b/shoop/admin/templates/shoop/admin/products/edit_media.jinja
@@ -1,34 +1,30 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="media_form"></div>
-            <div class="col-md-9 media-edit-content">
-                <form method="post" id="media_form">
-                    {% csrf_token %}
-                    {% for mf in form.management_form %}{{ mf|safe }}{% endfor %}
-                    {% for f in form %}
-                        {% set f_title = ("" ~ f.instance if f.instance.pk else _("File ") ~ loop.index) %}
-                        {% call content_block(f_title) %}
-                            {{ bs3.field(f.file) }}
-                            {{ bs3.field(f.external_url) }}
-                            {{ bs3.field(f.ordering) }}
-                            {{ bs3.field(f.shops) }}
-                            {{ bs3.field(f.kind) }}
-                            {{ bs3.field(f.enabled) }}
-                            {{ bs3.field(f.public) }}
-                            {{ bs3.field(f.purchased) }}
-                            {% if f.instance.pk and f.DELETE %}
-                                {{ bs3.field(f.DELETE) }}
-                            {% endif %}
-                            {% for fld in f.hidden_fields() %}{{ fld|safe }}{% endfor %}
-                            {{ language_dependent_content_tabs(f, ["title", "description"]) }}
-                        {% endcall %}
-                    {% endfor %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="media_form", extra_classes="media-edit-content") %}
+        <form method="post" id="media_form">
+            {% csrf_token %}
+            {% for mf in form.management_form %}{{ mf|safe }}{% endfor %}
+            {% for f in form %}
+                {% set f_title = ("" ~ f.instance if f.instance.pk else _("File ") ~ loop.index) %}
+                {% call content_block(f_title) %}
+                    {{ bs3.field(f.file) }}
+                    {{ bs3.field(f.external_url) }}
+                    {{ bs3.field(f.ordering) }}
+                    {{ bs3.field(f.shops) }}
+                    {{ bs3.field(f.kind) }}
+                    {{ bs3.field(f.enabled) }}
+                    {{ bs3.field(f.public) }}
+                    {{ bs3.field(f.purchased) }}
+                    {% if f.instance.pk and f.DELETE %}
+                        {{ bs3.field(f.DELETE) }}
+                    {% endif %}
+                    {% for fld in f.hidden_fields() %}{{ fld|safe }}{% endfor %}
+                    {{ language_dependent_content_tabs(f, ["title", "description"]) }}
+                {% endcall %}
+            {% endfor %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/sales_units/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/sales_units/edit.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
     {% call single_section_form("sales_unit_form", form) %}
         {{ language_dependent_content_tabs(form, ["name", "short_name"]) }}

--- a/shoop/admin/templates/shoop/admin/shops/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/shops/edit.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/admin/base.jinja" %}
 {% import "shoop/admin/macros/general.jinja" as gm with context %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+
 {% block content %}
     {% call gm.multi_section_single_form("shop_form") %}
         {% call gm.form_section(_("General Information")) %}

--- a/shoop/admin/templates/shoop/admin/suppliers/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/suppliers/edit.jinja
@@ -1,5 +1,6 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
+
 {% block content %}
     {{ single_section_form("supplier_form", form) }}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/taxes/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/taxes/edit.jinja
@@ -1,5 +1,6 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
+
 {% block content %}
     {{ single_section_form("tax_class_form", form) }}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/taxes/edit_customer_tax_group.jinja
+++ b/shoop/admin/templates/shoop/admin/taxes/edit_customer_tax_group.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
     {% call single_section_form("customer_tax_group_form", form) %}
         {{ language_dependent_content_tabs(form, ["name"]) }}

--- a/shoop/admin/templates/shoop/admin/taxes/edit_tax.jinja
+++ b/shoop/admin/templates/shoop/admin/taxes/edit_tax.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
     {% call single_section_form("tax_form", form) %}
         {{ language_dependent_content_tabs(form, ["name"]) }}

--- a/shoop/admin/templates/shoop/admin/taxes/edit_tax_class.jinja
+++ b/shoop/admin/templates/shoop/admin/taxes/edit_tax_class.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import single_section_form with context %}
 {% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+
 {% block content %}
     {% call single_section_form("tax_class_form", form) %}
         {{ language_dependent_content_tabs(form, ["name"]) }}

--- a/shoop/admin/templates/shoop/admin/users/change_password.jinja
+++ b/shoop/admin/templates/shoop/admin/users/change_password.jinja
@@ -1,20 +1,15 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+{% from "shoop/admin/macros/general.jinja" import content_block, info_row, content_with_sidebar %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="change_password_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="change_password_form">
-                    {% csrf_token %}
-                    {% call content_block(_("Change Password"), "fa-key") %}
-                        {{ bs3.field(form.old_password, show_help_block=True) }}
-                        {{ bs3.field(form.password1) }}
-                        {{ bs3.field(form.password2) }}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="change_password_form") %}
+        <form method="post" id="change_password_form">
+            {% csrf_token %}
+            {% call content_block(_("Change Password"), "fa-key") %}
+                {{ bs3.field(form.old_password, show_help_block=True) }}
+                {{ bs3.field(form.password1) }}
+                {{ bs3.field(form.password2) }}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/users/change_permissions.jinja
+++ b/shoop/admin/templates/shoop/admin/users/change_permissions.jinja
@@ -1,19 +1,15 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+{% from "shoop/admin/macros/general.jinja" import content_block, info_row, content_with_sidebar %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="permissions_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="permissions_form">
-                    {% csrf_token %}
-                    {% call content_block(title, "fa-key") %}
-                        {{ bs3.field(form.old_password, show_help_block=True) }}
-                        {{ bs3.field(form.is_staff) }}
-                        {{ bs3.field(form.is_superuser) }}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="permissions_form") %}
+        <form method="post" id="permissions_form">
+            {% csrf_token %}
+            {% call content_block(title, "fa-key") %}
+                {{ bs3.field(form.old_password, show_help_block=True) }}
+                {{ bs3.field(form.is_staff) }}
+                {{ bs3.field(form.is_superuser) }}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/users/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/users/detail.jinja
@@ -1,19 +1,15 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+{% from "shoop/admin/macros/general.jinja" import content_block, info_row, content_with_sidebar %}
+
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="user_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="user_form">
-                    {% csrf_token %}
-                    {% call content_block(_("User Information"), "fa-info-circle") %}
-                        {% for field in form %}
-                            {{ bs3.field(field) }}
-                        {% endfor %}
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="user_form") %}
+        <form method="post" id="user_form">
+            {% csrf_token %}
+            {% call content_block(_("User Information"), "fa-info-circle") %}
+                {% for field in form %}
+                    {{ bs3.field(field) }}
+                {% endfor %}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/admin/templates/shoop/admin/users/reset_password.jinja
+++ b/shoop/admin/templates/shoop/admin/users/reset_password.jinja
@@ -1,14 +1,14 @@
 {% extends "shoop/admin/base.jinja" %}
 {% from "shoop/admin/macros/general.jinja" import content_block, info_row %}
+
 {% block content %}
     <div class="container-fluid">
-        <div class="row">
+        <div class="content-block">
             <form method="post">
                 {% csrf_token %}
-                {% trans email=object.email %}Send a password reset email to {{ email }}?{% endtrans %}
-                <button class="btn btn-block btn-primary" type="submit">
-                    <i class="fa fa-envelope"></i>
-                    {% trans %}Send Reset Email{% endtrans %}
+                <p class="lead">{% trans email=object.email %}Send a password reset email to {{ email }}?{% endtrans %}</p>
+                <button class="btn btn-primary" type="submit">
+                    <i class="fa fa-envelope"></i> {% trans %}Send Reset Email{% endtrans %}
                 </button>
             </form>
         </div>

--- a/shoop/default_tax/templates/shoop/default_tax/admin/edit.jinja
+++ b/shoop/default_tax/templates/shoop/default_tax/admin/edit.jinja
@@ -1,78 +1,60 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar, text_between_fields %}
 
 {% block content %}
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-3 section-navigation" data-navigatee="tax_rule_form"></div>
-        <div class="col-md-9">
-            <form method="post" id="tax_rule_form">
-                {% csrf_token %}
-                {% call content_block(_("Tax rule information"), "fa-info-circle") %}
-                    {{ bs3.field(form.enabled) }}
+    {% call content_with_sidebar(content_id="tax_rule_form") %}
+        <form method="post" id="tax_rule_form">
+            {% csrf_token %}
+            {% call content_block(_("Tax rule information"), "fa-info-circle") %}
+                {{ bs3.field(form.enabled) }}
 
-                    {% call _text_between_fields() %}
-                      <h3>{{ _("Matching criteria") }}</h3>
-                      {{ _matching_criteria_help_text() }}
-                    {% endcall %}
-
-                    {{ bs3.field(form.tax_classes) }}
-                    {{ bs3.field(form.customer_tax_groups) }}
-                    {{ bs3.field(form.country_codes_pattern) }}
-                    {{ bs3.field(form.region_codes_pattern) }}
-                    {{ bs3.field(form.postal_codes_pattern) }}
-                    {{ bs3.field(form.priority) }}
-
-                    {% call _text_between_fields() %}
-                      <h3>{{ _("Applied tax") }}</h3>
-                      {{ _applied_tax_help_text() }}
-                    {% endcall %}
-
-                    {{ bs3.field(form.tax) }}
+                {% call text_between_fields() %}
+                    <h3>{% trans %}Matching criteria{% endtrans %}</h3>
+                    {{ _matching_criteria_help_text() }}
                 {% endcall %}
-            </form>
-        </div>
-    </div>
-</div>
+
+                {{ bs3.field(form.tax_classes) }}
+                {{ bs3.field(form.customer_tax_groups) }}
+                {{ bs3.field(form.country_codes_pattern) }}
+                {{ bs3.field(form.region_codes_pattern) }}
+                {{ bs3.field(form.postal_codes_pattern) }}
+                {{ bs3.field(form.priority) }}
+
+                {% call text_between_fields() %}
+                    <h3>{% trans %}Applied tax{% endtrans %}</h3>
+                    {{ _applied_tax_help_text() }}
+                {% endcall %}
+
+                {{ bs3.field(form.tax) }}
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}
 
-{% macro _text_between_fields() %}
-<div class="row">
-  <div class="col-sm-8 col-sm-push-4 col-lg-6 col-lg-push-3">
-    {{ caller() }}
-    <br>
-  </div>
-</div>
-{% endmacro %}
-
 {% macro _matching_criteria_help_text() %}
-<p>
-  {% trans %}
-    The following fields determine when this rule applies.  All
-    non-empty fields must match for the rule to apply.  Empty fields are
-    not considered, e.g. if "Customer tax groups" is left empty, all
-    customer tax groups will match.
-  {% endtrans %}
-</p>
-<p>
-  {% trans %}
-    Pattern can be a single value or a comma separated list of items,
-    where each item can be a single value or a range, such as
-    "value1-value2".  Special value "*" matches everything.  For
-    example, a pattern "1,2,50-90" will match values "1" and "2", and
-    "50", "90", and everything between.  The range uses alphabetical
-    ordering unless start, end and the string to be matched are all
-    numerical, i.e. "50-90" will match also "6a" and "700X", since they
-    are alphabetically between "50" and "90", but it will not match
-    "700000" since for numerical items natural numeric ordering is used.
-  {% endtrans %}
-</p>
+    <p>
+        {% trans %}
+            The following fields determine when this rule applies.  All
+            non-empty fields must match for the rule to apply.  Empty fields are
+            not considered, e.g. if "Customer tax groups" is left empty, all
+            customer tax groups will match.
+        {% endtrans %}
+    </p>
+    <p>
+        {% trans %}
+            Pattern can be a single value or a comma separated list of items,
+            where each item can be a single value or a range, such as
+            "value1-value2".  Special value "*" matches everything.  For
+            example, a pattern "1,2,50-90" will match values "1" and "2", and
+            "50", "90", and everything between.  The range uses alphabetical
+            ordering unless start, end and the string to be matched are all
+            numerical, i.e. "50-90" will match also "6a" and "700X", since they
+            are alphabetically between "50" and "90", but it will not match
+            "700000" since for numerical items natural numeric ordering is used.
+        {% endtrans %}
+    </p>
 {% endmacro %}
 
 {% macro _applied_tax_help_text() %}
-<p>
-  {% trans %}
-    When this rule applies, apply the following tax.
-  {% endtrans %}
-</p>
+    <p>{% trans %}When this rule applies, apply the following tax.{% endtrans %}</p>
 {% endmacro %}

--- a/shoop/notify/templates/notify/admin/edit_script.jinja
+++ b/shoop/notify/templates/notify/admin/edit_script.jinja
@@ -1,34 +1,29 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 {% block title %}
-{% if script.pk %}
-    {% trans %}Edit Script Information{% endtrans %}
-{% else %}
-    {% trans %}Create a new script{% endtrans %}
-{% endif %}
+    {% if script.pk %}
+        {% trans %}Edit Script Information{% endtrans %}
+    {% else %}
+        {% trans %}Create a new script{% endtrans %}
+    {% endif %}
 {% endblock %}
 
 {% block content %}
-    <div class="container-fluid">
-        <div class="row">
-            <div class="col-md-3 section-navigation" data-navigatee="script_form"></div>
-            <div class="col-md-9">
-                <form method="post" id="script_form">
-                {% csrf_token %}
-                    {% call content_block(_("Script Details"), "fa-info-circle") %}
-                        {{ bs3.field(form.event_identifier) }}
-                        {{ bs3.field(form.name) }}
-                        {{ bs3.field(form.enabled) }}
-                        <div class="row">
-                            <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-4">
-                                <button class="btn btn-success btn-block" type="submit">
-                                    <i class="fa fa-check"></i> {% trans %}OK{% endtrans %}
-                                </button>
-                            </div>
-                        </div>
-                    {% endcall %}
-                </form>
-            </div>
-        </div>
-    </div>
+    {% call content_with_sidebar(content_id="script_form") %}
+        <form method="post" id="script_form">
+            {% csrf_token %}
+            {% call content_block(_("Script Details"), "fa-info-circle") %}
+                {{ bs3.field(form.event_identifier) }}
+                {{ bs3.field(form.name) }}
+                {{ bs3.field(form.enabled) }}
+                <div class="row">
+                    <div class="col-lg-6 col-lg-offset-3 col-sm-8 col-sm-offset-4">
+                        <button class="btn btn-success btn-block" type="submit">
+                            <i class="fa fa-check"></i> {% trans %}OK{% endtrans %}
+                        </button>
+                    </div>
+                </div>
+            {% endcall %}
+        </form>
+    {% endcall %}
 {% endblock %}

--- a/shoop/simple_cms/templates/shoop/simple_cms/admin/edit.jinja
+++ b/shoop/simple_cms/templates/shoop/simple_cms/admin/edit.jinja
@@ -1,41 +1,19 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
 
 {% block title %}{{ page.title or _("New Page") }}{% endblock %}
 
-{% block extra_js %}
-<script type="text/javascript" src="{{ static("shoop_admin/js/remarkable.js") }}"></script>
-{% endblock %}
-
 {% block content %}
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-3 section-navigation" data-navigatee="page_form"></div>
-        <div class="col-md-9">
-            <form method="post" id="page_form">
+    {% call content_with_sidebar(content_id="page_form") %}
+        <form method="post" id="page_form">
             {% csrf_token %}
             {% call content_block(_("General Information"), "fa-info-circle") %}
-                <div class="row language-tabs">
-                    <div class="col-md-6 col-md-push-3">
-                        <ul class="nav nav-tabs">
-                            {% for language in form.languages %}
-                            <li role="presentation" {% if loop.first %}class="active"{% endif %}>
-                                <a href="#language-{{ language }}" role="tab" data-toggle="tab" id="tab-{{ language }}">{{ form.language_names[language] }}</a>
-                            </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                <div class="tab-content">
-                    {% for language in form.languages %}
-                        <div class="tab-pane {% if loop.first %}active{% endif %}" id="language-{{ language }}">
-                            {% set map = form.trans_name_map[language] %}
-                            {{ bs3.field(form[map.title]) }}
-                            {{ bs3.field(form[map.url]) }}
-                            {{ bs3.field(form[map.content], widget_class="remarkable-field") }}
-                        </div>
-                    {% endfor %}
-                </div>
+                {% call(form, language, map) language_dependent_content_tabs(form, tab_id_prefix="additional-language") %}
+                    {{ bs3.field(form[map.title]) }}
+                    {{ bs3.field(form[map.url]) }}
+                    {{ bs3.field(form[map.content], widget_class="remarkable-field") }}
+                {% endcall %}
             {% endcall %}
 
             {% call content_block(_("Availability"), "fa-clock-o") %}
@@ -47,9 +25,10 @@
             {% call content_block(_("Extras"), "fa-plus-circle") %}
                 {{ bs3.field(form.identifier) }}
             {% endcall %}
-            </form>
-        </div>
-    </div>
-</div>
+        </form>
+    {% endcall %}
 {% endblock %}
 
+{% block extra_js %}
+<script type="text/javascript" src="{{ static("shoop_admin/js/remarkable.js") }}"></script>
+{% endblock %}

--- a/shoop/xtheme/templates/shoop/xtheme/admin/config_detail.jinja
+++ b/shoop/xtheme/templates/shoop/xtheme/admin/config_detail.jinja
@@ -1,27 +1,23 @@
 {% extends "shoop/admin/base.jinja" %}
-{% from "shoop/admin/macros/general.jinja" import content_block %}
-{% block title %}{% trans name=theme.name %}Theme Configuration: {{ name }}{% endtrans %}{% endblock %}
-{% block content %}
-<div class="container-fluid">
-    <div class="row">
-        <div class="col-md-3 section-navigation" data-navigatee="theme_settings_form"></div>
-        <div class="col-md-9">
-            <form method="post" id="theme_settings_form">
-                {% csrf_token %}
-                {% call content_block(_("Theme Configuration"), "fa-info-circle") %}
-                    {% if form.fields %}
-                        {% for field in form %}
-                            {{ bs3.field(field) }}
-                        {% endfor %}
-                    {% else %}
-                        <div class="alert alert-info">
-                            {% trans %}There's nothing to configure in this theme.{% endtrans %}
-                        </div>
-                    {% endif %}
-                {% endcall %}
-            </form>
-        </div>
-    </div>
-</div>
-{% endblock %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
 
+{% block title %}{% trans name=theme.name %}Theme Configuration: {{ name }}{% endtrans %}{% endblock %}
+
+{% block content %}
+    {% call content_with_sidebar(content_id="theme_settings_form") %}
+        <form method="post" id="theme_settings_form">
+            {% csrf_token %}
+            {% call content_block(_("Theme Configuration"), "fa-cog") %}
+                {% if form.fields %}
+                    {% for field in form %}
+                        {{ bs3.field(field) }}
+                    {% endfor %}
+                {% else %}
+                    <div class="alert alert-info">
+                        {% trans %}There's nothing to configure in this theme.{% endtrans %}
+                    </div>
+                {% endif %}
+            {% endcall %}
+        </form>
+    {% endcall %}
+{% endblock %}


### PR DESCRIPTION
Use new macro for wrapping the admin content. This helps creating new templates when the structure
is automated.

Also unify the code styles in templates and use correct indentation.

Refs SHOOP-1660