### PR TITLE
MANIFEST.in: Include *.map to the Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,7 +6,7 @@ include ChangeLog.rst
 include tox.ini
 
 recursive-include shoop \
-    *.jinja *.txt *.js *.css *.json *.less \
+    *.jinja *.txt *.js *.css *.json *.less *.map \
     *.ico *.png *.svg \
     *.woff *.woff2 *.eot *.otf *.ttf *.po *.mo
 


### PR DESCRIPTION
Include the source maps of CSS and JS files in the Python
packages (including wheel) to make developers happy.