### PR TITLE
Admin: Transfer sku properly to product

### DIFF
--- a/shoop/admin/modules/products/views/edit.py
+++ b/shoop/admin/modules/products/views/edit.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib import messages
 from django.db.transaction import atomic
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, get_language
 
 from shoop.admin.form_part import FormPart, FormPartsViewMixin, SaveFormPartsMixin, TemplatedFormDef
 from shoop.admin.utils.views import CreateOrUpdateView
@@ -45,7 +45,10 @@ class ProductBaseFormPart(FormPart):
     def get_initial(self):
         if not self.object.pk:
             # Sane defaults...
+            name_field = "name__%s" % get_language()
             return {
+                name_field: self.request.GET.get("name", ""),
+                "sku": self.request.GET.get("sku", ""),
                 "type": ProductType.objects.first(),
                 "tax_class": TaxClass.objects.first()
             }

--- a/shoop_tests/admin/test_product_module.py
+++ b/shoop_tests/admin/test_product_module.py
@@ -48,3 +48,18 @@ def test_product_edit_view_works_at_all(rf, admin_user):
             assert (product.sku in response.rendered_content)  # it's probable the SKU is there
             response = view_func(request, pk=None)  # "new mode"
             assert response.rendered_content  # yeah, something gets rendered
+
+
+@pytest.mark.django_db
+def test_product_edit_view_with_params(rf, admin_user):
+    get_default_shop()
+    sku = "test-sku"
+    name = "test name"
+    request = apply_request_middleware(rf.get("/", {"name": name, "sku": sku}), user=admin_user)
+
+    with replace_modules([ProductModule]):
+        with admin_only_urls():
+            view_func = ProductEditView.as_view()
+            response = view_func(request)
+            assert (sku in response.rendered_content)  # it's probable the SKU is there
+            assert (name in response.rendered_content)  # it's probable the name is there


### PR DESCRIPTION
Fix issue with `sku` and `name` `GET` params not being handled in product
view when adding products through search.

Refs SHOOP-1062