### PR TITLE
Version number in shop admin

### DIFF
--- a/shoop/admin/templates/shoop/admin/dashboard/dashboard.jinja
+++ b/shoop/admin/templates/shoop/admin/dashboard/dashboard.jinja
@@ -96,6 +96,9 @@
                 {% if activity %}
                     {% call regular_block("medium") %}{{ activity_block_content(activity) }}{% endcall %}
                 {% endif %}
+                <div class="block width-large">
+                    <p>{{ _("Shoop %(version)s", version=version) }}</p>
+                </div>
             </div>
         {% endblock %}
     </main>

--- a/shoop/admin/views/dashboard.py
+++ b/shoop/admin/views/dashboard.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from django.views.generic.base import TemplateView
 
+import shoop
 from shoop.admin.dashboard import get_activity
 from shoop.admin.module_registry import get_modules
 from shoop.core.telemetry import try_send_telemetry
@@ -17,6 +18,7 @@ class DashboardView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(DashboardView, self).get_context_data(**kwargs)
+        context["version"] = shoop.__version__
         context["notifications"] = notifications = []
         context["blocks"] = blocks = []
         for module in get_modules():


### PR DESCRIPTION
Added the Shoop version number to the admin dashboard to help merchant/
admin troubleshooting process

![screenshot from 2016-01-14 09 35 28](https://cloud.githubusercontent.com/assets/5107464/12334819/f47c977c-bab0-11e5-9096-6b302e7fb8c1.png)

Refs SHOOP-1999