### PR TITLE
Protected fields

### DIFF
--- a/shoop/admin/modules/shops/views/edit.py
+++ b/shoop/admin/modules/shops/views/edit.py
@@ -11,14 +11,17 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.admin.forms.widgets import MediaChoiceWidget
-from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.admin.toolbar import get_default_edit_toolbar
+from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.core.models import Shop
+from shoop.core.utils.form_mixins import ProtectedFieldsMixin
 from shoop.utils.excs import Problem
 from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
 
 
-class ShopForm(MultiLanguageModelForm):
+class ShopForm(ProtectedFieldsMixin, MultiLanguageModelForm):
+    change_protect_field_text = _("This field cannot be changed since there are existing orders for this shop.")
+
     class Meta:
         model = Shop
         exclude = ("owner", "options")

--- a/shoop/core/models/shops.py
+++ b/shoop/core/models/shops.py
@@ -35,6 +35,7 @@ class ShopStatus(Enum):
 @python_2_unicode_compatible
 class Shop(ChangeProtected, TranslatableShoopModel):
     protected_fields = ["currency", "prices_include_tax"]
+    change_protect_message = _("The following fields cannot be changed since there are existing orders for this shop")
 
     identifier = InternalIdentifierField(unique=True)
     domain = models.CharField(max_length=128, blank=True, null=True, unique=True)

--- a/shoop/core/utils/form_mixins.py
+++ b/shoop/core/utils/form_mixins.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.utils.translation import ugettext_lazy as _
+
+
+class ProtectedFieldsMixin(object):
+    change_protect_field_text = _("This field cannot be changed since it is protected.")
+
+    def _get_protected_fields(self):
+        """
+        Get a tuple of protected fields if set.
+        The fields are set in model level when model has `ChangeProtected`
+        """
+        if self.instance and self.instance.pk:
+            are_changes_protected = getattr(self.instance, "_are_changes_protected", None)
+            if are_changes_protected:  # Supports the `_are_changes_protected` protocol?
+                if not are_changes_protected():  # Not protected though?
+                    return ()  # Nothing protected, then.
+            return getattr(self.instance, "protected_fields", ())
+        return ()
+
+    def disable_protected_fields(self):
+        for field in self._get_protected_fields():
+            self.fields[field].widget.attrs["disabled"] = True
+            self.fields[field].help_text = self.change_protect_field_text
+            self.fields[field].required = False
+
+    def clean_protected_fields(self, cleaned_data):
+        """
+        Ignore protected fields (they are set to `disabled`,
+        so they will not be in the form data).
+
+        As a side effect, this removes the fields from `changed_data` too.
+
+        :param cleaned_data: Cleaned data
+        :type cleaned_data: dict
+        :return: Cleaned data without protected field data
+        :rtype: dict
+        """
+        for field in self._get_protected_fields():
+            if field in self.changed_data:
+                self.changed_data.remove(field)
+            cleaned_data[field] = getattr(self.instance, field)
+        return cleaned_data
+
+    def clean(self):
+        return self.clean_protected_fields(super(ProtectedFieldsMixin, self).clean())
+
+    def __init__(self, **kwargs):
+        super(ProtectedFieldsMixin, self).__init__(**kwargs)
+        self.disable_protected_fields()

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -594,14 +594,15 @@ def create_random_company():
     )
 
 
-def create_random_order(customer=None, products=(), completion_probability=0):
+def create_random_order(customer=None, products=(), completion_probability=0, shop=None):
     if not customer:
         customer = Contact.objects.all().order_by("?").first()
 
     if not customer:
         raise ValueError("No valid contacts")
 
-    shop = get_default_shop()
+    if shop is None:
+        shop = get_default_shop()
 
     request = apply_request_middleware(RequestFactory().get("/"),
                                        customer=customer)

--- a/shoop_tests/admin/test_shop_edit.py
+++ b/shoop_tests/admin/test_shop_edit.py
@@ -1,0 +1,48 @@
+import pytest
+from django.conf import settings
+from django.utils.translation import activate
+from shoop.admin.modules.shops.views.edit import ShopForm
+from shoop.core.models import Shop, ShopStatus
+from shoop.testing.factories import create_random_order, create_random_person, create_product, get_default_supplier
+from shoop_tests.utils import printable_gibberish
+from shoop_tests.utils.forms import get_form_data
+
+
+@pytest.mark.django_db
+def test_protected_fields():
+    activate("en")
+    shop = Shop.objects.create(
+        name="testshop",
+        identifier="testshop",
+        status=ShopStatus.ENABLED,
+        public_name="test shop",
+        domain="derp",
+        currency="EUR"
+    )
+    assert shop.name == "testshop"
+    assert shop.currency == "EUR"
+    shop_form = ShopForm(instance=shop, languages=settings.LANGUAGES)
+    assert not shop_form._get_protected_fields()  # No protected fields just yet, right?
+    data = get_form_data(shop_form, prepared=True)
+    shop_form = ShopForm(data=data, instance=shop, languages=settings.LANGUAGES)
+    _test_cleanliness(shop_form)
+    shop_form.save()
+
+    # Now let's make it protected!
+    create_product(printable_gibberish(), shop=shop, supplier=get_default_supplier())
+    order = create_random_order(customer=create_random_person(), shop=shop)
+    assert order.shop == shop
+
+    # And try again...
+    data["currency"] = "XBT"  # Bitcoins!
+    shop_form = ShopForm(data=data, instance=shop, languages=settings.LANGUAGES)
+    assert shop_form._get_protected_fields()  # So protected!
+    _test_cleanliness(shop_form)
+    shop = shop_form.save()
+    assert shop.currency == "EUR"  # But the shop form ignored the change . . .
+
+
+def _test_cleanliness(shop_form):
+    shop_form.full_clean()
+    assert not shop_form.errors
+    assert shop_form.cleaned_data

--- a/shoop_tests/utils/forms.py
+++ b/shoop_tests/utils/forms.py
@@ -45,22 +45,11 @@ def get_form_data(form, prepared=False):
 
         if data_value:
             value = data_value
-            data[prefixed_name] = value
         else:
-            if not field.show_hidden_initial:
-                initial_value = form.initial.get(name, field.initial)
-                if callable(initial_value):
-                    initial_value = initial_value()
-            else:
-                initial_prefixed_name = form.add_initial_prefix(name)
-                hidden_widget = field.hidden_widget()
-                try:
-                    initial_value = field.to_python(hidden_widget.value_from_datadict(
-                        form.data, form.files, initial_prefixed_name))
-                except ValidationError:
-                    form._changed_data.append(name)
-                    continue
-            value = initial_value
+            value = form.initial.get(name, field.initial)
+            if callable(value):
+                value = value()
+
         if prepared:
             value = field.prepare_value(value)
             if value is None:


### PR DESCRIPTION
Add better error message when trying to save shop that has protection triggered.
Add protection handling to `MultiLanguageModelForm`

Refs SHOOP-1896