### PR TITLE
Travis: Show py.test warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ python:
   - "3.4"
 install:
   - pip install -U pip
-  - pip install coveralls -e .[everything]
+  - pip install coveralls
+  - pip install -e .[everything]
 script:
   - flake8
   - isort -c -rc shoop
-  - python _misc/ensure_license_headers.py -s shoop
-  - python _misc/check_sanity.py shoop
-  - py.test -vvv --cov shoop shoop_tests
+  - _misc/ensure_license_headers.py -s shoop
+  - _misc/check_sanity.py shoop
+  - py.test -ra -vvv --cov shoop shoop_tests
 after_success: coveralls
 notifications:
   slack:

--- a/tox.ini
+++ b/tox.ini
@@ -23,5 +23,5 @@ commands = \
     py.test \
     -ra -v \
     --junit-xml={envlogdir}/junit-{envname}.xml \
-    --cov shoop --cov-report=xml --cov-config={toxinidir}/.coveragerc \
+    --cov shoop --cov-report=xml \
     {posargs:shoop_tests}


### PR DESCRIPTION
Add "-ra" argument to py.test to make it show warnings.  This unifies
test running of Travis and Tox.

Also clean-up the travis.yml a bit and remove now unneeded
"--cov-config" argument from py.test call in tox.ini.