### PR TITLE
sanity_utils: Ignore coverage.xml and var directory (SHOOP-1954)

### DIFF
--- a/_misc/sanity_utils.py
+++ b/_misc/sanity_utils.py
@@ -25,6 +25,7 @@ IGNORED_DIRS = [
     'CVS',
     'htmlcov',
     'node_modules',
+    'var',
     'venv*',
 ]
 
@@ -61,6 +62,7 @@ IGNORED_PATTERNS = [
     '*.zip',
     '.coverage',
     '_version.py',
+    'coverage.xml',
     'Makefile',
     'vendor.js',
 ]


### PR DESCRIPTION
This is needed to make _misc/check_sanity.py run cleanly after tox is
ran (in our Jenkins master builder).