### PR TITLE
Fix last shoop migration

### DIFF
--- a/shoop/core/migrations/0013_address_changes.py
+++ b/shoop/core/migrations/0013_address_changes.py
@@ -101,6 +101,10 @@ class Migration(migrations.Migration):
             model_name='order',
             name='mutable_shipping_address',
         ),
+        migrations.RenameModel(
+            old_name='Address',
+            new_name='MutableAddress'
+        ),
         migrations.AlterField(
             model_name='contact',
             name='default_billing_address',
@@ -116,8 +120,5 @@ class Migration(migrations.Migration):
             name='address',
             field=models.ForeignKey(related_name='saved_addresses', verbose_name='address', to='shoop.MutableAddress'),
         ),
-        migrations.RenameModel(
-            old_name='Address',
-            new_name='MutableAddress'
-        ),
+        
     ]


### PR DESCRIPTION
The latest migration regarding renaming `Address` to `MutableAddress`, while applied correctly, caused `python manage.py migrate/makemigrations` to crash with:

    Traceback (most recent call last):
      File "/home/jaywink/.virtualenvs/kakara/lib/python3.4/site-packages/django/apps/config.py", line 159, in get_model
        return self.models[model_name.lower()]
    KeyError: 'mutableaddress'

Full paste: http://pastebin.com/iVXAZ0F7

Did a slight reordering and things seem to work. I haven't tried applying this migration to an old db though, since this migration doesn't want to reverse itself at all.