### PR TITLE
Fix couple tax related terms

### DIFF
--- a/doc/taxes.rst
+++ b/doc/taxes.rst
@@ -80,7 +80,7 @@ default_tax.TaxRule
   * regions (regexp? :D)
   * postal_codes (regexp? :D)
   * tax (FK)
-  * priority (Rules with same priority are value-added (e.g. US taxes)
+  * priority (Rules with same priority are added (e.g. US taxes)
     and rules with different priority are compound taxes (e.g. Canada
     Quobec PST usecase))
 

--- a/shoop/core/taxing/utils.py
+++ b/shoop/core/taxing/utils.py
@@ -15,7 +15,7 @@ from ._price import TaxedPrice
 
 def stacked_value_added_taxes(price, taxes):
     """
-    Stack value-added taxes on the given price without compounding.
+    Stack added taxes on the given price without compounding.
 
     Note that this will not take compound taxation (Quebec) into account.
 

--- a/shoop/default_tax/migrations/0006_taxrule_help_texts.py
+++ b/shoop/default_tax/migrations/0006_taxrule_help_texts.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('default_tax', '0005_taxrule_override_group'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='taxrule',
+            name='override_group',
+            field=models.IntegerField(help_text='If several rules match, only the rules with the highest override group number will be effective.  This can be used, for example, to implement tax exemption by adding a rule with very high override group that sets a zero tax.', default=0, verbose_name='override group number'),
+        ),
+        migrations.AlterField(
+            model_name='taxrule',
+            name='priority',
+            field=models.IntegerField(help_text='Rules with same priority define added taxes (e.g. US taxes) and rules with different priority define compound taxes (e.g. Canada Quebec PST case)', default=0, verbose_name='priority'),
+        ),
+    ]

--- a/shoop/default_tax/models.py
+++ b/shoop/default_tax/models.py
@@ -36,8 +36,8 @@ class TaxRule(models.Model):
     priority = models.IntegerField(
         default=0,
         verbose_name=_("priority"), help_text=_(
-            "Rules with same priority are value-added (e.g. US taxes) "
-            "and rules with different priority are compound taxes "
+            "Rules with same priority define added taxes (e.g. US taxes) "
+            "and rules with different priority define compound taxes "
             "(e.g. Canada Quebec PST case)"))
     override_group = models.IntegerField(
         default=0,
@@ -45,7 +45,7 @@ class TaxRule(models.Model):
             "If several rules match, only the rules with the highest "
             "override group number will be effective.  This can be "
             "used, for example, to implement tax exemption by adding "
-            "a rule with very high priority that sets a zero tax."))
+            "a rule with very high override group that sets a zero tax."))
     tax = models.ForeignKey(Tax, on_delete=models.PROTECT)
 
     def matches(self, taxing_context):


### PR DESCRIPTION
* Rephrase "value added taxes" to "added taxes"
  - Value added taxes (VAT) is totally different thing as the taxes added
    together, which usually is used to implement sales taxes.
* Fix error in TaxRule help text: "priority" to "override group"

Refs SHOOP-1636