### PR TITLE
Add autoexpiring versioned cache API (SHOOP-1702)

### DIFF
--- a/shoop/core/cache/__init__.py
+++ b/shoop/core/cache/__init__.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+"""
+Utilities for versioned caching and automatic timeout determination.
+
+Versioning works by way of namespaces. Namespaces are the first
+colon-separated part of cache keys.
+
+For instance, the cache keys ``price:10``, ``price:20``, and ``price``
+all belong to the ``price`` namespace and can be invalidated with
+one ``bump_version("price")`` call.
+
+The versions themselves are stored within the cache, within the
+``_version`` namespace.  (As an implementation detail, this allows one
+to invalidate _all_ versioned keys by bumping the version of
+``_version``. Very meta!)
+"""
+
+from .impl import VersionedCache
+
+__all__ = [
+    "bump_version",
+    "clear",
+    "get",
+    "set",
+    "VersionedCache",
+]
+
+_default_cache = VersionedCache(using="default")
+get = _default_cache.get
+set = _default_cache.set
+bump_version = _default_cache.bump_version
+clear = _default_cache.clear

--- a/shoop/core/cache/impl.py
+++ b/shoop/core/cache/impl.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+import threading
+import time
+
+from django.conf import settings
+from django.core.cache import caches
+from django.core.signals import request_finished
+from django.utils.encoding import force_str
+
+DEFAULT_CACHE_DURATIONS = {
+    # Add default durations for various namespaces here (in seconds)
+}
+_versions = threading.local()
+
+
+def _clear_versions_for_request(**kwargs):
+    _versions.__dict__.clear()
+
+
+request_finished.connect(_clear_versions_for_request, dispatch_uid="shoop.core.cache._clear_versions_for_request")
+
+
+def _get_cache_key_namespace(cache_key):
+    """
+    Split the given cache key by the first colon to get a namespace.
+
+    :param cache_key: Cache key string
+    :type cache_key: str
+    :return: Cache namespace string
+    :rtype: str
+    """
+    return force_str(cache_key).split(str(":"), 1)[0]
+
+
+def get_cache_duration(cache_key):
+    """
+    Determine a cache duration for the given cache key.
+
+    :param cache_key: Cache key string
+    :type cache_key: str
+    :return: Timeout seconds
+    :rtype: int
+    """
+    namespace = _get_cache_key_namespace(cache_key)
+    duration = settings.SHOOP_CACHE_DURATIONS.get(namespace)
+    if duration is None:
+        duration = DEFAULT_CACHE_DURATIONS.get(namespace, settings.SHOOP_DEFAULT_CACHE_DURATION)
+    return duration
+
+
+class VersionedCache(object):
+    def __init__(self, using):
+        """
+        :param using: Cache alias
+        :type using: str
+        """
+        self.using = using
+        self._cache = caches[self.using]
+
+    def bump_version(self, cache_key):
+        """
+        Bump up the cache version for the given cache key/namespace.
+
+        :param cache_key: Cache key or namespace
+        :type cache_key: str
+        """
+        namespace = _get_cache_key_namespace(cache_key)
+        version = str(time.time())
+        self.set(str("_version:") + namespace, version)
+        setattr(_versions, namespace, version)
+
+    def get_version(self, cache_key):
+        """
+        Get the cache version (or None) for the given cache key/namespace.
+
+        The cache version is stored in thread-local storage for
+        the current request, so unless bumped in-request,
+        all `get`s within a single request should get coherently versioned
+        data from the cache.
+
+        :param cache_key: Cache key or namespace
+        :type cache_key: str
+        :return: Version ID or none
+        :rtype: str|None
+        """
+        namespace = _get_cache_key_namespace(cache_key)
+        if not hasattr(_versions, namespace):
+            version = self._cache.get(str("_version:") + namespace)
+            setattr(_versions, namespace, version)
+        else:
+            version = getattr(_versions, namespace, None)
+        return version
+
+    def set(self, key, value, timeout=None, version=None):
+        """
+        Set the value for key `key` in the cache.
+
+        Unlike `django.core.caches[using].set()`, this also derives
+        timeout and versioning information from the key (and cached
+        version data) if the key begins with a colon-separated namespace,
+        such as `foo:bar`.
+
+        :param key: Cache key
+        :type key: str
+        :param value: Value to cache
+        :type value: object
+        :param timeout: Timeout seconds or None (for auto-determination)
+        :type timeout: int|None
+        :param version: Version string or None (for auto-determination)
+        :type version: str|None
+        :param using: Cache alias
+        :type using: str
+        """
+        if timeout is None:
+            timeout = get_cache_duration(key)
+        if version is None:
+            version = self.get_version(key)
+        self._cache.set(key, value, timeout=timeout, version=version)
+
+    def get(self, key, version=None, default=None):
+        """
+        Get the value for key `key` in the cache.
+
+        Unlike `django.core.caches[using].get()`, versioning information
+        can be auto-derived from the key (and cached version data) if the
+        key begins with a colon-separated namespace, such as `foo:bar`.
+
+        :param key: Cache key
+        :type key: str
+        :param version: Version string or None (for auto-determination)
+        :type version: str|None
+        :param default: Default value, if the key is not found
+        :type default: object
+        :param using: Cache alias
+        :type using: str
+        :return: cached value
+        :rtype: object
+        """
+        if version is None:
+            version = self.get_version(key)
+        return self._cache.get(key, default=default, version=version)
+
+    def clear(self):
+        self._cache.clear()

--- a/shoop/core/settings.py
+++ b/shoop/core/settings.py
@@ -136,3 +136,10 @@ SHOOP_TELEMETRY_ENABLED = True
 
 #: The submission URL for Shoop's telemetry (statistics) system
 SHOOP_TELEMETRY_URL = "https://telemetry.shoop.io/collect/"
+
+#: Default cache duration for various caches in seconds
+SHOOP_DEFAULT_CACHE_DURATION = 60 * 30
+
+#: Overrides for default cache durations by key namespace.
+#: These override possible defaults in `shoop.core.cache.impl.DEFAULT_CACHE_DURATIONS`.
+SHOOP_CACHE_DURATIONS = {}

--- a/shoop/front/apps/simple_search/views.py
+++ b/shoop/front/apps/simple_search/views.py
@@ -10,12 +10,12 @@ from __future__ import unicode_literals
 import hashlib
 
 from django import forms
-from django.core.cache import cache
 from django.db.models import Q
 from django.utils.encoding import force_bytes
 from django.views.generic import ListView
 
-from shoop.core.models import Product
+from shoop.core import cache
+from shoop.core.models.products import Product
 from shoop.front.utils.product_sorting import PRODUCT_SORT_CHOICES, sort_products
 from shoop.front.utils.views import cache_product_things
 from shoop.front.template_helpers.product import is_visible
@@ -23,7 +23,7 @@ from shoop.front.template_helpers.product import is_visible
 
 def get_search_product_ids(request, query):
     query = query.strip().lower()
-    cache_key = "simple_search_%s" % hashlib.sha1(force_bytes(query)).hexdigest()
+    cache_key = "simple_search:%s" % hashlib.sha1(force_bytes(query)).hexdigest()
     product_ids = cache.get(cache_key)
     if product_ids is None:
         product_ids = Product.objects.filter(

--- a/shoop/front/utils/product_statistics.py
+++ b/shoop/front/utils/product_statistics.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals, with_statement
 
 import datetime
 
-from django.core.cache import cache
+from shoop.core import cache
 from django.db.models import Sum
 from django.utils.translation import get_language
 
@@ -19,7 +19,7 @@ from shoop.core.models import OrderLine, OrderLineType, Product
 def get_best_selling_product_info(shop_ids, cutoff_days=30):
     shop_ids = sorted(map(int, shop_ids))
     cutoff_date = datetime.date.today() - datetime.timedelta(days=cutoff_days)
-    cache_key = "best_sellers_%r_%s" % (shop_ids, cutoff_date)
+    cache_key = "best_sellers:%r_%s" % (shop_ids, cutoff_date)
     sales_data = cache.get(cache_key)
     if sales_data is None:
         sales_data = (
@@ -39,7 +39,7 @@ def get_best_selling_product_info(shop_ids, cutoff_days=30):
 
 
 def get_products_ordered_with(prod, count=20, request=None, language=None):
-    cache_key = "ordered_with_%d" % prod.pk
+    cache_key = "ordered_with:%d" % prod.pk
     product_ids = cache.get(cache_key)
     if product_ids is None:
         # XXX: could this be optimized more? (and does it matter?)

--- a/shoop_tests/utils/test_cache.py
+++ b/shoop_tests/utils/test_cache.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from shoop.core import cache
+
+
+def test_cache_api():
+    key = "test_prefix:123"
+    value = "456"
+    cache.set(key, value)
+    assert cache.get(key) == value
+    cache.bump_version(key)
+    assert cache.get(key, default="derp") == "derp"  # version was bumped, so no way this is there
+    cache.set(key, value)
+    assert cache.get(key) == value


### PR DESCRIPTION
This is the versioned cache API as introduced in #62, rebased, extracted and slightly updated too.