### PR TITLE
Auth: Enable email login and password recovery with username

### DIFF
--- a/shoop/front/apps/auth/forms.py
+++ b/shoop/front/apps/auth/forms.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import AuthenticationForm
+from django.contrib.auth.tokens import default_token_generator
+from django.core.exceptions import MultipleObjectsReturned
+from django.core.mail import send_mail
+from django.db.models import Q
+from django.template import loader
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.utils.translation import ugettext as _
+
+
+class EmailAuthenticationForm(AuthenticationForm):
+
+    def __init__(self, *args, **kwargs):
+        super(EmailAuthenticationForm, self).__init__(*args, **kwargs)
+        self.fields['username'].label = _("Username or email address")
+
+    def clean_username(self):
+        username = self.data['username']
+        user_model = get_user_model()
+        if '@' in username:
+            try:
+                username = user_model.objects.get(email=username).username
+            except MultipleObjectsReturned:
+                raise forms.ValidationError(
+                    _("Multiple users have this email, please use username to login."),
+                    code='invalid_login_multiple_users'
+                )
+        return username
+
+
+class RecoverPasswordForm(forms.Form):
+    username = forms.CharField(label=_("Username"), max_length=254, required=False)
+    email = forms.EmailField(label=_("Email"), max_length=254, required=False)
+    token_generator = default_token_generator
+    subject_template_name = "shoop/user/recover_password_mail_subject.jinja",
+    email_template_name = "shoop/user/recover_password_mail_content.jinja"
+    from_email = None
+
+    def clean(self):
+        data = self.cleaned_data
+        if not (data["username"] or data["email"]):
+            raise forms.ValidationError(
+                _("Please provide either username or password"), code="no_email_or_username"
+            )
+        return data
+
+    def save(self, request):
+        self.request = request
+        user_model = get_user_model()
+
+        username = self.cleaned_data["username"]
+        email = self.cleaned_data["email"]
+        active_users = user_model.objects.filter(
+            Q(username__iexact=username) | Q(email__iexact=email), Q(is_active=True)
+        )
+
+        for user in active_users:
+            self.process_user(user)
+
+    def process_user(self, user_to_recover):
+        if not user_to_recover.has_usable_password():
+            return False
+
+        context = {
+            'site_name': getattr(self.request, "shop", _("shop")),
+            'uid': urlsafe_base64_encode(force_bytes(user_to_recover.pk)),
+            'user_to_recover': user_to_recover,
+            'token': self.token_generator.make_token(user_to_recover),
+            'request': self.request,
+        }
+        subject = loader.render_to_string(self.subject_template_name, context)
+        subject = ''.join(subject.splitlines())  # Email subject *must not* contain newlines
+        email = loader.render_to_string(self.email_template_name, context, request=self.request)
+        send_mail(subject, email, self.from_email, [user_to_recover.email])
+        return True

--- a/shoop/front/apps/auth/templates/shoop/user/recover_password.jinja
+++ b/shoop/front/apps/auth/templates/shoop/user/recover_password.jinja
@@ -15,6 +15,7 @@
     <div class="col-sm-8 col-sm-push-2 col-md-6 col-md-push-3">
         <form role="form" method="post">
             {% csrf_token %}
+            {{ render_field(form.username) }}
             {{ render_field(form.email) }}
             <button type="submit" class="btn btn-primary btn-block">
                 {% trans %}Send password recovery instructions{% endtrans %}

--- a/shoop/front/apps/auth/templates/shoop/user/recover_password_mail_content.jinja
+++ b/shoop/front/apps/auth/templates/shoop/user/recover_password_mail_content.jinja
@@ -1,3 +1,7 @@
+Hi {{ user_to_recover.get_full_name() }},
+
+{% trans username=user_to_recover.username %}In case you've forgotten, your username is {{ username }}.{% endtrans %}
+
 {% trans %}You're receiving this email because you requested a password reset for your user account at {{ site_name }}.{% endtrans %}
 {% trans %}Please go to the following page and choose a new password:{% endtrans %}
 {{ request.build_absolute_uri(url("shoop:recover_password_confirm", uidb64=uid, token=token)) }}

--- a/shoop/front/apps/auth/views.py
+++ b/shoop/front/apps/auth/views.py
@@ -10,25 +10,23 @@ from __future__ import unicode_literals
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model, login, logout
-from django.contrib.auth.forms import AuthenticationForm, SetPasswordForm
+from django.contrib.auth.forms import SetPasswordForm
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.auth.views import REDIRECT_FIELD_NAME
-from django.core.mail import send_mail
 from django.core.urlresolvers import reverse_lazy
 from django.db.transaction import atomic
 from django.http import HttpResponseRedirect
-from django.template import loader
-from django.utils.encoding import force_bytes
-from django.utils.http import is_safe_url, urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.http import is_safe_url, urlsafe_base64_decode
 from django.utils.translation import ugettext as _
 from django.views.generic import FormView, TemplateView
 
+from shoop.front.apps.auth.forms import EmailAuthenticationForm, RecoverPasswordForm
 from shoop.utils.excs import Problem
 
 
 class LoginView(FormView):
     template_name = 'shoop/user/login.jinja'
-    form_class = AuthenticationForm
+    form_class = EmailAuthenticationForm
 
     def get_form(self, form_class=None):
         form = super(LoginView, self).get_form(form_class)
@@ -58,39 +56,6 @@ class LogoutView(TemplateView):
         if request.user.is_authenticated():
             logout(request)
         return super(LogoutView, self).dispatch(request, *args, **kwargs)
-
-
-class RecoverPasswordForm(forms.Form):
-    email = forms.EmailField(label=_("Email"), max_length=254)
-    token_generator = default_token_generator
-    subject_template_name = "shoop/user/recover_password_mail_subject.jinja",
-    email_template_name = "shoop/user/recover_password_mail_content.jinja"
-    from_email = None
-
-    def save(self, request):
-        self.request = request
-        user_model = get_user_model()
-        active_users = user_model.objects.filter(email__iexact=self.cleaned_data["email"], is_active=True)
-        for user in active_users:
-            self.process_user(user)
-
-    def process_user(self, user):
-        if not user.has_usable_password():
-            return False
-
-        context = {
-            'email': user.email,
-            'site_name': getattr(self.request, "shop", _("shop")),
-            'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-            'user': user,
-            'token': self.token_generator.make_token(user),
-            'request': self.request,
-        }
-        subject = loader.render_to_string(self.subject_template_name, context)
-        subject = ''.join(subject.splitlines())  # Email subject *must not* contain newlines
-        email = loader.render_to_string(self.email_template_name, context, request=self.request)
-        send_mail(subject, email, self.from_email, [user.email])
-        return True
 
 
 class RecoverPasswordView(FormView):

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
@@ -62,7 +62,7 @@
                                 {% if request.resolver_match.url_name == "logout" %}{% set next="/" %}{% endif %}
                                 <input type="hidden" name="next" value="{{ next or request.path }}">
                                 <div class="form-group">
-                                    <label for="username">{% trans %}Username{% endtrans %}</label>
+                                    <label for="username">{% trans %}Username or email address{% endtrans %}</label>
                                     <input type="text" name="username" class="form-control">
                                 </div>
                                 <div class="form-group">

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/user/recover_password.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/user/recover_password.jinja
@@ -16,6 +16,7 @@
         <div class="well">
             <form role="form" method="post">
                 {% csrf_token %}
+                {{ render_field(form.username) }}
                 {{ render_field(form.email) }}
                 <button type="submit" class="btn btn-primary btn-block">
                     {% trans %}Send password recovery instructions{% endtrans %}


### PR DESCRIPTION
Allow login with email.
Allow password recovevry with username. Add more user information
to password recovery email.

Refs SHOOP-1670