### PR TITLE
Campaign groundwork (SHOOP-2045)

### DIFF
--- a/shoop/admin/modules/orders/views/create.py
+++ b/shoop/admin/modules/orders/views/create.py
@@ -12,7 +12,6 @@ import json
 
 from babel.numbers import format_decimal
 from django.contrib import messages
-from django.contrib.auth.models import AnonymousUser
 from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import reverse
@@ -27,8 +26,8 @@ from django_countries import countries
 
 from shoop.admin.modules.orders.json_order_creator import JsonOrderCreator
 from shoop.core.models import (
-    CompanyContact, Contact, MethodStatus, Order, PaymentMethod, Product,
-    ShippingMethod, Shop, ShopStatus
+    AnonymousContact, CompanyContact, Contact, MethodStatus, Order,
+    PaymentMethod, Product, ShippingMethod, Shop, ShopStatus
 )
 from shoop.core.pricing import get_pricing_module
 from shoop.utils.i18n import (
@@ -97,9 +96,7 @@ def encode_line(line):
 def get_price_info(shop, customer, product, quantity):
     ctx_request = RequestFactory().get("/")
     ctx_request.shop = shop
-    if customer:
-        ctx_request.customer = customer
-    ctx_request.user = AnonymousUser()
+    ctx_request.customer = (customer or AnonymousContact())
     context = get_pricing_module().get_context_from_request(ctx_request)
     return product.get_price_info(context, quantity=quantity)
 

--- a/shoop/apps/provides.py
+++ b/shoop/apps/provides.py
@@ -169,19 +169,50 @@ def load_module(setting_name, provide_category):
     """
     Load a module from a module setting.
 
-    The value of the setting must be a module identifier for the given provide category.
+    The value of the setting must be a module
+    identifier for the given provide category.
 
     :param setting_name: The setting name for the identifier
     :type setting_name: str
-    :param provide_category: The provide category for the identifier lookup (e.g. `tax_module`)
+    :param provide_category:
+      The provide category for the identifier lookup (e.g. ``tax_module``)
     :type provide_category: str
     :return: An object.
     :rtype: object
     """
-    setting_value = getattr(settings, setting_name, None)
-    if not setting_value:
-        raise ImproperlyConfigured("The setting `%s` MUST be set." % setting_name)
+    setting_value = _get_settings_value(setting_name)
+    return _load_module(provide_category, setting_name, setting_value)
 
+
+def load_modules(setting_name, provide_category):
+    """
+    Load a list of modules from a module setting.
+
+    The value of the setting must be a list of module
+    identifiers for the given provide category.
+
+    The modules are returned in the same order they
+    are declared in the settings.
+
+    :param setting_name: The setting name for the identifier list
+    :type setting_name: str
+    :param provide_category:
+      The provide category for the identifier lookup (e.g. ``tax_module``)
+    :type provide_category: str
+    :return: A list of objects
+    :rtype: list[object]
+    """
+    setting_value = _get_settings_value(setting_name)
+    return [_load_module(provide_category, setting_name, x) for x in setting_value]
+
+
+def _get_settings_value(setting_name, required=True):
+    if not hasattr(settings, setting_name):
+        raise ImproperlyConfigured("The setting `%s` MUST be set." % setting_name)
+    return getattr(settings, setting_name, None)
+
+
+def _load_module(provide_category, setting_name, setting_value):
     object = get_identifier_to_object_map(provide_category).get(setting_value)
     if not object:
         raise ImproperlyConfigured(

--- a/shoop/core/migrations/0015_product_minimum_price.py
+++ b/shoop/core/migrations/0015_product_minimum_price.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0014_verbose_names'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='shopproduct',
+            name='minimum_price_value',
+            field=shoop.core.fields.MoneyValueField(null=True, max_digits=36, decimal_places=9, blank=True, verbose_name='minimum price'),
+        ),
+    ]

--- a/shoop/core/models/_product_shops.py
+++ b/shoop/core/models/_product_shops.py
@@ -69,6 +69,9 @@ class ShopProduct(MoneyPropped, models.Model):
     default_price = PriceProperty('default_price_value', 'shop.currency', 'shop.prices_include_tax')
     default_price_value = MoneyValueField(verbose_name=_("default price"), null=True, blank=True)
 
+    minimum_price = PriceProperty('minimum_price_value', 'shop.currency', 'shop.prices_include_tax')
+    minimum_price_value = MoneyValueField(verbose_name=_("minimum price"), null=True, blank=True)
+
     class Meta:
         unique_together = (("shop", "product",),)
 

--- a/shoop/core/models/_products.py
+++ b/shoop/core/models/_products.py
@@ -310,10 +310,8 @@ class Product(TaxableItem, AttributableMixin, TranslatableModel):
         :type context: shoop.core.pricing.PricingContextable
         :rtype: shoop.core.pricing.PriceInfo
         """
-        from shoop.core.pricing import get_pricing_module
-        module = get_pricing_module()
-        pricing_context = module.get_context(context)
-        return module.get_price_info(pricing_context, product=self, quantity=quantity)
+        from shoop.core.pricing import get_price_info
+        return get_price_info(product=self, context=context, quantity=quantity)
 
     def get_price(self, context, quantity=1):
         """

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -180,7 +180,7 @@ class OrderSource(object):
     taxful_total_discount_or_none = taxful_total_discount.or_none
     taxless_total_discount_or_none = taxless_total_discount.or_none
 
-    total_price_of_products = _PriceSum("price", "_get_product_lines")
+    total_price_of_products = _PriceSum("price", "get_product_lines")
 
     @property
     def shipping_method(self):
@@ -258,6 +258,15 @@ class OrderSource(object):
         See also `get_final_lines`.
         """
         return self._lines
+
+    @property
+    def product_count(self):
+        """
+        Get the total number of products in this OrderSource.
+
+        :rtype: decimal.Decimal|int
+        """
+        return sum([line.quantity for line in self.get_product_lines()])
 
     def get_final_lines(self, with_taxes=False):
         """
@@ -339,7 +348,7 @@ class OrderSource(object):
             for line in self.shipping_method.get_source_lines(self):
                 yield line
 
-    def _get_product_lines(self):
+    def get_product_lines(self):
         """
         Get lines with a product.
 

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -62,6 +62,27 @@ __all__ = [
     "TaxfulPrice",
     "TaxlessPrice",
     "get_pricing_module",
+    "get_price_info",
 ]
+
+
+def get_price_info(product, context, quantity):
+    """
+    Get `PriceInfo` object for the given product in given context.
+
+    Returned `PriceInfo` object contains calculated `price` and
+    `base_price`.  The calculation of prices is handled in the
+    current pricing module and possible campaign modules.
+
+    :type product: shoop.core.models.Product
+    :type context: shoop.core.pricing.PricingContextable
+    :type quantity: int
+    :rtype: shoop.core.pricing.PriceInfo
+    """
+    pricing_module = get_pricing_module()
+    pricing_context = pricing_module.get_context(context)
+    price_info = pricing_module.get_price_info(pricing_context, product=product, quantity=quantity)
+    return price_info
+
 
 update_module_attributes(__all__, __name__)

--- a/shoop/core/pricing/__init__.py
+++ b/shoop/core/pricing/__init__.py
@@ -46,6 +46,10 @@ from __future__ import unicode_literals
 
 from shoop.utils import update_module_attributes
 
+from ._campaigns import (
+    BasketCampaignModule, CatalogCampaignModule, get_basket_campaign_modules,
+    get_catalog_campaign_modules
+)
 from ._context import PricingContext, PricingContextable
 from ._module import get_pricing_module, PricingModule
 from ._price import Price, TaxfulPrice, TaxlessPrice
@@ -53,6 +57,12 @@ from ._price_info import PriceInfo
 from ._priceful import Priceful
 
 __all__ = [
+    "BasketCampaignModule",
+    "CatalogCampaignModule",
+    "get_basket_campaign_modules",
+    "get_catalog_campaign_modules",
+    "get_price_info",
+    "get_pricing_module",
     "Price",
     "Priceful",
     "PriceInfo",
@@ -61,8 +71,6 @@ __all__ = [
     "PricingModule",
     "TaxfulPrice",
     "TaxlessPrice",
-    "get_pricing_module",
-    "get_price_info",
 ]
 
 
@@ -82,6 +90,10 @@ def get_price_info(product, context, quantity):
     pricing_module = get_pricing_module()
     pricing_context = pricing_module.get_context(context)
     price_info = pricing_module.get_price_info(pricing_context, product=product, quantity=quantity)
+
+    for campaign_module in get_catalog_campaign_modules():
+        price_info = campaign_module.discount_price(context, price_info, product)
+
     return price_info
 
 

--- a/shoop/core/pricing/_campaigns.py
+++ b/shoop/core/pricing/_campaigns.py
@@ -1,0 +1,56 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import abc
+
+import six
+from django.conf import settings
+
+from shoop.apps.provides import load_modules
+
+
+def get_basket_campaign_modules():
+    """
+    Get a list of active basket discount module instances.
+
+    :rtype: list[BasketCampaignModule]
+    """
+
+    return _get_campaign_modules("SHOOP_BASKET_CAMPAIGN_MODULES", "basket_campaign_module")
+
+
+def get_catalog_campaign_modules():
+    """
+    Get a list of active catalog discount module instances.
+
+    :rtype: list[CatalogCampaignModule]
+    """
+
+    return _get_campaign_modules("SHOOP_CATALOG_CAMPAIGN_MODULES", "catalog_campaign_module")
+
+
+def _get_campaign_modules(setting_name, provide_category):
+    modules = []
+    if getattr(settings, setting_name, None):
+        # `load_modules` would error out at the setting being falsy,
+        # so handle that here instead.
+        for cls in load_modules(setting_name, provide_category):
+            modules.append(cls())
+    return modules
+
+
+class CatalogCampaignModule(six.with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def discount_price(self, context, price_info, product):
+        # TODO (campaigns) docstring
+        pass
+
+
+class BasketCampaignModule(six.with_metaclass(abc.ABCMeta)):
+    @abc.abstractmethod
+    def get_basket_campaign_lines(self, order_source, lines):
+        # TODO (campaigns) docstring
+        pass

--- a/shoop/core/pricing/_context.py
+++ b/shoop/core/pricing/_context.py
@@ -41,7 +41,7 @@ class PricingContext(PricingContextable):
     """
     Context for pricing.
     """
-    REQUIRED_VALUES = ()
+    REQUIRED_VALUES = ("shop", "customer")
 
     def __init__(self, **kwargs):
         kwargs.setdefault("time", now())

--- a/shoop/core/pricing/_module.py
+++ b/shoop/core/pricing/_module.py
@@ -50,7 +50,10 @@ class PricingModule(six.with_metaclass(abc.ABCMeta)):
         :type request: HttpRequest
         :rtype: PricingContext
         """
-        return self.pricing_context_class()
+        return self.pricing_context_class(
+            customer=request.customer,
+            shop=request.shop
+        )
 
     def get_context_from_data(self, **context_data):
         """

--- a/shoop/core/pricing/default_pricing.py
+++ b/shoop/core/pricing/default_pricing.py
@@ -8,28 +8,12 @@
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import ShopProduct
-from shoop.core.pricing import PriceInfo, PricingContext, PricingModule
-
-
-class DefaultPricingContext(PricingContext):
-    REQUIRED_VALUES = ["shop"]
-    shop = None
+from shoop.core.pricing import PriceInfo, PricingModule
 
 
 class DefaultPricingModule(PricingModule):
     identifier = "default_pricing"
     name = _("Default Pricing")
-
-    pricing_context_class = DefaultPricingContext
-
-    def get_context_from_request(self, request):
-        """
-        Inject shop into pricing context.
-
-        Shop information is used to find correct `ShopProduct`
-        in `self.get_price_info`
-        """
-        return self.pricing_context_class(shop=request.shop)
 
     def get_price_info(self, context, product, quantity=1):
         """

--- a/shoop/discount_pricing/module.py
+++ b/shoop/discount_pricing/module.py
@@ -23,26 +23,14 @@ import six
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import ShopProduct
-from shoop.core.pricing import PriceInfo, PricingContext, PricingModule
+from shoop.core.pricing import PriceInfo, PricingModule
 
 from .models import DiscountedProductPrice
-
-
-class DiscountPricingContext(PricingContext):
-    REQUIRED_VALUES = ["shop"]
-    shop = None
 
 
 class DiscountPricingModule(PricingModule):
     identifier = "discount_pricing"
     name = _("Discount Pricing")
-
-    pricing_context_class = DiscountPricingContext
-
-    def get_context_from_request(self, request):
-        return self.pricing_context_class(
-            shop=request.shop,
-        )
 
     def get_price_info(self, context, product, quantity=1):
         shop = context.shop

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -18,6 +18,7 @@ from shoop.testing.factories import (
     get_default_shipping_method, get_default_supplier, get_default_tax,
     get_initial_order_status, get_shop
 )
+from shoop.testing.utils import apply_request_middleware
 
 
 def create_order(request, creator, customer, product):
@@ -112,6 +113,7 @@ def test_basic_order(rf, admin_user, mode):
 
     request = rf.get('/')
     request.shop = shop
+    apply_request_middleware(request)
     product = get_default_product()
     customer = get_person_contact(admin_user)
     for x in range(10):

--- a/shoop_tests/core/test_default_pricing.py
+++ b/shoop_tests/core/test_default_pricing.py
@@ -14,6 +14,7 @@ from shoop.testing.factories import (
     create_product, create_random_person, get_default_customer_group,
     get_default_shop
 )
+from shoop.testing.utils import apply_request_middleware
 
 original_pricing_module = settings.SHOOP_PRICING_MODULE
 
@@ -43,6 +44,7 @@ def initialize_test(rf, include_tax=False):
 
     request = rf.get("/")
     request.shop = shop
+    apply_request_middleware(request)
     request.customer = customer
     return request, shop, group
 

--- a/shoop_tests/core/test_order_creator.py
+++ b/shoop_tests/core/test_order_creator.py
@@ -31,6 +31,16 @@ def test_invalid_source_line_updating():
         SourceLine(source).update({"update": True})
 
 
+def test_codes_type_conversion():
+    source = OrderSource(Shop())
+    source.codes = "test"
+    assert source.codes == {"t", "e", "s"}
+    source.codes = ["test", 1, "1"]
+    assert source.codes == {"test", "1"}
+    source.codes = ["12", "23"]
+    assert source.codes == {"12", "23"}
+
+
 def seed_source(user):
     source = BasketishOrderSource(get_default_shop())
     billing_address = get_address()
@@ -44,6 +54,7 @@ def seed_source(user):
     assert source.payment_method_id == get_default_payment_method().id
     assert source.shipping_method_id == get_default_shipping_method().id
     return source
+
 
 @pytest.mark.django_db
 def test_order_creator(rf, admin_user):

--- a/shoop_tests/core/test_product_variation_child_pricing.py
+++ b/shoop_tests/core/test_product_variation_child_pricing.py
@@ -4,9 +4,11 @@ from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 from shoop.testing.factories import (
     create_product, get_default_product, get_default_shop
 )
+from shoop.testing.utils import apply_request_middleware
 
 
 def init_test(request, shop, prices):
+    apply_request_middleware(request)
     parent = create_product("parent_product", shop=shop)
     children = [create_product("child-%d" % price, shop=shop, default_price=price) for price in prices]
     for child in children:

--- a/shoop_tests/discount_pricing/test_discount_pricing.py
+++ b/shoop_tests/discount_pricing/test_discount_pricing.py
@@ -12,6 +12,7 @@ from shoop.core.pricing import get_pricing_module, TaxfulPrice, TaxlessPrice
 from shoop.discount_pricing.models import DiscountedProductPrice
 from shoop.discount_pricing.module import DiscountPricingModule
 from shoop.testing.factories import create_product, get_shop
+from shoop.testing.utils import apply_request_middleware
 
 pytestmark = pytest.mark.skipif("shoop.discount_pricing" not in settings.INSTALLED_APPS,
                                 reason="Discount pricing not installed")
@@ -38,6 +39,7 @@ def test_module_is_active():
 def initialize_test(rf, include_tax=False):
     request = rf.get("/")
     request.shop = get_shop(prices_include_tax=include_tax)
+    apply_request_middleware(request)
     return request
 
 # Tests for Discount Pricing

--- a/shoop_tests/front/test_basket.py
+++ b/shoop_tests/front/test_basket.py
@@ -14,6 +14,7 @@ from shoop.front.models import StoredBasket
 from shoop.testing.factories import (
     create_product, get_default_shop, get_default_supplier
 )
+from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils import printable_gibberish
 
 
@@ -38,12 +39,15 @@ def test_basket(rf, storage):
             request = rf.get("/")
             request.session = {}
             request.shop = shop
+            apply_request_middleware(request)
             basket = get_basket(request)
             assert basket == request.basket
+            assert basket.product_count == 0
             line = basket.add_product(supplier=supplier, shop=shop, product=product, quantity=q)
             assert line.quantity == q
             assert basket.get_lines()
             assert basket.get_product_ids_and_quantities().get(product.pk) == q
+            assert basket.product_count == q
             basket.save()
             delattr(request, "basket")
             basket = get_basket(request)

--- a/shoop_tests/simple_pricing/test_simple_pricing.py
+++ b/shoop_tests/simple_pricing/test_simple_pricing.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 from django.conf import settings
+from shoop.core.models import AnonymousContact
 
 from shoop.core.pricing import get_pricing_module, TaxfulPrice, TaxlessPrice
 from shoop.simple_pricing.models import SimpleProductPrice
@@ -14,6 +15,7 @@ from shoop.simple_pricing.module import SimplePricingModule
 from shoop.testing.factories import (
     create_product, create_random_person, get_default_customer_group, get_shop
 )
+from shoop.testing.utils import apply_request_middleware
 
 pytestmark = pytest.mark.skipif("shoop.simple_pricing" not in settings.INSTALLED_APPS,
                                 reason="Simple pricing not installed")
@@ -37,7 +39,7 @@ def initialize_test(rf, include_tax=False):
     customer.groups.add(group)
     customer.save()
 
-    request = rf.get("/")
+    request = apply_request_middleware(rf.get("/"))
     request.shop = shop
     request.customer = customer
     return request, shop, group
@@ -146,7 +148,7 @@ def test_price_infos(rf):
 
 
 @pytest.mark.django_db
-def test_no_customer(rf):
+def test_customer_is_anonymous(rf):
     request, shop, group = initialize_test(rf, True)
     price = shop.create_price
 
@@ -154,7 +156,7 @@ def test_no_customer(rf):
 
     SimpleProductPrice.objects.create(product=product, group=group, shop=shop, price_value=50)
 
-    request.customer = None
+    request.customer = AnonymousContact()
 
     price_info = product.get_price_info(request)
 
@@ -162,9 +164,11 @@ def test_no_customer(rf):
 
 
 @pytest.mark.django_db
-def test_zero_default_price(rf):
+def test_zero_default_price(rf, admin_user):
     request, shop, group = initialize_test(rf, True)
+
     price = shop.create_price
+
 
     # create a product with zero price
     product = create_product("random-1", shop=shop, default_price=0)


### PR DESCRIPTION
Add support for upcoming campaign module.

* Add `load_modules` method for provides because campaigns will require multiple modules to be loaded
* Add `codes` property to `OrderSource`. This property can contain any type of code that affects `OrderSource`. The upcoming campaign module will use these codes for coupons
* Publish `OrderSource.get_product_lines()` because product lines must be easily available for upcoming campaigns
* Add `product_count` property to  `OrderSource`. This property is needed by upcoming campaigns. 
* Add `minimum_price` field to `ShopProduct`. This field will be used in upcoming campaign module to set a limit how low the product price can go.
* Require `shop` and `customer` in all pricing contexts. This change was made to simplify the usage of `PricingContext`. The current implementation required all subclasses to override the `get_context_from_request` method to add `shop` and `customer` there.
* Add core support for Campaign Module:
** Add two modules `CatalogCampaignModule` and `BasketCampaignModule`. 

Few notes about the naming
The original thought behind the naming was to have `CampaignDiscountModule` and `BasketDiscountModule`. Campaigns, however, won't always be giving discounts. Consider these two campaigns: `Buy n get x free` or `buy x get 20% off the whole basket`. Both are campaigns, but definitely not discounts per se. 

This PR will enable removing `discount_pricing` and adding the core for Campaigns feature