### PR TITLE
Admin Gulp: Really fix the es6 switch.

### DIFF
--- a/shoop/admin/gulp_bits/js-packages.js
+++ b/shoop/admin/gulp_bits/js-packages.js
@@ -32,6 +32,7 @@ module.exports = {
         ]
     },
     "dashboard": {
+        "es6": true,
         "files": bowerFiles("./static_src/dashboard")
     },
     "media-browser": {

--- a/shoop/admin/gulp_bits/metatasks/js-metatask.js
+++ b/shoop/admin/gulp_bits/metatasks/js-metatask.js
@@ -21,7 +21,7 @@ function normalJsBundle(spec, name) {
     var transpiler = gutil.noop();
     if (spec.es6) {
         // Don't transpile Bower components.
-        transpiler = gulpif(/bower_components/, gutil.noop(), babel());
+        transpiler = gulpif(function(file) { return /bower_components/.test(file.path); }, gutil.noop(), babel());
     }
     gulp.task(taskName, function () {
         if (settings.WATCH && !watcher) {


### PR DESCRIPTION
You can use `export DEBUG=*` before running `gulp js:dashboard` to verify Babel only traverses our components:

![image](https://cloud.githubusercontent.com/assets/58669/11556116/6c75b5a8-99ad-11e5-89d9-99cf4895c2cd.png)
