### PR TITLE
Do not forcibly update POT-Creation-Date with makemessages (SHOOP-1932)

### DIFF
--- a/shoop/core/management/commands/makemessages.py
+++ b/shoop/core/management/commands/makemessages.py
@@ -10,6 +10,8 @@ Patched version of Django's Makemessages that works with Jinja2.
 Works by monkey patching django.utils.translation.trans_real.templatize
 with our version.
 """
+from __future__ import unicode_literals
+
 import datetime
 import os
 from io import BytesIO
@@ -137,7 +139,7 @@ def jinja_messages_to_python(src, origin=None):
     """
     Convert Jinja2 file to Python preserving only messages.
     """
-    output = StringIO()
+    output = StringIO('')
     output_lineno = 1
     for (lineno, message, comments, context) in extract_jinja(src, origin):
         for comment in comments:

--- a/shoop/core/management/commands/makemessages.py
+++ b/shoop/core/management/commands/makemessages.py
@@ -10,6 +10,8 @@ Patched version of Django's Makemessages that works with Jinja2.
 Works by monkey patching django.utils.translation.trans_real.templatize
 with our version.
 """
+import datetime
+import os
 from io import BytesIO
 
 import babel.messages.extract
@@ -42,13 +44,93 @@ COMMENT_TAG = 'Translators:'
 
 
 class Command(makemessages.Command):
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--no-pot-date', action='store_true', dest='no_pot_date',
+            default=False,
+            help=(
+                "Don't update POT-Creation-Date if it would be "
+                "the only change to the PO file"))
+
     def handle(self, *args, **options):
+        self.no_pot_date = options.get('no_pot_date')
+
         old_templatize = trans_real.templatize
         trans_real.templatize = jinja_messages_to_python
         try:
             super(Command, self).handle(*args, **options)
         finally:
             trans_real.templatize = old_templatize
+
+    def build_potfiles(self):
+        """
+        Build PO Template files and return paths to them.
+
+        Extends base classes version of this method by adding the
+        "Remove POT-Creation-Date" feature.
+        """
+        potfiles = super(Command, self).build_potfiles()
+
+        if self.no_pot_date:
+            unique_potfiles = sorted(set(potfiles))  # Remove duplicates
+            for potfile in unique_potfiles:
+                _remove_pot_creation_date(potfile)
+
+        return potfiles
+
+    def write_po_file(self, potfile, locale):
+        """
+        Writo PO file of given locale to disk.
+
+        Extends base classes version of this method by adding a feature
+        to not change those PO files at all that have only the
+        "POT-Creation-Date" header changed.
+        """
+
+        basedir = os.path.join(os.path.dirname(potfile), locale, 'LC_MESSAGES')
+        pofile = os.path.join(basedir, '%s.po' % str(self.domain))
+
+        if self.no_pot_date:
+            orig_contents = _read_file(pofile)
+
+        super(Command, self).write_po_file(potfile, locale)
+
+        if self.no_pot_date:
+            new_contents = _read_file(pofile)
+            if orig_contents != new_contents:
+                modified_contents = _update_pot_creation_date(new_contents)
+                with open(pofile, 'wb') as fp:
+                    fp.write(modified_contents)
+
+
+def _remove_pot_creation_date(filepath):
+    modified_lines = []
+    with open(filepath, 'rb') as fp:
+        for line in fp:
+            if not line.startswith(b'"POT-Creation-Date: '):
+                modified_lines.append(line)
+    with open(filepath, 'wb') as fp:
+        for line in modified_lines:
+            fp.write(line)
+
+
+def _read_file(filepath):
+    with open(filepath, 'rb') as fp:
+        return fp.read()
+
+
+def _update_pot_creation_date(po_contents):
+    pot_line_template = '"POT-Creation-Date: {:%Y-%m-%d %H:%M}+0000\\n"'
+    now = datetime.datetime.utcnow()
+    pot_line = pot_line_template.format(now).encode('utf-8')
+    lines = []
+    for line in po_contents.splitlines():
+        if line.startswith(b'"PO-Revision-Date: '):
+            lines.append(pot_line + b'\n')
+        if not line.startswith(b'"POT-Creation-Date: '):
+            lines.append(line + b'\n')
+    return b''.join(lines)
 
 
 def jinja_messages_to_python(src, origin=None):

--- a/shoop/core/management/commands/shoop_makemessages.py
+++ b/shoop/core/management/commands/shoop_makemessages.py
@@ -32,6 +32,8 @@ class Command(makemessages.Command):
                     kwargs["default"] = True
                 elif args[0] == "--no-location":
                     kwargs["default"] = True
+                elif args[0] == "--no-pot-date":
+                    kwargs["default"] = True
                 parser.add_argument(*args, **kwargs)
                 if args[0].startswith("--no-") and kwargs.get("default"):
                     name = "--include-" + args[0][5:]


### PR DESCRIPTION
Doing "shoop_makemessages" in the shoop directory updates all the
translation base files, but it unnecessarily updates also the
POT-Creation-Date header which causes all PO files to change even if
there is no change to messages.  This makes it hard to periodically
update the message files (with clean commits).

Update the Shoop's "makemessages" command to support skipping
POT-Creation-Date updating of PO files which don't have any changes to
messages and make "shoop_makemessages" to toggle that option on by
default.