### PR TITLE
Remove Priceful.total_price (SHOOP-1734)

### DIFF
--- a/shoop/admin/templates/shoop/admin/orders/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/detail.jinja
@@ -81,8 +81,8 @@
                                 <td class="text-right">{{ line.quantity|number }}</td>
                                 <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
                                 <td class="text-right">{{ line.tax_rate|percent }}</td>
-                                <td class="text-right">{{ line.taxless_total_price|money }}</td>
-                                <td class="text-right">{{ line.taxful_total_price|money }}</td>
+                                <td class="text-right">{{ line.taxless_price|money }}</td>
+                                <td class="text-right">{{ line.taxful_price|money }}</td>
                             </tr>
                             {% endfor %}
                         </tbody>
@@ -105,10 +105,10 @@
                                         {{ line.quantity|number }} &times; {{ line.taxless_base_unit_price|money }} {% if line.taxless_discount_amount %}<span class="text-muted">{% trans %}Discount{% endtrans %}{{ line.taxless_discount_amount|money }}</span>{% endif %}
                                     </div>
                                     <div class="col-xs-6 text-right">
-                                        <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_total_price|money }}</strong>
+                                        <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_price|money }}</strong>
                                     </div>
                                     <div class="col-xs-12 text-right text-muted">
-                                        {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_total_price|money }} {% trans %}Taxless{% endtrans %})
+                                        {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_price|money }} {% trans %}Taxless{% endtrans %})
                                     </div>
                                 </div>
                             </li>

--- a/shoop/core/models/orders.py
+++ b/shoop/core/models/orders.py
@@ -269,8 +269,8 @@ class Order(models.Model):
         taxful_total = TaxfulPrice(0, self.currency)
         taxless_total = TaxlessPrice(0, self.currency)
         for line in self.lines.all():
-            taxful_total += line.taxful_total_price
-            taxless_total += line.taxless_total_price
+            taxful_total += line.taxful_price
+            taxless_total += line.taxless_price
         self.taxful_total_price = _round_price(taxful_total)
         self.taxless_total_price = _round_price(taxless_total)
 
@@ -536,7 +536,7 @@ class Order(models.Model):
             line_taxes = list(line.taxes.all())
             all_line_taxes.extend(line_taxes)
             if not line_taxes:
-                untaxed += line.taxless_total_price
+                untaxed += line.taxless_price
         return taxing.TaxSummary.from_line_taxes(all_line_taxes, untaxed)
 
     def get_product_ids_and_quantities(self):

--- a/shoop/core/order_creator/source.py
+++ b/shoop/core/order_creator/source.py
@@ -337,9 +337,9 @@ class SourceLine(TaxableItem, Priceful):
     Note: Properties like price, taxful_price, tax_rate, etc. are
     inherited from the `Priceful` mixin.
     """
-    quantity = None
-    base_unit_price = None
-    discount_amount = None
+    quantity = None  # override property from Priceful
+    base_unit_price = None  # override property from Priceful
+    discount_amount = None  # override property from Priceful
 
     _FIELDS = [
         "line_id", "parent_line_id", "type",

--- a/shoop/core/order_creator/source.py
+++ b/shoop/core/order_creator/source.py
@@ -164,9 +164,9 @@ class OrderSource(object):
             extra_data=order.extra_data,
         )
 
-    total_price = _PriceSum("total_price")
-    taxful_total_price = _PriceSum("taxful_total_price")
-    taxless_total_price = _PriceSum("taxless_total_price")
+    total_price = _PriceSum("price")
+    taxful_total_price = _PriceSum("taxful_price")
+    taxless_total_price = _PriceSum("taxless_price")
     taxful_total_price_or_none = taxful_total_price.or_none
     taxless_total_price_or_none = taxless_total_price.or_none
 
@@ -176,7 +176,7 @@ class OrderSource(object):
     taxful_total_discount_or_none = taxful_total_discount.or_none
     taxless_total_discount_or_none = taxless_total_discount.or_none
 
-    total_price_of_products = _PriceSum("total_price", "_get_product_lines")
+    total_price_of_products = _PriceSum("price", "_get_product_lines")
 
     @property
     def shipping_method(self):
@@ -334,8 +334,8 @@ class SourceLine(TaxableItem, Priceful):
     """
     Line of OrderSource.
 
-    Note: Properties like total_price, taxful_total_price, tax_rate,
-    etc. are inherited from the `Priceful` mixin.
+    Note: Properties like price, taxful_price, tax_rate, etc. are
+    inherited from the `Priceful` mixin.
     """
     quantity = None
     base_unit_price = None

--- a/shoop/core/pricing/_priceful_properties.py
+++ b/shoop/core/pricing/_priceful_properties.py
@@ -52,17 +52,3 @@ class TaxlessFrom(PriceRate):
             return TaxlessPrice(price.amount * inv_tax_ratio)
         else:
             return price
-
-
-class Alias(object):
-    def __init__(self, field):
-        self.field = field
-        self.__doc__ = "Alias of `%s`" % (field,)
-
-    def __get__(self, instance, type=None):
-        if instance is None:
-            return self
-        return getattr(instance, self.field)
-
-    def __set__(self, instance, value):
-        setattr(instance, self.field, value)

--- a/shoop/core/pricing/price_info.py
+++ b/shoop/core/pricing/price_info.py
@@ -13,29 +13,34 @@ from .price import Price
 
 
 class PriceInfo(Priceful):
+    """
+    Object for passing around pricing data of an item.
+    """
+
     price = None
     base_price = None
     quantity = None
 
-    """
-    Object for passing around pricing data of an item.
-    """
     def __init__(self, price, base_price, quantity, expires_on=None):
         """
         Initialize PriceInfo with prices and other parameters.
 
         Prices can be taxful or taxless, but their types must match.
 
-        :param Price price:
+        :type price: Price
+        :param price:
           Effective price for the specified quantity.
-        :param Price base_price:
+        :type base_price: Price
+        :param base_price:
           Base price for the specified quantity.  Discounts are
           calculated based on this.
-        :param numbers.Number quantity:
+        :type quantity: numbers.Number
+        :param quantity:
           Quantity that the given price is for.  Unit price is
           calculated by ``discounted_unit_price = price / quantity``.
           Note: Quantity could be non-integral (i.e. decimal).
-        :param numbers.Number|None expires_on:
+        :type expires_on: numbers.Number|None
+        :param expires_on:
           Timestamp, comparable to values returned by :func:`time.time`,
           determining the point in time when the prices are no longer
           valid, or None if no expire time is set (which could mean

--- a/shoop/core/pricing/priceful.py
+++ b/shoop/core/pricing/priceful.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 import decimal
 
-from ._priceful_properties import Alias, TaxfulFrom, TaxlessFrom
+from ._priceful_properties import TaxfulFrom, TaxlessFrom
 from .price import TaxfulPrice, TaxlessPrice
 
 
@@ -199,9 +199,3 @@ class Priceful(object):
 
     taxful_unit_discount_amount = TaxfulFrom('unit_discount_amount')
     taxless_unit_discount_amount = TaxlessFrom('unit_discount_amount')
-
-    # TODO: Replace occurences of these aliases with their source fields
-
-    total_price = Alias('price')
-    taxful_total_price = Alias('taxful_price')
-    taxless_total_price = Alias('taxless_price')

--- a/shoop/core/shortcuts/__init__.py
+++ b/shoop/core/shortcuts/__init__.py
@@ -36,4 +36,4 @@ def update_order_line_from_product(request, order_line, product, quantity=1, sup
     order_line.verified = False
     order_line.base_unit_price = price_info.base_unit_price
     order_line.discount_amount = price_info.discount_amount
-    assert order_line.total_price == price_info.price
+    assert order_line.price == price_info.price

--- a/shoop/core/taxing/_module.py
+++ b/shoop/core/taxing/_module.py
@@ -81,7 +81,7 @@ class TaxModule(six.with_metaclass(abc.ABCMeta)):
         :type line: shoop.core.order_creator.SourceLine
         :rtype: Iterable[LineTax]
         """
-        taxed_price = self.get_taxed_price_for(context, line, line.total_price)
+        taxed_price = self.get_taxed_price_for(context, line, line.price)
         return taxed_price.taxes
 
     @abc.abstractmethod

--- a/shoop/core/templatetags/shoop_common.py
+++ b/shoop/core/templatetags/shoop_common.py
@@ -42,7 +42,7 @@ def money(amount, digits=None, widen=0):
 
 
 @library.filter
-def percent(value, ndigits=3):
+def percent(value, ndigits=0):
     return format_percent(value, ndigits)
 
 

--- a/shoop/front/apps/personal_order_history/templates/shoop/personal_order_history/order_detail.jinja
+++ b/shoop/front/apps/personal_order_history/templates/shoop/personal_order_history/order_detail.jinja
@@ -102,8 +102,8 @@
                         {{ number_cell(line.quantity) }}
                         {{ price_or_empty_cell(line.taxless_discount_amount) }}
                         {{ number_cell(line.tax_rate|percent) }}
-                        {{ price_cell(line.taxless_total_price) }}
-                        {{ price_cell(line.taxful_total_price) }}
+                        {{ price_cell(line.taxless_price) }}
+                        {{ price_cell(line.taxful_price) }}
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/shoop/front/apps/simple_order_notification/templates.py
+++ b/shoop/front/apps/simple_order_notification/templates.py
@@ -15,9 +15,9 @@ Your order has been received and will be processed as soon as possible.
 For reference, here's a list of your order's contents.
 
 {% for line in order.lines.all() %}
-{%- if line.taxful_total_price -%}
+{%- if line.taxful_total_price %}
 * {{ line.quantity }} x {{ line.text }} - {{ line.taxful_total_price|money }}
-{%- endif -%}
+{% endif -%}
 {%- endfor %}
 
 Order Total: {{ order.taxful_total_price|money }}

--- a/shoop/front/apps/simple_order_notification/templates.py
+++ b/shoop/front/apps/simple_order_notification/templates.py
@@ -15,8 +15,8 @@ Your order has been received and will be processed as soon as possible.
 For reference, here's a list of your order's contents.
 
 {% for line in order.lines.all() %}
-{%- if line.taxful_total_price %}
-* {{ line.quantity }} x {{ line.text }} - {{ line.taxful_total_price|money }}
+{%- if line.taxful_price %}
+* {{ line.quantity }} x {{ line.text }} - {{ line.taxful_price|money }}
 {% endif -%}
 {%- endfor %}
 

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -48,7 +48,7 @@ class BasketLine(SourceLine):
         price_info = product.get_price_info(request, quantity=self.quantity)
         self.base_unit_price = price_info.base_unit_price
         self.discount_amount = price_info.discount_amount
-        assert self.total_price == price_info.price
+        assert self.price == price_info.price
         self.net_weight = product.net_weight
         self.gross_weight = product.gross_weight
         self.shipping_mode = product.shipping_mode

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -476,7 +476,7 @@ def create_order_with_product(
         product_order_line.save()
         product_order_line.taxes.add(OrderLineTax.from_tax(
             get_test_tax(tax_rate),
-            product_order_line.taxless_total_price.amount,
+            product_order_line.taxless_price.amount,
             order_line=product_order_line,
         ))
     assert order.get_product_ids_and_quantities()[product.pk] == (quantity * n_lines), "Things got added"
@@ -642,7 +642,7 @@ def create_random_order(customer=None, products=(), completion_probability=0):
             sku=product.sku,
             text=product.safe_translation_getter("name", any_language=True)
         )
-        assert line.total_price == price_info.price
+        assert line.price == price_info.price
     with atomic():
         oc = OrderCreator(request)
         order = oc.create_order(source)

--- a/shoop/themes/classic_gray/templates/classic_gray/navigation_basket_partial.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/navigation_basket_partial.jinja
@@ -32,7 +32,7 @@
                     {% for line in request.basket.get_lines() %}
                         <tr>
                             <td>{{ line.quantity|number }} &times; <a href="{{ shoop.urls.model_url(line.product) }}">{{ line.text }}</a></td>
-                            <td class="text-right">{{ line.total_price|money }}</td>
+                            <td class="text-right">{{ line.price|money }}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/product_preview.jinja
@@ -9,7 +9,10 @@
                 <div class="col-md-6 col-sm-5">
                     {% if priceinfo.is_discounted %}
                         <div class="discount">
-                            <span class="label label-danger">{% trans %}Save{% endtrans %} {{ priceinfo.discount_percentage|int }} %</span>
+                          <span class="label label-danger">
+                            {% set discount_percent = priceinfo.discount_rate|percent %}
+                            {{- _("Save %(discount_percent)s", discount_percent=discount_percent) -}}
+                          </span>
                         </div>
                     {% endif %}
                     {% set image = product.primary_image|thumbnail(size=(600,600)) %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
@@ -49,7 +49,7 @@
                 </div>
                 <div class="product-sum">
                     <h4 class="price text-right">
-                        <small>{% trans %}Total{% endtrans %}: </small>{{ line.total_price|money }}
+                        <small>{% trans %}Total{% endtrans %}: </small>{{ line.price|money }}
                         {% if line.is_discounted %}
                             <br><small><s class="text-muted">{{ line.base_price|money }}</s></small>
                         {% endif %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_confirm_table.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_confirm_table.jinja
@@ -60,7 +60,7 @@
                     {{ line.quantity|number }}
                 </td>
                 <td class="text-right">
-                    <span class="line-total">{{ line.taxful_total_price|money }}</span>
+                    <span class="line-total">{{ line.taxful_price|money }}</span>
                 </td>
             </tr>
         {% endfor %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -9,7 +9,7 @@
         <a href="{{ u }}" rel="product-detail" title="{{ product.name }}">
             {% if price_info.is_discounted %}
                 <div class="labels">
-                    <span class="label label-sale">{{ -price_info.discount_percentage|int }}%</span>
+                    <span class="label label-sale">{{ -price_info.discount_rate|percent }}</span>
                 </div>
             {% endif %}
             {% if show_image %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/partials/product_table.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/partials/product_table.jinja
@@ -57,7 +57,7 @@
                     {{ line.quantity|number }}
                 </td>
                 <td class="text-right">
-                    <span class="line-total">{{ line.taxful_total_price|money }}</span>
+                    <span class="line-total">{{ line.taxful_price|money }}</span>
                 </td>
             </tr>
         {% endfor %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -52,7 +52,10 @@
         <div class="product-image col-sm-6 col-md-5">
             {% if priceinfo.is_discounted %}
                 <div class="discount">
-                    <span class="label label-danger">{% trans %}Save{% endtrans %} {{ priceinfo.discount_percentage|int }} %</span>
+                  <span class="label label-danger">
+                    {% set discount_percent = priceinfo.discount_rate|percent %}
+                    {{- _("Save %(discount_percent)s", discount_percent=discount_percent) -}}
+                  </span>
                 </div>
             {% endif %}
             {% include "shoop/front/product/_product_images.jinja" %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/personal_order_history/order_detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/personal_order_history/order_detail.jinja
@@ -110,8 +110,8 @@
                         {{ number_cell(line.quantity) }}
                         {{ price_or_empty_cell(line.taxless_discount_amount) }}
                         {{ number_cell(line.tax_rate|percent) }}
-                        {{ price_cell(line.taxless_total_price) }}
-                        {{ price_cell(line.taxful_total_price) }}
+                        {{ price_cell(line.taxless_price) }}
+                        {{ price_cell(line.taxful_price) }}
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/shoop/themes/default_theme/templates/default/shoop/front/basket/partials/table.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/basket/partials/table.jinja
@@ -83,7 +83,7 @@
                             {% endif %}
                         </td>
                         <td class="text-right">
-                            <span class="line-total">{{ line.total_price|money }}</span>
+                            <span class="line-total">{{ line.price|money }}</span>
                         </td>
                         <td class="del-basket-line-form">
                             {% if line.can_delete %}

--- a/shoop/themes/default_theme/templates/default/shoop/front/checkout/_confirm_table.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/checkout/_confirm_table.jinja
@@ -52,7 +52,7 @@
                     {{ line.quantity|number }}
                 </td>
                 <td class="text-right">
-                    <span class="line-total">{{ line.taxful_total_price|money }}</span>
+                    <span class="line-total">{{ line.taxful_price|money }}</span>
                 </td>
             </tr>
         {% endfor %}

--- a/shoop/themes/default_theme/templates/default/shoop/front/includes/_navigation.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/includes/_navigation.jinja
@@ -79,7 +79,7 @@
                                     {% for line in request.basket.get_lines() %}
                                         <tr>
                                             <td>{{ line.quantity|number }} &times; {{ line.text }}</td>
-                                            <td class="text-right">{{ line.total_price|money }}</td>
+                                            <td class="text-right">{{ line.price|money }}</td>
                                         </tr>
                                     {% else %}
                                         <tr>

--- a/shoop/themes/default_theme/templates/default/shoop/front/macros.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/macros.jinja
@@ -17,7 +17,8 @@
             <p class="price">
                 {{ price_info.price|money }}
                 {% if price_info.is_discounted %}
-                    ({{price_info.base_price|money}}) <span class="discount-percent">{{ -price_info.discount_percentage|int }}%</span>
+                    ({{price_info.base_price|money}})
+                    <span class="discount-percent">{{ -price_info.discount_rate|percent }}</span>
                 {% endif %}
             </p>
             {% if show_description %}

--- a/shoop/themes/default_theme/templates/default/shoop/front/order/partials/product_table.jinja
+++ b/shoop/themes/default_theme/templates/default/shoop/front/order/partials/product_table.jinja
@@ -45,7 +45,7 @@
                     {{ line.quantity|number }}
                 </td>
                 <td class="text-right">
-                    <span class="line-total">{{ line.taxful_total_price|money }}</span>
+                    <span class="line-total">{{ line.taxful_price|money }}</span>
                 </td>
             </tr>
         {% endfor %}

--- a/shoop/utils/i18n.py
+++ b/shoop/utils/i18n.py
@@ -51,12 +51,10 @@ def get_current_babel_locale(fallback="en-US-POSIX"):
     return locale
 
 
-def format_percent(value, digits):
+def format_percent(value, digits=0):
     locale = get_current_babel_locale()
-    if not digits:
-        return babel.numbers.format_percent(value, locale)
     pattern = locale.percent_formats.get(None).pattern
-    new_pattern = pattern.replace("0", "0." + (digits * "#"))
+    new_pattern = pattern.replace("0", "0." + (digits * "0"))
     return babel.numbers.format_percent(value, new_pattern, locale)
 
 

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -40,7 +40,7 @@ def create_order(request, creator, customer, product):
     product_order_line = OrderLine(order=order)
     update_order_line_from_product(order_line=product_order_line, product=product, request=request, quantity=5, supplier=supplier)
     product_order_line.base_unit_price = shop.create_price(100)
-    assert product_order_line.total_price.value > 0
+    assert product_order_line.price.value > 0
     product_order_line.save()
 
     line_tax = get_line_taxes_for(product_order_line)[0]
@@ -54,7 +54,7 @@ def create_order(request, creator, customer, product):
     discount_order_line = OrderLine(order=order, quantity=1, type=OrderLineType.OTHER)
     discount_order_line.discount_amount = shop.create_price(30)
     assert discount_order_line.discount_amount.value == 30
-    assert discount_order_line.total_price.value == -30
+    assert discount_order_line.price.value == -30
     assert discount_order_line.base_unit_price.value == 0
     discount_order_line.save()
 
@@ -90,7 +90,7 @@ def get_line_taxes_for(order_line):
     tax_module = DefaultTaxModule()
     tax_ctx = tax_module.get_context_from_order_source(order_line.order)
     product = order_line.product
-    price = order_line.total_price
+    price = order_line.price
     taxed_price = tax_module.get_taxed_price_for(tax_ctx, product, price)
     return taxed_price.taxes
 

--- a/shoop_tests/core/test_methods.py
+++ b/shoop_tests/core/test_methods.py
@@ -110,12 +110,12 @@ def test_methods(admin_user, country):
         for line in final_lines:
             if line.type == OrderLineType.SHIPPING:
                 if country == "SE":  # We _are_ using Expenseefe-a Svedee Sheepping after all.
-                    assert line.total_price == source.shop.create_price("5.00")
+                    assert line.price == source.shop.create_price("5.00")
                 else:
-                    assert line.total_price == source.shop.create_price("4.00")
+                    assert line.price == source.shop.create_price("4.00")
                 assert line.text == u"Expenseefe-a Svedee Sheepping"
             if line.type == OrderLineType.PAYMENT:
-                assert line.total_price == source.shop.create_price(4)
+                assert line.price == source.shop.create_price(4)
 
 
 @pytest.mark.django_db

--- a/shoop_tests/core/test_orders.py
+++ b/shoop_tests/core/test_orders.py
@@ -70,11 +70,11 @@ def test_line_discount():
     ol.base_unit_price = order.shop.create_price(40)
     ol.save()
     ol.taxes.add(OrderLineTax.from_tax(
-        get_default_tax(), ol.taxless_total_price.amount, order_line=ol))
+        get_default_tax(), ol.taxless_price.amount, order_line=ol))
     assert ol.taxless_discount_amount == order.shop.create_price(50)
     assert ol.taxful_discount_amount == TaxfulPrice(75, currency)
-    assert ol.taxless_total_price == order.shop.create_price(150)
-    assert ol.taxful_total_price == TaxfulPrice(150 + 75, currency)
+    assert ol.taxless_price == order.shop.create_price(150)
+    assert ol.taxful_price == TaxfulPrice(150 + 75, currency)
     assert ol.taxless_base_unit_price == order.shop.create_price(40)
     assert ol.taxful_base_unit_price == TaxfulPrice(60, currency)
     assert "Thing" in six.text_type(ol)
@@ -92,13 +92,13 @@ def test_line_discount_more():
     currency = order.shop.currency
     assert ol.taxless_base_unit_price == TaxlessPrice(30, currency)
     assert ol.taxless_discount_amount == TaxlessPrice(50, currency)
-    assert ol.taxless_total_price == TaxlessPrice(5 * 30 - 50, currency)
+    assert ol.taxless_price == TaxlessPrice(5 * 30 - 50, currency)
     ol.taxes.add(OrderLineTax.from_tax(
-        get_default_tax(), ol.taxless_total_price.amount, order_line=ol))
+        get_default_tax(), ol.taxless_price.amount, order_line=ol))
     assert ol.taxless_discount_amount == TaxlessPrice(50, currency)
     assert ol.taxful_discount_amount == TaxfulPrice(75, currency)
-    assert ol.taxless_total_price == TaxlessPrice(100, currency)
-    assert ol.taxful_total_price == TaxfulPrice(150, currency)
+    assert ol.taxless_price == TaxlessPrice(100, currency)
+    assert ol.taxful_price == TaxfulPrice(150, currency)
     assert ol.taxless_base_unit_price == TaxlessPrice(30, currency)
     assert ol.taxful_base_unit_price == TaxfulPrice(45, currency)
 
@@ -121,7 +121,7 @@ def test_basic_order():
 
     discount_order_line = OrderLine(order=order, quantity=1, type=OrderLineType.OTHER)
     discount_order_line.discount_amount = price(30)
-    assert discount_order_line.total_price == price(-30)
+    assert discount_order_line.price == price(-30)
     discount_order_line.save()
 
     order.cache_prices()

--- a/shoop_tests/core/test_priceful.py
+++ b/shoop_tests/core/test_priceful.py
@@ -53,6 +53,7 @@ def test_discount_rate():
 def test_discount_percentage():
     assert line.discount_percentage == 100 * (Decimal(12) / 45)
 
+
 def test_is_discounted():
     assert line.is_discounted == True
     assert line2.is_discounted == False
@@ -63,8 +64,8 @@ def test_unit_discount_amount():
 
 
 def test_taxed_prices():
-    assert line.taxful_total_price == line.total_price
-    assert line.taxless_total_price == TaxlessPrice(30, 'EUR')  # 33 - 3
+    assert line.taxful_price == line.price
+    assert line.taxless_price == TaxlessPrice(30, 'EUR')  # 33 - 3
 
 
 def test_tax_rate_and_percentage():
@@ -158,17 +159,6 @@ def test_tax_special_cases3():
     assert taxless_line.tax_rate == 0
 
 
-def test_aliases():
-    line = Line(
-        base_unit_price=TaxfulPrice(100, 'EUR'),
-        quantity=3,
-        discount_amount=TaxfulPrice(5, 'EUR'),
-        tax_amount=Money(1, 'EUR'),
-    )
-    assert line.total_price == line.price
-    assert line.total_price == TaxfulPrice(295, 'EUR')
-
-
 def assert_almost_equal(x, y):
     assert Decimal(abs(x - y)) < 0.0000000000000000000000001
 
@@ -176,4 +166,3 @@ def assert_almost_equal(x, y):
 def test_property_docs():
     assert Line.taxful_discount_amount.__doc__ == "Taxful `discount_amount`"
     assert Line.taxless_discount_amount.__doc__ == "Taxless `discount_amount`"
-    assert Line.total_price.__doc__ == "Alias of `price`"

--- a/shoop_tests/core/test_template_tags.py
+++ b/shoop_tests/core/test_template_tags.py
@@ -39,6 +39,64 @@ def test_number_formatters_fi():
         assert number(Decimal("38.05000")) == "38,05"
 
 
+def en_percent(num, ndigits="not-given"):
+    """
+    Format given number as percent in en-US locale.
+    """
+    with translation.override("en-US"):
+        if ndigits == "not-given":
+            return percent(Decimal(num))
+        else:
+            return percent(Decimal(num), ndigits)
+
+
+def test_percent_formatter_simple():
+    assert en_percent("0.1") == "10%"
+    assert en_percent("0.16") == "16%"
+    assert en_percent("0.99") == "99%"
+
+
+def test_percent_formatter_special_numbers():
+    assert en_percent("0") == "0%"
+    assert en_percent("1") == "100%"
+    assert en_percent("2") == "200%"
+    assert en_percent("3000") == "300,000%"
+    assert en_percent("-0.1") == "-10%"
+    assert en_percent("-1") == "-100%"
+    assert en_percent("-10") == "-1,000%"
+
+
+def test_percent_formatter_default_is_0_digits():
+    assert en_percent("0.111") == "11%"
+    assert en_percent("0.111111") == "11%"
+
+
+def test_percent_formatter_more_digits():
+    assert en_percent("0.166", 1) == "16.6%"
+    assert en_percent("0.166", 2) == "16.60%"
+    assert en_percent("0.166", 3) == "16.600%"
+    assert en_percent("0.166", 9) == "16.600000000%"
+    assert en_percent("0.1", 1) == "10.0%"
+    assert en_percent("0.1", 2) == "10.00%"
+    assert en_percent("0.1", 3) == "10.000%"
+    assert en_percent("0", 1) == "0.0%"
+
+
+def test_percent_formatter_fewer_digits():
+    assert en_percent("0.11111", 2) ==  "11.11%"
+    assert en_percent("0.11111", 1) ==  "11.1%"
+    assert en_percent("0.11111", 0) ==  "11%"
+
+
+def test_percent_formatter_fewer_digits_rounding():
+    assert en_percent("0.2714", 1) == "27.1%"
+    assert en_percent("0.2715", 1) == "27.2%"  # towards even
+    assert en_percent("0.2716", 1) == "27.2%"
+    assert en_percent("0.2724", 1) == "27.2%"
+    assert en_percent("0.2725", 1) == "27.2%"  # towards even
+    assert en_percent("0.2726", 1) == "27.3%"
+
+
 def test_money_formatter_en():
     with translation.override("en-US"):
         assert money(Money("29.99", "USD")) == "$29.99"

--- a/shoop_tests/functional/test_tax_system.py
+++ b/shoop_tests/functional/test_tax_system.py
@@ -55,7 +55,7 @@ def test_stacked_tax_taxless_price():
             line = source.get_final_lines(with_taxes=True)[0]
             assert isinstance(line, SourceLine)
             assert line.taxes
-            assert line.taxful_total_price.value == Decimal("10.800")
+            assert line.taxful_price.value == Decimal("10.800")
             source.uncache()
 
             # Let's move out to a taxless location.
@@ -63,7 +63,7 @@ def test_stacked_tax_taxless_price():
             line = source.get_final_lines(with_taxes=True)[0]
             assert isinstance(line, SourceLine)
             assert not line.taxes
-            assert line.taxful_total_price.value == Decimal("10")
+            assert line.taxful_price.value == Decimal("10")
 
 
 @pytest.mark.django_db
@@ -83,8 +83,8 @@ def test_stacked_tax_taxful_price():
             line = source.get_final_lines(with_taxes=True)[0]
             assert isinstance(line, SourceLine)
             assert line.taxes
-            assert line.taxful_total_price == TaxfulPrice(20, 'EUR')
-            assert_almost_equal(line.taxless_total_price, TaxlessPrice("18.518518", 'EUR'))
+            assert line.taxful_price == TaxfulPrice(20, 'EUR')
+            assert_almost_equal(line.taxless_price, TaxlessPrice("18.518518", 'EUR'))
             source.uncache()
 
             # Let's move out to a taxless location.
@@ -92,8 +92,8 @@ def test_stacked_tax_taxful_price():
             line = source.get_final_lines(with_taxes=True)[0]
             assert isinstance(line, SourceLine)
             assert not line.taxes
-            assert line.taxful_total_price == TaxfulPrice(20, source.currency)
-            assert line.taxless_total_price.value == Decimal("20")
+            assert line.taxful_price == TaxfulPrice(20, source.currency)
+            assert line.taxless_price.value == Decimal("20")
 
 
 def assert_almost_equal(x, y):


### PR DESCRIPTION
The Priceful interface was introduced a while ago, but the refactoring
was not done through.  This step of unifying `price`/`total_price`
usages was left, so do it now for cleaning up our code base.

Also includes couple somewhat unrelated fixes that were found while
doing this.

Refs SHOOP-1636/SHOOP-1734