### PR TITLE
Deny price unit changes of in-use Shop (SHOOP-1658)

### DIFF
--- a/shoop/admin/modules/shops/views/edit.py
+++ b/shoop/admin/modules/shops/views/edit.py
@@ -33,6 +33,7 @@ class ShopEditView(CreateOrUpdateView):
     form_class = ShopForm
     template_name = "shoop/admin/shops/edit.jinja"
     context_object_name = "shop"
+    add_form_errors_as_messages = True
 
     def get_object(self, queryset=None):
         obj = super(ShopEditView, self).get_object(queryset)

--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -56,7 +56,7 @@ class ChangeProtected(object):
         super(ChangeProtected, self).clean(*args, **kwargs)
         if self.pk:
             changed_protected_fields = self._get_changed_protected_fields()
-            if changed_protected_fields and self._is_in_use():
+            if changed_protected_fields and self._are_changes_protected():
                 message = "{change_protect_message}: {fields}".format(
                     change_protect_message=self.change_protect_message,
                     fields=", ".join(sorted(changed_protected_fields)),
@@ -67,7 +67,15 @@ class ChangeProtected(object):
         self.clean()
         super(ChangeProtected, self).save(*args, **kwargs)
 
-    def _is_in_use(self):
+    def _are_changes_protected(self):
+        """
+        Check if changes of this object should be protected.
+
+        This can be overridden in the subclasses to make it possible to
+        avoid change protection e.g. if object is not in use yet.
+
+        The base class implementation just returns True.
+        """
         return True
 
     def _get_changed_protected_fields(self):

--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -48,6 +48,7 @@ class TranslatableShoopModel(ShoopModel, parler.models.TranslatableModel):
 
 
 class ChangeProtected(object):
+    protected_fields = None
     unprotected_fields = []
     change_protect_message = _("The following fields can not be changed")
 
@@ -70,9 +71,12 @@ class ChangeProtected(object):
         return True
 
     def _get_changed_protected_fields(self):
-        protected_fields = [
-            x.name for x in self._meta.get_fields()
-            if not x.is_relation and x.name not in self.unprotected_fields]
+        if self.protected_fields is not None:
+            protected_fields = self.protected_fields
+        else:
+            protected_fields = [
+                x.name for x in self._meta.get_fields()
+                if not x.is_relation and x.name not in self.unprotected_fields]
         in_db = type(self).objects.get(pk=self.pk)
         return [
             field for field in protected_fields

--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -47,19 +47,19 @@ class TranslatableShoopModel(ShoopModel, parler.models.TranslatableModel):
         abstract = True
 
 
-class ImmutableMixin(object):
+class ChangeProtected(object):
     unprotected_fields = []
     immutability_message = _("Cannot change immutable object that is in use")
 
     def clean(self, *args, **kwargs):
-        super(ImmutableMixin, self).clean(*args, **kwargs)
+        super(ChangeProtected, self).clean(*args, **kwargs)
         if self.pk:
             if self._has_any_protected_field_changed() and self._is_in_use():
                 raise ValidationError(self.immutability_message)
 
     def save(self, *args, **kwargs):
         self.clean()
-        super(ImmutableMixin, self).save(*args, **kwargs)
+        super(ChangeProtected, self).save(*args, **kwargs)
 
     def _is_in_use(self):
         return True

--- a/shoop/core/models/order_lines.py
+++ b/shoop/core/models/order_lines.py
@@ -57,7 +57,7 @@ class OrderLineManager(models.Manager):
 
 
 @python_2_unicode_compatible
-class OrderLine(models.Model, Priceful):
+class OrderLine(MoneyPropped, models.Model, Priceful):
     order = UnsavedForeignKey("Order", related_name='lines', on_delete=models.PROTECT, verbose_name=_('order'))
     product = UnsavedForeignKey(
         "Product", blank=True, null=True, related_name="order_lines",

--- a/shoop/core/models/orders.py
+++ b/shoop/core/models/orders.py
@@ -36,7 +36,9 @@ from shoop.core.utils.reference import get_order_identifier, get_reference_numbe
 from shoop.utils.analog import LogEntryKind, define_log_model
 from shoop.utils.money import Money
 from shoop.utils.numbers import bankers_round
-from shoop.utils.properties import TaxfulPriceProperty, TaxlessPriceProperty
+from shoop.utils.properties import (
+    MoneyPropped, TaxfulPriceProperty, TaxlessPriceProperty,
+)
 
 from .order_lines import OrderLineType
 
@@ -151,7 +153,7 @@ class OrderQuerySet(models.QuerySet):
 
 
 @python_2_unicode_compatible
-class Order(models.Model):
+class Order(MoneyPropped, models.Model):
     # Identification
     shop = UnsavedForeignKey("Shop", on_delete=models.PROTECT)
     created_on = models.DateTimeField(auto_now_add=True, editable=False)

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -70,5 +70,5 @@ class Shop(ChangeProtected, TranslatableShoopModel):
         else:
             return TaxlessPrice(value, self.currency)
 
-    def _is_in_use(self):
+    def _are_changes_protected(self):
         return Order.objects.filter(shop=self).exists()

--- a/shoop/core/models/taxes.py
+++ b/shoop/core/models/taxes.py
@@ -16,10 +16,10 @@ from shoop.core.fields import CurrencyField, InternalIdentifierField, MoneyValue
 from shoop.utils.i18n import format_money, format_percent
 from shoop.utils.properties import MoneyProperty, MoneyPropped
 
-from ._base import ImmutableMixin, TranslatableShoopModel
+from ._base import ChangeProtected, TranslatableShoopModel
 
 
-class Tax(MoneyPropped, ImmutableMixin, TranslatableShoopModel):
+class Tax(MoneyPropped, ChangeProtected, TranslatableShoopModel):
     identifier_attr = 'code'
 
     immutability_message = _(

--- a/shoop/core/models/taxes.py
+++ b/shoop/core/models/taxes.py
@@ -80,7 +80,7 @@ class Tax(MoneyPropped, ChangeProtected, TranslatableShoopModel):
             text += " ({})".format(format_money(self.amount))
         return text
 
-    def _is_in_use(self):
+    def _are_changes_protected(self):
         return self.order_line_taxes.exists()
 
     class Meta:

--- a/shoop/core/models/taxes.py
+++ b/shoop/core/models/taxes.py
@@ -22,7 +22,7 @@ from ._base import ChangeProtected, TranslatableShoopModel
 class Tax(MoneyPropped, ChangeProtected, TranslatableShoopModel):
     identifier_attr = 'code'
 
-    immutability_message = _(
+    change_protect_message = _(
         "Cannot change business critical fields of Tax that is in use")
     unprotected_fields = ['enabled']
 

--- a/shoop/front/models/stored_basket.py
+++ b/shoop/front/models/stored_basket.py
@@ -13,14 +13,16 @@ from django.utils.crypto import get_random_string
 
 from shoop.core.fields import CurrencyField, MoneyValueField, TaggedJSONField
 from shoop.core.models import Contact, PersonContact, Product, Shop
-from shoop.utils.properties import TaxfulPriceProperty, TaxlessPriceProperty
+from shoop.utils.properties import (
+    MoneyPropped, TaxfulPriceProperty, TaxlessPriceProperty,
+)
 
 
 def generate_key():
     return get_random_string(32)
 
 
-class StoredBasket(models.Model):
+class StoredBasket(MoneyPropped, models.Model):
     # A combination of the PK and key is used to retrieve a basket for session situations.
     key = models.CharField(max_length=32, default=generate_key)
 


### PR DESCRIPTION
Changing currency or taxfulness of Shop's prices while it has any orders
is not good, so deny it.

Also rename ImmutableMixin to ChangeProtected and improve it a bit and
make the non-field errors visible in ShopEditView.