### PR TITLE
Assign created customers to CustomerTaxGroups on creation

### DIFF
--- a/shoop/core/management/commands/shoop_init.py
+++ b/shoop/core/management/commands/shoop_init.py
@@ -13,7 +13,8 @@ from six import print_
 
 from shoop.core.defaults.order_statuses import create_default_order_statuses
 from shoop.core.models import (
-    Category, OrderStatus, PaymentMethod, ProductType, SalesUnit, ShippingMethod, Shop, ShopStatus, Supplier, TaxClass
+    Category, CustomerTaxGroup, OrderStatus, PaymentMethod, ProductType, SalesUnit, ShippingMethod, Shop, ShopStatus,
+    Supplier, TaxClass
 )
 
 
@@ -32,6 +33,8 @@ class Initializer(object):
         schema(Supplier, "default", name="Default Supplier"),
         schema(SalesUnit, "pcs", name="Pieces"),
         schema(Category, "default", name="Default Category"),
+        schema(CustomerTaxGroup, "default_person_customers", name="Retail Customers"),
+        schema(CustomerTaxGroup, "default_company_customers", name="Company Customers")
     ]
 
     def __init__(self):

--- a/shoop/core/models/taxes.py
+++ b/shoop/core/models/taxes.py
@@ -110,3 +110,17 @@ class CustomerTaxGroup(TranslatableShoopModel):
     class Meta:
         verbose_name = _('customer tax group')
         verbose_name_plural = _('customer tax groups')
+
+    @classmethod
+    def get_default_person_group(cls):
+        obj, c = CustomerTaxGroup.objects.get_or_create(identifier="default_person_customers", defaults={
+            "name": _("Retail Customers")
+        })
+        return obj
+
+    @classmethod
+    def get_default_company_group(cls):
+        obj, c = CustomerTaxGroup.objects.get_or_create(identifier="default_company_customers", defaults={
+            "name": _("Company Customers")
+        })
+        return obj

--- a/shoop_tests/core/test_customers.py
+++ b/shoop_tests/core/test_customers.py
@@ -6,7 +6,7 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
-from shoop.core.models import CompanyContact, PersonContact, get_person_contact
+from shoop.core.models import CompanyContact, PersonContact, get_person_contact, CustomerTaxGroup
 from shoop.testing.factories import DEFAULT_NAME, get_default_customer_group, DEFAULT_IDENTIFIER
 
 
@@ -34,3 +34,17 @@ def test_companies(django_user_model):
             off = (cx * 3 + x) % len(peons)
             contact = get_person_contact(user=peons[off])
             company.members.add(contact)
+
+
+@pytest.mark.django_db
+def test_customer_tax_group1():
+    # test that created person is assigned to proper group
+    person = PersonContact.objects.create(email="test@example.com", name="Test Tester")
+    assert person.tax_group.identifier == "default_person_customers"
+
+
+@pytest.mark.django_db
+def test_customer_tax_group2():
+    # test that created company is assigned to proper group
+    company = CompanyContact.objects.create(email="test@example.com", name="Test Tester", tax_number="FI123123")
+    assert company.tax_group.identifier == "default_company_customers"

--- a/shoop_tests/core/test_taxes.py
+++ b/shoop_tests/core/test_taxes.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.utils.translation import activate
+from shoop.core.models import CustomerTaxGroup
+
+
+@pytest.mark.django_db
+def test_customertaxgroup():
+    activate("en")
+    person_group = CustomerTaxGroup.get_default_person_group()
+    assert CustomerTaxGroup.objects.count() == 1
+    assert person_group.identifier == "default_person_customers"
+    assert person_group.name == "Retail Customers"
+
+    company_group = CustomerTaxGroup.get_default_company_group()
+    assert CustomerTaxGroup.objects.count() == 2
+    assert company_group.identifier == "default_company_customers"
+    assert company_group.name == "Company Customers"


### PR DESCRIPTION
Add default group getters for `CustomerTaxGroup`
Add default tax groups to `shoop_init` management command

Refs SHOOP-1621