### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: false
+language: python
+cache:
+  directories:
+    - $HOME/.cache/pip
+python:
+  - "2.7"
+  - "3.4"
+install:
+  - pip install -U pip
+  - pip install coveralls -e .[everything]
+script: py.test -vvv --cov shoop shoop_tests
+after_success: coveralls

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ REQUIRES = [
     'jsonfield==1.0.3',
     'Markdown==2.6.2',
     'pytz==2015.4',
-    'requests==2.7.0',
+    'requests>=2.7.0,<3',
     'six==1.9.0',
     'Jinja2==2.8',
     'pytoml==0.1.4'

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ deps =
     beautifulsoup4==4.3.2
     mock==1.0.1
     pytest-cache==1.0
-    pytest==2.7.2
-    pytest-cov==1.8.1
-    pytest-django==2.8.0
+    pytest==2.8.4
+    pytest-cov==2.2.0
+    pytest-django==2.9.1
     # END testing deps
 commands = \
     py.test \


### PR DESCRIPTION
[Seems to work!](https://travis-ci.org/akx/shoop/builds/94130836)

Once the wheels have been cached, the install step is a snappy 10 to 18 seconds, so the build time is about 2 minutes altogether. Not bad!

The project has been set up on Travis, but build hooks are currently switched off there.