### PR TITLE
Move apply_request_middleware to testing

### DIFF
--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -41,9 +41,9 @@ from shoop.default_tax.models import TaxRule
 from shoop.testing.text_data import random_title
 from shoop.utils.filer import filer_image_from_data
 from shoop.utils.money import Money
-from shoop_tests.utils import apply_request_middleware
 
 from .image_generator import generate_image
+from .utils import apply_request_middleware
 
 DEFAULT_IDENTIFIER = "default"
 DEFAULT_NAME = "Default"

--- a/shoop/testing/utils.py
+++ b/shoop/testing/utils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.conf import settings
+from django.core.exceptions import MiddlewareNotUsed
+from django.utils.module_loading import import_string
+
+
+def apply_request_middleware(request, **attrs):
+    """
+    Apply all the `process_request` capable middleware configured
+    into the given request.
+
+    :param request: The request to massage.
+    :type request: django.http.HttpRequest
+    :param attrs: Additional attributes to set after massage.
+    :type attrs: dict
+    :return: The same request, massaged in-place.
+    :rtype: django.http.HttpRequest
+    """
+    for middleware_path in settings.MIDDLEWARE_CLASSES:
+        mw_class = import_string(middleware_path)
+        try:
+            mw_instance = mw_class()
+        except MiddlewareNotUsed:
+            continue
+
+        if hasattr(mw_instance, 'process_request'):
+            mw_instance.process_request(request)
+    for key, value in attrs.items():
+        setattr(request, key, value)
+    return request

--- a/shoop_tests/admin/test_contact_page.py
+++ b/shoop_tests/admin/test_contact_page.py
@@ -10,7 +10,7 @@ from django.core import mail
 import pytest
 from shoop.admin.modules.contacts.views.reset import ContactResetPasswordView
 from shoop.testing.factories import get_default_shop, create_random_person
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_media_module.py
+++ b/shoop_tests/admin/test_media_module.py
@@ -11,7 +11,8 @@ from six import BytesIO
 
 from shoop.admin.modules.media.views import MediaBrowserView
 from shoop.testing.factories import get_default_shop
-from shoop_tests.utils import apply_request_middleware, printable_gibberish
+from shoop.testing.utils import apply_request_middleware
+from shoop_tests.utils import printable_gibberish
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_modules.py
+++ b/shoop_tests/admin/test_modules.py
@@ -20,9 +20,10 @@ from shoop.admin.menu import get_menu_entry_categories
 from shoop.admin.module_registry import replace_modules, get_module_urls, get_modules
 from shoop.admin.views.search import get_search_results
 from shoop.testing.factories import get_default_shop
+from shoop.testing.utils import apply_request_middleware
 from shoop.utils.excs import Problem
 from shoop_tests.admin.fixtures.test_module import TestModule
-from shoop_tests.utils import empty_iterable, apply_request_middleware
+from shoop_tests.utils import empty_iterable
 from shoop_tests.utils.faux_users import AnonymousUser, StaffUser, SuperUser, AuthenticatedUser
 from shoop_tests.utils.templates import get_templates_setting_for_specific_directories
 

--- a/shoop_tests/admin/test_multishop_setting.py
+++ b/shoop_tests/admin/test_multishop_setting.py
@@ -9,7 +9,7 @@ import pytest
 
 from shoop.admin.modules.shops.views.edit import ShopEditView
 from shoop.testing.factories import get_default_shop
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 from shoop.utils.excs import Problem
 
 

--- a/shoop_tests/admin/test_order_creator.py
+++ b/shoop_tests/admin/test_order_creator.py
@@ -8,7 +8,8 @@ from shoop.testing.factories import (
     get_default_supplier, get_default_shop,
     get_default_shipping_method, get_initial_order_status
 )
-from shoop_tests.utils import printable_gibberish, apply_request_middleware, assert_contains
+from shoop.testing.utils import apply_request_middleware
+from shoop_tests.utils import printable_gibberish, assert_contains
 from shoop.admin.modules.orders.views.create import OrderCreateView
 
 TEST_COMMENT = "Hello. Is it me you're looking for?"

--- a/shoop_tests/admin/test_order_module.py
+++ b/shoop_tests/admin/test_order_module.py
@@ -10,7 +10,7 @@ from shoop.admin.modules.orders.dashboard import OrderValueChartDashboardBlock
 from shoop.admin.modules.orders.views.detail import OrderSetStatusView
 from shoop.core.models.orders import OrderStatusRole, OrderStatus, Order
 from shoop.testing.factories import create_random_order, get_default_product, create_random_person
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_product_module.py
+++ b/shoop_tests/admin/test_product_module.py
@@ -13,8 +13,9 @@ from shoop.admin.utils.urls import get_model_url
 from shoop.admin.views.search import get_search_results
 from shoop.core.models import ProductVisibility
 from shoop_tests.admin.utils import admin_only_urls
-from shoop_tests.utils import empty_iterable, apply_request_middleware
+from shoop_tests.utils import empty_iterable
 from shoop.testing.factories import get_default_product, get_default_shop, create_product
+from shoop.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_tax_module.py
+++ b/shoop_tests/admin/test_tax_module.py
@@ -12,7 +12,7 @@ from shoop.admin.modules.taxes import TaxModule
 from shoop.admin.modules.taxes.views import TaxClassEditView
 from shoop.testing.factories import get_default_shop, get_default_tax_class
 from shoop_tests.admin.utils import admin_only_urls
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_user_module.py
+++ b/shoop_tests/admin/test_user_module.py
@@ -13,8 +13,9 @@ from shoop.admin.modules.users.views import UserDetailView
 from shoop.core.models.contacts import Contact
 from shoop.testing.factories import get_default_shop, create_random_person
 from shoop.testing.soup_utils import extract_form_fields
+from shoop.testing.utils import apply_request_middleware
 from shoop.utils.excs import Problem
-from shoop_tests.utils import apply_request_middleware, printable_gibberish
+from shoop_tests.utils import printable_gibberish
 
 
 @pytest.mark.django_db

--- a/shoop_tests/admin/test_views.py
+++ b/shoop_tests/admin/test_views.py
@@ -13,7 +13,7 @@ from shoop.testing.factories import (
     create_random_person, get_default_shop
 )
 from shoop.utils.importing import load
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 
 
 @pytest.mark.parametrize("class_spec", [

--- a/shoop_tests/core/test_order_creator.py
+++ b/shoop_tests/core/test_order_creator.py
@@ -12,7 +12,7 @@ from shoop.core.order_creator import OrderCreator, OrderSource, SourceLine
 from shoop.testing.factories import get_address, get_default_shop, get_default_payment_method, \
     get_default_shipping_method, get_default_product, get_default_supplier, get_initial_order_status
 from shoop.utils.models import get_data_dict
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 
 def test_invalid_order_source_updating():

--- a/shoop_tests/core/test_product_packages.py
+++ b/shoop_tests/core/test_product_packages.py
@@ -12,7 +12,7 @@ from shoop.core.models import OrderLineType, AnonymousContact, ProductMode, Shop
 from shoop.core.order_creator import OrderCreator
 from shoop.core.order_creator.source import SourceLine
 from shoop.testing.factories import create_product, get_default_shop, get_default_supplier, get_initial_order_status
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 import six
 

--- a/shoop_tests/front/test_middleware.py
+++ b/shoop_tests/front/test_middleware.py
@@ -14,7 +14,7 @@ from shoop.admin.urls import login
 from shoop.front.middleware import ShoopFrontMiddleware
 from shoop.front.views.index import IndexView
 from shoop.testing.factories import get_default_shop
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils.fixtures import regular_user
 from .fixtures import get_request
 

--- a/shoop_tests/front/test_simple_search.py
+++ b/shoop_tests/front/test_simple_search.py
@@ -10,7 +10,7 @@ from django.utils import translation
 import pytest
 from shoop.front.apps.simple_search.views import get_search_product_ids, SearchView
 from shoop.testing.factories import get_default_product, get_default_shop, create_product
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 
 
 UNLIKELY_STRING = "TJiCrQWaGChYNathovfViXPWO"

--- a/shoop_tests/simple_cms/test_page_view.py
+++ b/shoop_tests/simple_cms/test_page_view.py
@@ -12,7 +12,7 @@ from shoop.simple_cms.views import PageView
 from shoop.testing.factories import get_default_shop
 from django.utils import translation
 from shoop_tests.simple_cms.utils import create_page, create_multilanguage_page
-from shoop_tests.utils import apply_request_middleware
+from shoop.testing.utils import apply_request_middleware
 from django.core.cache import cache
 
 

--- a/shoop_tests/utils/__init__.py
+++ b/shoop_tests/utils/__init__.py
@@ -15,11 +15,9 @@ import types
 from bs4 import BeautifulSoup
 
 from django.conf import settings
-from django.core.exceptions import MiddlewareNotUsed
 from django.core.urlresolvers import set_urlconf, clear_url_caches, get_urlconf
 from django.test import override_settings, Client, TestCase
 from django.utils.crypto import get_random_string
-from django.utils.module_loading import import_string
 from django.utils.timezone import now
 
 
@@ -100,32 +98,6 @@ def error_exists(errors, code):
 
 def error_does_not_exist(errors, code):
     return error_code_test(errors, False, code)
-
-
-def apply_request_middleware(request, **attrs):
-    """
-    Apply all the `process_request` capable middleware configured
-    into the given request.
-
-    :param request: The request to massage.
-    :type request: django.http.HttpRequest
-    :param attrs: Additional attributes to set after massage.
-    :type attrs: dict
-    :return: The same request, massaged in-place.
-    :rtype: django.http.HttpRequest
-    """
-    for middleware_path in settings.MIDDLEWARE_CLASSES:
-        mw_class = import_string(middleware_path)
-        try:
-            mw_instance = mw_class()
-        except MiddlewareNotUsed:
-            continue
-
-        if hasattr(mw_instance, 'process_request'):
-            mw_instance.process_request(request)
-    for key, value in attrs.items():
-        setattr(request, key, value)
-    return request
 
 
 def very_recently(datetime, how_recently=1):


### PR DESCRIPTION
In `shoop.testing.factories` there was an import from `shoop_tests` for
`apply_request_middleware` function.  This caused `shoop.testing` to
depend on BeautifulSoup, since `shoop_tests.utils` imports `bs4`.  This
dependency is undesirable and not even stated in `setup.py`.

Fix this by moving the `apply_request_middleware` to
`shoop.testing.utils` and update its users accordingly.