### PR TITLE
Don't use `from django.conf import settings` in app init modules.

### DIFF
--- a/shoop/front/__init__.py
+++ b/shoop/front/__init__.py
@@ -5,7 +5,7 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
-from django.conf import settings
+import django.conf
 from shoop.apps import AppConfig
 from shoop.apps.settings import validate_templates_configuration
 
@@ -26,8 +26,7 @@ class ShoopFrontAppConfig(AppConfig):
 
     def ready(self):
         validate_templates_configuration()
-
-        if settings.SHOOP_FRONT_INSTALL_ERROR_HANDLERS:
+        if django.conf.settings.SHOOP_FRONT_INSTALL_ERROR_HANDLERS:
             from .error_handling import install_error_handlers
             install_error_handlers()
 

--- a/shoop/themes/classic_gray/__init__.py
+++ b/shoop/themes/classic_gray/__init__.py
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree.
 
 from django import forms
-from django.conf import settings
+import django.conf
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
@@ -51,7 +51,7 @@ class ClassicGrayTheme(Theme):
                 yield {"url": url}
 
     def _format_cms_links(self, **query_kwargs):
-        if "shoop.simple_cms" not in settings.INSTALLED_APPS:
+        if "shoop.simple_cms" not in django.conf.settings.INSTALLED_APPS:
             return
         from shoop.simple_cms.models import Page
         for page in Page.objects.visible().filter(**query_kwargs):

--- a/shoop_tests/utils/__init__.py
+++ b/shoop_tests/utils/__init__.py
@@ -14,7 +14,7 @@ import types
 
 from bs4 import BeautifulSoup
 
-from django.conf import settings
+import django.conf
 from django.core.urlresolvers import set_urlconf, clear_url_caches, get_urlconf
 from django.test import override_settings, Client, TestCase
 from django.utils.crypto import get_random_string
@@ -64,7 +64,7 @@ def replace_urls(patterns, extra=None):
     :param extra: Dict to add to the created urlconf
     :type extra: dict
     """
-    old_urlconf = get_urlconf(default=settings.ROOT_URLCONF)
+    old_urlconf = get_urlconf(default=django.conf.settings.ROOT_URLCONF)
     urlconf_module_name = "replace_urls_%s" % uuid.uuid4()
     module = types.ModuleType(urlconf_module_name)
     module.urlpatterns = patterns


### PR DESCRIPTION
When `fooapp.settings` is imported, that `settings` is injected into the
`fooapp` parent module, overriding the `django.conf` import, making it
impossible to actually access `django.conf.settings`.

Notably, this caused `shoop.front` to never actually honor
`SHOOP_FRONT_INSTALL_ERROR_HANDLERS`, which in kind made application
initialization begin importing the root urlconf, which in the case of e.g.
Django-CMS caused database accesses, causing exceptions during migration.