### PR TITLE
Set default country in checkout address forms

### DIFF
--- a/shoop/front/checkout/addresses.py
+++ b/shoop/front/checkout/addresses.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.conf import settings
 from django.forms.models import model_to_dict
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic.edit import FormView
@@ -23,6 +24,12 @@ class AddressForm(forms.ModelForm):
     class Meta:
         model = Address
         fields = ("name", "phone", "email", "street", "street2", "postal_code", "city", "region", "country")
+
+    def __init__(self, **kwargs):
+        super(AddressForm, self).__init__(**kwargs)
+        if not kwargs.get("instance"):
+            # Set default country
+            self.fields["country"].initial = settings.SHOOP_ADDRESS_HOME_COUNTRY
 
 
 class CompanyForm(TaxNumberCleanMixin, forms.ModelForm):

--- a/shoop/front/checkout/single_page.py
+++ b/shoop/front/checkout/single_page.py
@@ -8,6 +8,7 @@
 from __future__ import unicode_literals
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
@@ -27,6 +28,12 @@ class AddressForm(forms.ModelForm):
     class Meta:
         model = Address
         fields = ("name", "phone", "email", "street", "street2", "postal_code", "city", "region", "country")
+
+    def __init__(self, **kwargs):
+        super(AddressForm, self).__init__(**kwargs)
+        if not kwargs.get("instance"):
+            # Set default country
+            self.fields["country"].initial = settings.SHOOP_ADDRESS_HOME_COUNTRY
 
 
 def _to_choices(objects):

--- a/shoop_tests/front/test_checkout.py
+++ b/shoop_tests/front/test_checkout.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.test import override_settings
+
+from shoop.front.checkout.addresses import AddressForm
+from shoop.front.checkout.single_page import AddressForm as SinglePageAddressForm
+
+
+def test_checkout_addresses_has_no_default_country():
+    form = AddressForm()
+    assert form.fields["country"].initial is None
+
+
+@override_settings(SHOOP_ADDRESS_HOME_COUNTRY="FI")
+def test_checkout_addresses_has_default_country():
+    form = AddressForm()
+    assert form.fields["country"].initial == "FI"
+
+
+def test_checkout_singlepage_addresses_has_no_default_country():
+    form = SinglePageAddressForm()
+    assert form.fields["country"].initial is None
+
+
+@override_settings(SHOOP_ADDRESS_HOME_COUNTRY="FI")
+def test_checkout_singlepage_addresses_has_default_country():
+    form = SinglePageAddressForm()
+    assert form.fields["country"].initial == "FI"


### PR DESCRIPTION
If SHOOP_ADDRESS_HOME_COUNTRY is set, prefill that as country in address forms.

Rationale: shops are often based in a certain country, operating mostly in that area. Prefill a default country in address forms to help the majority of users.