### PR TITLE
Core: Fix migration 0013_address_changes (SHOOP-2003)

### DIFF
--- a/shoop/core/migrations/0013_address_changes.py
+++ b/shoop/core/migrations/0013_address_changes.py
@@ -33,6 +33,11 @@ def copy_order_addresses(apps, schema_editor):
             order.save()
 
 
+class FakeAlterField(migrations.AlterField):
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        pass
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -101,23 +106,23 @@ class Migration(migrations.Migration):
             model_name='order',
             name='mutable_shipping_address',
         ),
-        migrations.AlterField(
-            model_name='contact',
-            name='default_billing_address',
-            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.PROTECT, verbose_name='billing address', blank=True, to='shoop.MutableAddress', null=True),
-        ),
-        migrations.AlterField(
-            model_name='contact',
-            name='default_shipping_address',
-            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.PROTECT, verbose_name='shipping address', blank=True, to='shoop.MutableAddress', null=True),
-        ),
-        migrations.AlterField(
-            model_name='savedaddress',
-            name='address',
-            field=models.ForeignKey(related_name='saved_addresses', verbose_name='address', to='shoop.MutableAddress'),
-        ),
         migrations.RenameModel(
             old_name='Address',
             new_name='MutableAddress'
         ),
+        FakeAlterField(
+            model_name='contact',
+            name='default_billing_address',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.PROTECT, verbose_name='billing address', blank=True, to='shoop.MutableAddress', null=True),
+        ),
+        FakeAlterField(
+            model_name='contact',
+            name='default_shipping_address',
+            field=models.ForeignKey(related_name='+', on_delete=django.db.models.deletion.PROTECT, verbose_name='shipping address', blank=True, to='shoop.MutableAddress', null=True),
+        ),
+        FakeAlterField(
+            model_name='savedaddress',
+            name='address',
+            field=models.ForeignKey(related_name='saved_addresses', verbose_name='address', to='shoop.MutableAddress'),
+        )
     ]

--- a/shoop_tests/core/test_migrations.py
+++ b/shoop_tests/core/test_migrations.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.conf import settings
+from django.core.management import call_command
+from six import StringIO
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_makemigrations():
+    if type(settings.MIGRATION_MODULES).__name__ == "DisableMigrations":
+        pytest.skip()
+    out = StringIO()
+    call_command("makemigrations", "shoop", "--dry-run", stdout=out)
+    assert "No changes detected in app 'shoop'" in out.getvalue()


### PR DESCRIPTION
* Do RenameModel first, which handles all foreign key changes to database.
* FakeAlterField applies only state forwards.