### PR TITLE
Classic Gray: Fix logo text line height

### DIFF
--- a/shoop/themes/classic_gray/static_src/less/classic-gray/navigation.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/navigation.less
@@ -146,7 +146,7 @@
                 }
                 &.text {
                     transition: color 0.1s;
-                    line-height: 50px;
+                    line-height: 60px;
                     color: @text-color;
                 }
                 &:hover, &:focus {


### PR DESCRIPTION
Since logo padding was changed the logo text line height needs to be updated too.

Refs SHOOP-1630