### PR TITLE
Fix coverage reporting of Tox and do doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - isort -c -rc shoop
   - _misc/ensure_license_headers.py -s shoop
   - _misc/check_sanity.py shoop
-  - py.test -ra -vvv --cov shoop shoop_tests
+  - py.test -ra -vvv --doctest-modules --cov shoop shoop_tests shoop
 after_success: coveralls
 notifications:
   slack:

--- a/shoop/core/modules/interface.py
+++ b/shoop/core/modules/interface.py
@@ -70,9 +70,9 @@ class ModuleInterface(object):
         """
         Get a dict that maps module spec identifiers (short strings) into actual spec names.
 
-        As an example:
+        As an example::
 
-        >>> {"Eggs": "foo_package.bar_module:EggsClass"}
+            {"Eggs": "foo_package.bar_module:EggsClass"}
 
         :rtype: dict[str, str]
         """

--- a/shoop/utils/_united_decimal.py
+++ b/shoop/utils/_united_decimal.py
@@ -14,9 +14,9 @@ class UnitedDecimal(decimal.Decimal):
     Decimal with unit.
 
     Allows creating decimal classes that cannot be mixed, e.g. to
-    prevent operations like
+    prevent operations like::
 
-    >>> TaxfulPrice(1) + TaxlessPrice(2)
+        TaxfulPrice(1) + TaxlessPrice(2)
 
     where :class:`~shoop.core.pricing.TaxfulPrice` and
     :class:`~shoop.core.princing.TaxlessPrice` are subclasses of

--- a/shoop/utils/excs.py
+++ b/shoop/utils/excs.py
@@ -25,9 +25,9 @@ class Problem(Exception):
         Append a link to this Problem and return itself.
 
         This API is designed after `Exception.with_traceback()`,
-        so you can fluently chain this in a `raise` statement:
+        so you can fluently chain this in a `raise` statement::
 
-        >>> raise Problem("Oops").with_link("...", "...")
+            raise Problem("Oops").with_link("...", "...")
 
         :param url: URL string
         :type url: str

--- a/shoop/utils/iterables.py
+++ b/shoop/utils/iterables.py
@@ -29,11 +29,8 @@ def batch(iterable, count):
     """
     Yield batches of `count` items from the given iterable.
 
-    >>> for x in batch([1, 2, 3, 4, 5, 6, 7], 3):
-    >>>   print(x)
-    [1, 2, 3]
-    [4, 5, 6]
-    [7]
+    >>> tuple(x for x in batch([1, 2, 3, 4, 5, 6, 7], 3))
+    ([1, 2, 3], [4, 5, 6], [7])
 
     :param iterable: An iterable
     :type iterable: Iterable

--- a/shoop/utils/text.py
+++ b/shoop/utils/text.py
@@ -5,6 +5,8 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
 import re
 import unicodedata
 
@@ -28,7 +30,7 @@ def flatten(str, whitespace="-"):
     Flatten the given text into lowercase ASCII, removing diacriticals etc.
     Replace runs of whitespace with the given whitespace replacement.
 
-    >>> print(flatten(u"hellö, wörld"))
+    >>> print(flatten("hellö, wörld"))
     hello,-world
 
     :param str: The string to massage

--- a/shoop/utils/text.py
+++ b/shoop/utils/text.py
@@ -28,8 +28,8 @@ def flatten(str, whitespace="-"):
     Flatten the given text into lowercase ASCII, removing diacriticals etc.
     Replace runs of whitespace with the given whitespace replacement.
 
-    >>> flatten(u"hellö, wörld")
-    "hello,-world"
+    >>> print(flatten(u"hellö, wörld"))
+    hello,-world
 
     :param str: The string to massage
     :type str: str

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ minversion=2.3.1
 envlist = py27,py34
 
 [testenv]
+changedir = {envsitepackagesdir}
 deps =
     # Pip 6 is needed for Environment markers (PEP-426) support, which
     # are used to mark Python 2 only deps (like enum34)
@@ -24,4 +25,4 @@ commands = \
     -ra -v \
     --junit-xml={envlogdir}/junit-{envname}.xml \
     --cov shoop --cov-report=xml \
-    {posargs:shoop_tests}
+    {posargs:{toxinidir}/shoop_tests}

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     # END testing deps
 commands = \
     py.test \
-    -ra -v \
+    -ra -v --doctest-modules \
     --junit-xml={envlogdir}/junit-{envname}.xml \
     --cov shoop --cov-report=xml \
-    {posargs:{toxinidir}/shoop_tests}
+    {posargs:{toxinidir}/shoop_tests shoop}


### PR DESCRIPTION
Coverage reporting for Tox was broken on commit d7a4a6a97bf (which was
made, because there was some version of Tox that did not support
envsitepackagesdir variable).  Fix it.

Also enable doctests for Tox and Travis and fix some incorrectly
formatted doctests.

Refs SHOOP-1954