### PR TITLE
Classic Gray: Show maintenance mode for admin

### DIFF
--- a/shoop/themes/classic_gray/static_src/less/classic-gray/base.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/base.less
@@ -73,6 +73,9 @@ table tr {
     .close {
         opacity: 1;
     }
+    &.alert-top {
+        margin: 0;
+    }
 }
 
 .progress {

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/base.jinja
@@ -16,6 +16,12 @@
     <link rel="stylesheet" href="{{ STATIC_URL }}classic_gray/css/style.css">
 </head>
 <body>
+    {% if request.shop.maintenance_mode %}
+        <div class="alert alert-warning alert-top text-center alert-dismissible">
+            <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            {% trans %}Shop is currently in maintenance mode.{% endtrans %}
+        </div>
+    {% endif %}
     <nav class="main-nav">
         {% include "shoop/front/includes/_navigation.jinja" %}
     </nav>


### PR DESCRIPTION
Add a dismissable alert banner if the shop is in maintenance mode.
Now the admin can see in shop side if the maintenance mode is left on.

Refs SHOOP-1585