### PR TITLE
setup.py: Tune exclude patterns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,12 @@ Topic :: Software Development :: Libraries :: Python Modules
 """.strip().splitlines()
 
 utils.set_exclude_patters([
-    'build', 'doc',
+    '__pycache__', '*.py[cod]',
     'node_modules', 'bower_components',
-    'var', '__pycache__', 'LC_MESSAGES',
-    '.tox', 'venv*',
+    'build', 'doc', 'var',
+    '.tox', '.cache', 'venv*',
     '.git', '.gitignore',
+    'LC_MESSAGES',
     'local_settings.py',
 ])
 


### PR DESCRIPTION
Add '*.py[cod]' and '.cache' to exclude patterns in setup.py and reorder
the listing to more logical order.

This should make the caching of "build_resources" work better, since
previously also the pyc files were included when determining the cache
key for a resource compile source directory.