### PR TITLE
Remove unused requirements.txt from core and front

### DIFF
--- a/shoop/core/requirements.txt
+++ b/shoop/core/requirements.txt
@@ -1,1 +1,0 @@
-Nothing here. See setup.py.

--- a/shoop/front/requirements.txt
+++ b/shoop/front/requirements.txt
@@ -1,1 +1,0 @@
-django-jinja==1.0.5


### PR DESCRIPTION
Prensence of requirements.txt makes some tools interpret the directory
as project root.  We don't use these files for anything, so better just
remove them.