### PR TITLE
Fix tax calc and implement override groups (SHOOP-1622)

### DIFF
--- a/shoop/core/taxing/utils.py
+++ b/shoop/core/taxing/utils.py
@@ -51,3 +51,52 @@ def stacked_value_added_taxes(price, taxes):
         taxful = TaxfulPrice(taxless.amount + total_tax_amount)
 
     return TaxedPrice(taxful, taxless, line_taxes)
+
+
+def calculate_compounded_added_taxes(price, tax_groups):
+    """
+    Calculate compounded and added taxes from given groups of taxes.
+
+    The `tax_groups` argument should be a list of tax groups, where each
+    tax group is a list of `Tax` objects.  Taxes in each tax group will
+    be added together and finally each added tax group will be
+    compounded over each other.
+
+    :param price: Taxful or taxless price to calculate taxes for
+    :type price: shoop.core.pricing.Price
+    :param tax_groups: List of tax groups, each being a list of taxes
+    :type tax_groups: list[list[shoop.core.models.Tax]]
+    :return: TaxedPrice with the calculated taxes.
+    :rtype: TaxedPrice
+    """
+    if price.includes_tax:
+        return _calc_compounded_added_taxes_from_taxful(price, tax_groups)
+    else:
+        return _calc_compounded_added_taxes_from_taxless(price, tax_groups)
+
+
+def _calc_compounded_added_taxes_from_taxful(amount, tax_groups):
+    base_price = TaxfulPrice(amount)
+    reversed_line_taxes = []
+    for taxes in reversed(tax_groups):
+        taxed_price = stacked_value_added_taxes(base_price, taxes)
+        base_price = TaxfulPrice(taxed_price.taxless)
+        reversed_line_taxes.extend(reversed(taxed_price.taxes))
+    line_taxes = list(reversed(reversed_line_taxes))
+    return TaxedPrice(
+        taxful=TaxfulPrice(amount),
+        taxless=TaxlessPrice(base_price),
+        taxes=line_taxes)
+
+
+def _calc_compounded_added_taxes_from_taxless(amount, tax_groups):
+    base_price = TaxlessPrice(amount)
+    line_taxes = []
+    for taxes in tax_groups:
+        taxed_price = stacked_value_added_taxes(base_price, taxes)
+        base_price = TaxlessPrice(taxed_price.taxful)
+        line_taxes.extend(taxed_price.taxes)
+    return TaxedPrice(
+        taxful=TaxfulPrice(base_price),
+        taxless=TaxlessPrice(amount),
+        taxes=line_taxes)

--- a/shoop/default_tax/admin_module/views.py
+++ b/shoop/default_tax/admin_module/views.py
@@ -25,6 +25,7 @@ class TaxRuleForm(forms.ModelForm):
             "region_codes_pattern",
             "postal_codes_pattern",
             "priority",
+            "override_group",
             "tax",
             "enabled",
         ]
@@ -68,5 +69,6 @@ class TaxRuleListView(PicotableListView):
         Column("region_codes_pattern", _("Regions")),
         Column("postal_codes_pattern", _("Postal Codes")),
         Column("priority", _(u"Priority")),
+        Column("override_group", _(u"Override Group")),
         Column("enabled", _(u"Enabled")),
     ]

--- a/shoop/default_tax/migrations/0005_taxrule_override_group.py
+++ b/shoop/default_tax/migrations/0005_taxrule_override_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_tax', '0004_merge'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='taxrule',
+            name='override_group',
+            field=models.IntegerField(help_text='If several rules match, only the rules with the highest override group number will be effective.  This can be used, for example, to implement tax exemption by adding a rule with very high priority that sets a zero tax.', verbose_name='override group number', default=0),
+        ),
+        migrations.AlterField(
+            model_name='taxrule',
+            name='region_codes_pattern',
+            field=models.CharField(max_length=500, blank=True, verbose_name='Region codes pattern'),
+        ),
+    ]

--- a/shoop/default_tax/models.py
+++ b/shoop/default_tax/models.py
@@ -39,6 +39,13 @@ class TaxRule(models.Model):
             "Rules with same priority are value-added (e.g. US taxes) "
             "and rules with different priority are compound taxes "
             "(e.g. Canada Quebec PST case)"))
+    override_group = models.IntegerField(
+        default=0,
+        verbose_name=_("override group number"), help_text=_(
+            "If several rules match, only the rules with the highest "
+            "override group number will be effective.  This can be "
+            "used, for example, to implement tax exemption by adding "
+            "a rule with very high priority that sets a zero tax."))
     tax = models.ForeignKey(Tax, on_delete=models.PROTECT)
 
     def matches(self, taxing_context):

--- a/shoop/default_tax/module.py
+++ b/shoop/default_tax/module.py
@@ -4,12 +4,14 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from itertools import groupby
+from operator import attrgetter
+
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core import taxing
-from shoop.core.pricing import TaxfulPrice, TaxlessPrice
-from shoop.core.taxing.utils import stacked_value_added_taxes
+from shoop.core.taxing.utils import calculate_compounded_added_taxes
 from shoop.default_tax.models import TaxRule
 from shoop.utils.iterables import first
 
@@ -23,19 +25,63 @@ class DefaultTaxModule(taxing.TaxModule):
 
 
 def _calculate_taxes(price, taxing_context, tax_class):
-    customer_tax_group = taxing_context.customer_tax_group
-    # TODO: (TAX) Should tax exempt be done in some better way?
-    if customer_tax_group and customer_tax_group.identifier == 'tax_exempt':
-        return taxing.TaxedPrice(
-            TaxfulPrice(price.amount), TaxlessPrice(price.amount), [])
+    rules = _get_enabled_tax_rules(taxing_context, tax_class)
+    tax_groups = get_taxes_of_effective_rules(taxing_context, rules)
+    return calculate_compounded_added_taxes(price, tax_groups)
 
+
+def _get_enabled_tax_rules(taxing_context, tax_class):
+    """
+    Get enabled tax rules from the db for given parameters.
+
+    Returned rules are ordered desceding by override group and then
+    ascending by priority (as required by `_filter_and_group_rules`).
+
+    :type taxing_context: shoop.core.taxing.TaxingContext
+    :type tax_class: shoop.core.models.TaxClass
+    """
     tax_rules = TaxRule.objects.filter(enabled=True, tax_classes=tax_class)
-    if customer_tax_group:
+    if taxing_context.customer_tax_group:
         tax_rules = tax_rules.filter(
-            Q(customer_tax_groups=customer_tax_group) |
+            Q(customer_tax_groups=taxing_context.customer_tax_group) |
             Q(customer_tax_groups=None))
-    tax_rules = tax_rules.order_by("-priority")  # TODO: (TAX) Do the Right Thing with priority
-    taxes = [tax_rule for tax_rule in tax_rules if tax_rule.matches(taxing_context)]
-    tax_rule = first(taxes)  # TODO: (TAX) Do something better than just using the first tax!
-    tax = getattr(tax_rule, "tax", None)
-    return stacked_value_added_taxes(price, [tax] if tax else [])
+    tax_rules = tax_rules.order_by('-override_group', 'priority')
+    return tax_rules
+
+
+def get_taxes_of_effective_rules(taxing_context, tax_rules):
+    """
+    Get taxes grouped by priority from effective tax rules.
+
+    Effective tax rules is determined by first limiting the scope to the
+    rules that match the given taxing context (see `TaxRule.match`) and
+    then further limiting the matching rules by selecting only the rules
+    in the highest numbered override group.
+
+    The `Tax` objects in the effective rules will be grouped by the
+    priority of the rules.  The tax groups are returned as list of tax
+    lists.
+
+    :type taxing_context: shoop.core.taxing.TaxingContext
+    :param tax_rules:
+      Tax rules to filter from.  These should be ordered desceding by
+      override group and then ascending by priority.
+    :type tax_rules: Iterable[TaxRule]
+    :rtype: list[list[shoop.core.models.Tax]]
+    """
+    # Limit our scope to only matching rules
+    matching_rules = (
+        tax_rule for tax_rule in tax_rules
+        if tax_rule.matches(taxing_context))
+
+    # Further limit our scope to the highest numbered override group
+    grouped_by_override = groupby(matching_rules, attrgetter('override_group'))
+    highest_override_group = first(grouped_by_override, (None, []))[1]
+
+    # Group rules by priority
+    grouped_rules = groupby(highest_override_group, attrgetter('priority'))
+    tax_groups = [
+        [rule.tax for rule in rules]
+        for (_, rules) in grouped_rules]
+
+    return tax_groups

--- a/shoop/default_tax/templates/shoop/default_tax/admin/edit.jinja
+++ b/shoop/default_tax/templates/shoop/default_tax/admin/edit.jinja
@@ -19,6 +19,7 @@
                 {{ bs3.field(form.region_codes_pattern) }}
                 {{ bs3.field(form.postal_codes_pattern) }}
                 {{ bs3.field(form.priority) }}
+                {{ bs3.field(form.override_group) }}
 
                 {% call text_between_fields() %}
                     <h3>{% trans %}Applied tax{% endtrans %}</h3>

--- a/shoop_tests/core/test_taxing_utils.py
+++ b/shoop_tests/core/test_taxing_utils.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from decimal import Decimal
+
+import pytest
+
+from shoop.core.models import Tax
+from shoop.core.pricing import TaxfulPrice, TaxlessPrice
+from shoop.core.taxing.utils import calculate_compounded_added_taxes
+from shoop.utils.money import Money
+
+
+def tax(code, rate=None, amount=None):
+    return Tax(code=code, name=('Tax ' + code), rate=rate, amount=amount)
+
+
+def tfprice(value):
+    return TaxfulPrice(value, 'USD')
+
+
+def tlprice(value):
+    return TaxlessPrice(value, 'USD')
+
+
+def money(value):
+    return Money(value, 'USD')
+
+
+@pytest.mark.parametrize("price", [tlprice('123.00'), tfprice('123.00')])
+def test_compounded_added_taxes_empty(price):
+    result = calculate_compounded_added_taxes(price, [])
+    assert result.taxful == tfprice(123)
+    assert result.taxless == tlprice(123)
+    assert result.taxes == []
+
+    result2 = calculate_compounded_added_taxes(price, [[]])
+    assert result2.taxful == tfprice(123)
+    assert result2.taxless == tlprice(123)
+    assert result2.taxes == []
+
+
+@pytest.mark.parametrize("price", [tlprice('100.00'), tfprice('115.00')])
+def test_compounded_added_taxes_simple(price):
+    taxes = [[tax('15%', rate=Decimal('0.15'))]]
+    result = calculate_compounded_added_taxes(price, taxes)
+    assert result.taxful == tfprice('115')
+    assert result.taxless == tlprice('100')
+    assert len(result.taxes) == 1
+    assert result.taxes[0].tax.code == '15%'
+    assert result.taxes[0].amount == money('15')
+    assert result.taxes[0].base_amount == money('100')
+
+
+@pytest.mark.parametrize("price", [tlprice('100.00'), tfprice('121.00')])
+def test_compounded_added_taxes_simple_added(price):
+    taxes = [[
+        tax('15%', rate=Decimal('0.15')),
+        tax('5%', rate=Decimal('0.05')),
+        tax('1%', rate=Decimal('0.01')),
+    ]]
+    result = calculate_compounded_added_taxes(price, taxes)
+    assert result.taxful == tfprice('121')
+    assert result.taxless == tlprice('100')
+    assert len(result.taxes) == 3
+    assert result.taxes[0].tax.code == '15%'
+    assert result.taxes[0].amount == money('15')
+    assert result.taxes[0].base_amount == money('100')
+    assert result.taxes[1].tax.code == '5%'
+    assert result.taxes[1].amount == money('5')
+    assert result.taxes[1].base_amount == money('100')
+    assert result.taxes[2].tax.code == '1%'
+    assert result.taxes[2].amount == money('1')
+    assert result.taxes[2].base_amount == money('100')
+
+
+@pytest.mark.parametrize("price", [tlprice('100.00'), tfprice('121.9575')])
+def test_compounded_added_taxes_simple_compound(price):
+    taxes = [
+        [tax('15%', rate=Decimal('0.15'))],
+        [tax('5%', rate=Decimal('0.05'))],
+        [tax('1%', rate=Decimal('0.01'))],
+    ]
+    result = calculate_compounded_added_taxes(price, taxes)
+    assert result.taxful == tfprice('121.9575')
+    assert result.taxless == tlprice('100')
+    assert len(result.taxes) == 3
+    assert result.taxes[0].tax.code == '15%'
+    assert result.taxes[0].amount == money('15')
+    assert result.taxes[0].base_amount == money('100')
+    assert result.taxes[1].tax.code == '5%'
+    assert result.taxes[1].amount == money('5.75')
+    assert result.taxes[1].base_amount == money('115')
+    assert result.taxes[2].tax.code == '1%'
+    assert result.taxes[2].amount == money('1.2075')
+    assert result.taxes[2].base_amount == money('120.75')
+
+
+COMPLEX_TAX_GROUPS = [
+    [
+        tax('1A', rate=Decimal('0.5')),
+        tax('1B', rate=Decimal('0.24')),
+        tax('1C', amount=money('1.11')),
+        tax('1D', amount=money('0.89')),
+    ], [
+        tax('2A', rate=Decimal('0.1')),
+        tax('2B', rate=Decimal('0.01')),
+        tax('2C', amount=money('1.25')),
+        tax('2D', amount=money('0.25')),
+    ], [
+        tax('3A', amount=money('0.123')),
+    ], [
+        tax('4A', rate=Decimal('0.1')),
+    ]
+]
+
+
+@pytest.mark.parametrize("price", [tlprice('100'), tfprice('216.6813')])
+def test_compounded_added_taxes_complex(price):
+    result = calculate_compounded_added_taxes(price, COMPLEX_TAX_GROUPS)
+    result_taxes = [
+        (line_tax.tax.code, line_tax.amount, line_tax.base_amount)
+        for line_tax in result.taxes]
+    expected_taxes = [
+        # code, tax_amount, base_amount
+        ('1A', money('50.0'), money('100')),
+        ('1B', money('24.00'), money('100')),
+        ('1C', money('1.11'), money('100')),
+        ('1D', money('0.89'), money('100')),
+        ('2A', money('17.60'), money('176.0')),
+        ('2B', money('1.760'), money('176.0')),
+        ('2C', money('1.25'), money('176.0')),
+        ('2D', money('0.25'), money('176.0')),
+        ('3A', money('0.123'), money('196.860')),
+        ('4A', money('19.6983'), money('196.983')),
+    ]
+    assert result_taxes == expected_taxes
+    assert result.taxless == tlprice('100')
+    assert result.taxful == tfprice('216.6813')
+
+
+@pytest.mark.parametrize("prices", [
+    (tlprice('12345.6789'), tfprice('26233.115950206')),
+    (tlprice('10000.00'), tfprice('21249.6273')),
+    (tlprice('100.00'), tfprice('216.6813')),
+    (tlprice('12.97'), tfprice('31.7825838')),
+    (tlprice('10.00'), tfprice('25.4727')),
+    (tlprice('1.00'), tfprice('6.35184')),
+    (tlprice('0.03'), tfprice('4.2910362')),
+    (tlprice('0.02'), tfprice('4.2697908')),
+    (tlprice('0.01'), tfprice('4.2485454')),
+    (tlprice('0.00'), tfprice('4.2273')),
+    (tlprice('-1.00'), tfprice('2.10276')),
+    (tlprice('-1.9897483'), tfprice('0.000000146718')),
+    (tlprice('-10.00'), tfprice('-17.0181')),
+])
+def test_compounded_added_taxes_complex2(prices):
+    (taxless_price, taxful_price) = prices
+
+    res1 = calculate_compounded_added_taxes(taxless_price, COMPLEX_TAX_GROUPS)
+    assert res1.taxless == taxless_price
+    assert res1.taxful == taxful_price
+
+    res2 = calculate_compounded_added_taxes(taxful_price, COMPLEX_TAX_GROUPS)
+    assert res2.taxless == taxless_price
+    assert res2.taxful == taxful_price

--- a/shoop_tests/default_tax/test_default_tax.py
+++ b/shoop_tests/default_tax/test_default_tax.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+import random
+from decimal import Decimal
+
+import pytest
+from django.test.utils import override_settings
+
+from shoop.core.models import Tax
+from shoop.core.taxing import TaxingContext, get_tax_module
+from shoop.default_tax.models import TaxRule
+from shoop.default_tax.module import (
+    DefaultTaxModule,
+    get_taxes_of_effective_rules,
+)
+from shoop.testing.factories import create_product, get_shop
+from shoop.utils.money import Money
+
+
+class RuleDef(object):
+    def __init__(
+            self, tax, countries, regions, postals,
+            priority=0, override_group=0):
+        self.data = locals()
+
+    def get_tax_rule(self):
+        return TaxRule(
+            country_codes_pattern=self.data['countries'],
+            region_codes_pattern=self.data['regions'],
+            postal_codes_pattern=self.data['postals'],
+            priority=self.data['priority'],
+            override_group=self.data['override_group'],
+            tax=create_tax_from_string(self.data['tax']),
+        )
+
+
+TAX_RULE_DEFS = [
+    RuleDef('0% ZZ', 'XX', 'ZZ*', '', override_group=999),
+    RuleDef('0% Z', 'XX', 'Z*', '', override_group=99),
+    RuleDef('24% FI-ALV', 'FI', '', ''),
+    RuleDef('6.5% CA', 'US', 'CA', ''),
+    RuleDef('1% CA-OC', 'US', 'CA', '90600-92899'),
+    RuleDef('0% CA-OC-IR', 'US', 'CA', '92602'),
+    RuleDef('0.5% CA-OC-IR-DS', 'US', 'CA', '92602'),
+    RuleDef('5% GST', 'CA', 'AB,BC,MB,NT,NU,QC,SK,YT', '', priority=0),
+    RuleDef('5% PST5', 'CA', 'SK', '', priority=0),
+    RuleDef('10% PST10', 'CA', 'QC', '', priority=1),
+    RuleDef('50% 1A', 'XX', 'A', '', priority=1),
+    RuleDef('20% 1B', 'XX', 'A,B', '', priority=1),
+    RuleDef('30% 1C', 'XX', 'A-C', '', priority=1),
+    RuleDef('50% 2A', 'XX', 'A', '', priority=2),
+    RuleDef('50% 2B', 'XX', 'A-B', '', priority=2),
+    RuleDef('$30 3*', 'XX', '*', '', priority=3),
+    RuleDef('50% 4', 'XX', '', '', priority=4),
+]
+
+
+class Address(object):
+    def __init__(self, country, region, postal):
+        self.country_code = country
+        self.region_code = region
+        self.postal_code = postal
+
+
+EXPECTED_TAXES_BY_ADDRESS = [
+    (Address('FI', '', '20100'), ('FI-ALV',)),
+    (Address('US', 'CA', '92602'), ('CA CA-OC CA-OC-IR CA-OC-IR-DS',)),
+    (Address('US', 'CA', '92666'), ('CA CA-OC',)),
+    (Address('US', 'CA', '90000'), ('CA',)),
+    (Address('CA', 'QC', ''), ('GST', 'PST10',)),
+    (Address('CA', 'SK', ''), ('GST PST5',)),
+    (Address('CA', 'YT', ''), ('GST',)),
+    (Address('XX', 'A', ''), ('1A 1B 1C', '2A 2B', '3*', '4',)),
+    (Address('XX', 'B', ''), ('1B 1C', '2B', '3*', '4',)),
+    (Address('XX', 'C', ''), ('1C', '3*', '4',)),
+    (Address('XX', 'Y', ''), ('3*', '4',)),
+    (Address('XX', 'Z', ''), ('Z',)),
+    (Address('XX', 'ZX', ''), ('Z',)),
+    (Address('XX', 'ZZ', ''), ('ZZ',)),
+    (Address('XX', 'ZZ2', ''), ('ZZ',)),
+    (Address('AA', '', ''), ()),
+]
+
+
+@pytest.mark.parametrize("address, expected_taxes", EXPECTED_TAXES_BY_ADDRESS)
+def test_get_taxes_of_effective_rules(address, expected_taxes):
+    context = TaxingContext(location=address)
+    tax_rules = [ruledef.get_tax_rule() for ruledef in TAX_RULE_DEFS]
+    result = get_taxes_of_effective_rules(context, tax_rules)
+    grouped_codes_of_result = [[x.code for x in group] for group in result]
+    expected_codes = [x.split() for x in expected_taxes]
+    assert grouped_codes_of_result == expected_codes
+
+
+TAX_AMOUNTS = {  # taxes for $1000
+    ('FI-ALV',): 240,
+    ('CA CA-OC CA-OC-IR CA-OC-IR-DS',): 80,
+    ('CA CA-OC',): 75,
+    ('CA',): 65,
+    ('GST', 'PST10',): 155,
+    ('GST PST5',): 100,
+    ('GST',): 50,
+    ('1A 1B 1C', '2A 2B', '3*', '4',): 5045,
+    ('1B 1C', '2B', '3*', '4',): 2420,
+    ('1C', '3*', '4',): 995,
+    ('3*', '4',): 545,
+    ('Z',): 0,
+    ('ZZ',): 0,
+    (): 0,
+}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("address, expected_taxes", EXPECTED_TAXES_BY_ADDRESS)
+def test_module(address, expected_taxes):
+    """
+    Test the DefaultTaxModule.
+    """
+    # Create a product
+    shop = get_shop(prices_include_tax=False, currency='USD')
+    product = create_product('PROD', shop=shop, default_price=1000)
+    price = product.get_shop_instance(shop).default_price
+
+    # Put the tax rules into database
+    for ruledef in shuffled(TAX_RULE_DEFS):
+        rule = ruledef.get_tax_rule()
+        rule.tax.save()
+        rule.tax = rule.tax  # refresh the id
+        rule.save()
+        rule.tax_classes.add(product.tax_class)
+    assert TaxRule.objects.count() == len(TAX_RULE_DEFS)
+
+    with override_settings(SHOOP_TAX_MODULE='default_tax'):
+        module = get_tax_module()
+        assert isinstance(module, DefaultTaxModule)
+
+        context = TaxingContext(location=address)
+        taxed_price = module.get_taxed_price_for(context, product, price)
+        expected_codes = set(sum([x.split() for x in expected_taxes], []))
+        assert set(x.tax.code for x in taxed_price.taxes) == expected_codes
+        expected_tax = Money(TAX_AMOUNTS[expected_taxes], 'USD')
+        assert taxed_price.taxful.amount == price.amount + expected_tax
+
+    # Clean-up the rules
+    TaxRule.objects.all().delete()
+
+
+def create_tax_from_string(string):
+    if ' ' in string:
+        (spec, name) = string.split(' ', 1)
+    else:
+        name = spec = string
+    if spec.startswith('$'):
+        return create_tax(name, amount=Money(spec[1:], 'USD'))
+    elif spec.endswith('%'):
+        return create_tax(name, rate=(Decimal(spec[:-1]) / 100))
+    raise ValueError('Unknown tax string: %r' % (string,))
+
+
+def create_tax(code, rate=None, amount=None):
+    return Tax(code=code, name=('Tax ' + code), rate=rate, amount=amount)
+
+
+def shuffled(iterable):
+    items = list(iterable)
+    random.shuffle(items)
+    return items


### PR DESCRIPTION
Fix tax calculations of default_tax to make added and compounded taxes
work correctly.

Implement override groups for TaxRules.

Refs SHOOP-1636/SHOOP-1622