### PR TITLE
Xtheme: Allow addons to inject resources

### DIFF
--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -91,3 +91,5 @@ Provide Categories
     XTheme themes (full theme sets).
 ``xtheme_plugin``
     XTheme plugins (that are placed into placeholders within themes).
+``xtheme_resource_injection``
+    XTheme resources injection function that takes current context and content as parameters.

--- a/shoop/xtheme/engine.py
+++ b/shoop/xtheme/engine.py
@@ -12,6 +12,7 @@ import six
 from jinja2.environment import Environment, Template
 from jinja2.utils import concat, internalcode
 
+from shoop.apps.provides import get_provide_objects
 from shoop.xtheme.editing import add_edit_resources
 from shoop.xtheme.resources import RESOURCE_CONTAINER_VAR_NAME, ResourceContainer, inject_resources
 from shoop.xtheme.theme import get_current_theme
@@ -39,7 +40,9 @@ class XthemeTemplate(Template):
         return self.environment.handle_exception(exc_info, True)
 
     def _postprocess(self, context, content):
-        # TODO: Add a hook here for addons to inject resources without plugins
+        for inject_func in get_provide_objects("xtheme_resource_injection"):
+            if callable(inject_func):
+                inject_func(context, content)
         add_edit_resources(context)
         content = inject_resources(context, content)
         return content

--- a/shoop_tests/xtheme/test_addon_injections.py
+++ b/shoop_tests/xtheme/test_addon_injections.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from shoop.apps.provides import override_provides
+from shoop.xtheme.theme import override_current_theme_class
+from shoop.xtheme.resources import InlineScriptResource, add_resource
+from shoop_tests.xtheme.utils import get_jinja2_engine, get_request
+
+
+def add_test_injection(context, content):
+    add_resource(context, "body_end", InlineScriptResource("window.injectedFromAddon=true;"))
+
+
+@pytest.mark.django_db
+def test_simple_addon_injection():
+    request = get_request(edit=False)
+    jeng = get_jinja2_engine()
+    template = jeng.get_template("resinject.jinja")
+
+    with override_current_theme_class():
+        with override_provides(
+                "xtheme_resource_injection", ["shoop_tests.xtheme.test_addon_injections:add_test_injection",]):
+            # TestInjector should add alert to end of the body for every request
+            output = template.render(request=request)
+            head, body = output.split("</head>", 1)
+            assert "window.injectedFromAddon=true;" in body


### PR DESCRIPTION
Enable "xtheme_resource_injection" as a provider category that
defines function to add resources to theme.

Refs SHOOP-1685 / SHOOP-1690