### PR TITLE
Translate language names

### DIFF
--- a/shoop/admin/gulp_bits/js-packages.js
+++ b/shoop/admin/gulp_bits/js-packages.js
@@ -28,7 +28,8 @@ module.exports = {
             "js/remarkable-field.js",
             "js/form-utils.js",
             "js/jquery.form-submission-attributes.polyfill.js",
-            "js/datetimepicker.js"
+            "js/datetimepicker.js",
+            "js/language-changer.js"
         ]
     },
     "dashboard": {

--- a/shoop/admin/static_src/base/js/language-changer.js
+++ b/shoop/admin/static_src/base/js/language-changer.js
@@ -1,0 +1,26 @@
+/**
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+function changeLanguage() {
+    const form = document.createElement("form");
+    form.method = "POST";
+    form.action = window.ShoopAdminConfig.browserUrls.setLanguage;
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = "language";
+    input.id = "language-field";
+    input.value = $(this).data("value");
+    form.appendChild(input);
+    document.body.appendChild(form);
+    form.submit();
+}
+
+$(function(){
+    "use strict";
+    $(".languages li a").click(changeLanguage);
+});

--- a/shoop/admin/static_src/base/less/shoop/navigation.less
+++ b/shoop/admin/static_src/base/less/shoop/navigation.less
@@ -86,6 +86,10 @@
             min-width: 200px;
             box-shadow: 0px 2px 4px 0px rgba(0, 0, 0, 0.13);
 
+            a:hover {
+                text-decoration: none;
+            }
+
             &:before {
                 position: absolute;
                 bottom: 100%;
@@ -106,6 +110,26 @@
                 content: "";
                 display: block;
                 z-index: 2;
+            }
+
+            .languages {
+                list-style-type: none;
+                padding: 0;
+                margin: 0;
+                .language {
+                    display: block;
+                    margin: 0;
+                    padding: 10px;
+                    color: @text-color;
+                    &:hover {
+                        color: @brand-primary;
+                        background: @gray-bg;
+                    }
+                    &.active {
+                        color: @active-text-color;
+                        background: @brand-primary;
+                    }
+                }
             }
 
             .username {

--- a/shoop/admin/static_src/base/less/variables.less
+++ b/shoop/admin/static_src/base/less/variables.less
@@ -41,6 +41,7 @@
 @font-size-h6: @font-size-h5;
 
 @text-color: #555;
+@active-text-color: #fff;
 @gray-bg: #f4f4f4;
 @border-color: #ddd;
 

--- a/shoop/admin/template_helpers/shoop_admin.py
+++ b/shoop/admin/template_helpers/shoop_admin.py
@@ -55,6 +55,7 @@ BROWSER_URL_NAMES = {
     "media": "shoop_admin:media.browse",
     "product": "shoop_admin:product.list",
     "contact": "shoop_admin:contact.list",
+    "setLanguage": "shoop_admin:set-language",
 }
 
 

--- a/shoop/admin/templates/shoop/admin/base/_navigation.jinja
+++ b/shoop/admin/templates/shoop/admin/base/_navigation.jinja
@@ -45,8 +45,8 @@
         </div>
         {% if LANGUAGES|length > 1 %}
         <ul class="languages">
-            {% for code, name in LANGUAGES %}
-            <li><a href="#" class="language{% if LANGUAGE_CODE|lower == code|lower %} active{% endif %}" data-value="{{ code }}">{{ _("%(language)s",language=name)}}</a></li>
+            {% for (code, name, local_name) in get_language_choices() %}
+            <li><a href="#" class="language{% if LANGUAGE_CODE == code %} active{% endif %}" data-value="{{ code }}">{{ name }} ({{ local_name }})</a></li>
             {% endfor %}
         </ul>
         {% endif %}

--- a/shoop/admin/templates/shoop/admin/base/_navigation.jinja
+++ b/shoop/admin/templates/shoop/admin/base/_navigation.jinja
@@ -35,14 +35,22 @@
 {% if front_url %}<a class="nav-btn shop-btn" href="{{ front_url }}" data-toggle="tooltip" data-placement="bottom" title="{% trans %}Visit shop{% endtrans %}"><i class="fa fa-shopping-cart"></i></a>{% endif %}
 
 <div class="dropdown">
-    <button class="dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-expanded="true" data-placement="bottom" title="{% trans %}User{% endtrans %}">
-        <i class="fa fa-user"></i>
+    <button class="dropdown-toggle" type="button" id="dropdownMenu" data-toggle="dropdown" aria-expanded="true" data-placement="bottom" title="{% trans %}Settings{% endtrans %}">
+        <i class="fa fa-cog"></i>
     </button>
     <div class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu">
         {% if request.user.is_authenticated() %}
         <div class="username">
             <span class="icon"><i class="fa fa-user"></i></span>{% trans %}Hello{% endtrans %}, <span class="user">{{ request.user }}</span>!
         </div>
+        {% if LANGUAGES|length > 1 %}
+        <ul class="languages">
+            {% for code, name in LANGUAGES %}
+            <li><a href="#" class="language{% if LANGUAGE_CODE|lower == code|lower %} active{% endif %}" data-value="{{ code }}">{{ _("%(language)s",language=name)}}</a></li>
+            {% endfor %}
+        </ul>
+        {% endif %}
+        <div class="divider"></div>
         <div class="actions">
             <a href="{{ url("shoop_admin:logout") }}" class="btn btn-block btn-sm btn-info">
                 <i class="fa fa-sign-out"></i> {% trans %}Log out{% endtrans %}

--- a/shoop/admin/urls.py
+++ b/shoop/admin/urls.py
@@ -13,6 +13,8 @@ import warnings
 import django.contrib.auth.views as auth_views
 from django.conf.urls import patterns, url
 from django.contrib.auth import logout as do_logout
+from django.views.decorators.csrf import csrf_exempt
+from django.views.i18n import set_language
 
 from shoop.admin.module_registry import get_module_urls
 from shoop.admin.utils.urls import admin_url, AdminRegexURLPattern
@@ -50,6 +52,11 @@ def get_urls():
             kwargs={"template_name": "shoop/admin/auth/logout.jinja"},
             name='logout',
             require_authentication=False
+        ),
+        admin_url(
+            r'^set-language/$',
+            csrf_exempt(set_language),
+            name="set-language"
         ),
     ])
 

--- a/shoop/core/templatetags/shoop_common.py
+++ b/shoop/core/templatetags/shoop_common.py
@@ -12,6 +12,8 @@ from json import dumps as json_dump
 
 from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
+from django.conf import settings
+from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.timezone import localtime
 from django_jinja import library
@@ -21,6 +23,24 @@ from shoop.utils.i18n import (
     format_money, format_percent, get_current_babel_locale
 )
 from shoop.utils.serialization import ExtendedJSONEncoder
+
+
+@library.global_function
+def get_language_choices():
+    """
+    Get language choices as code and text in two languages.
+
+    :return:
+      Available language codes as tuples (code, name, local_name)
+      where name is in the currently active language, and local_name
+      is in the language of the item.
+    :rtype: Iterable[tuple[str,str,str]]
+    """
+    for (code, name) in settings.LANGUAGES:
+        lang_info = translation.get_language_info(code)
+        name_in_current_lang = translation.ugettext(name)
+        local_name = lang_info["name_local"]
+        yield (code, name_in_current_lang, local_name)
 
 
 @library.filter

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/language_changer.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/language_changer.jinja
@@ -5,8 +5,8 @@
         <i class="dropdown-icon fa fa-angle-down"></i>
     </a>
     <ul class="dropdown-menu languages" role="menu">
-        {% for code, name in LANGUAGES %}
-        <li><a href="#" class="language" data-value="{{ code }}">{{ name }}</a></li>
+        {% for (code, name, local_name) in get_language_choices() %}
+        <li><a href="#" class="language" data-value="{{ code }}">{{ name }} ({{ local_name }})</a></li>
         {% endfor %}
     </ul>
 </li>

--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -115,7 +115,7 @@ LANGUAGES = [
     ('en', 'English'),
     ('fi', 'Finnish'),
     ('ja', 'Japanese'),
-    ('zh-Hans', 'Chinese (Simplified)'),
+    ('zh-hans', 'Simplified Chinese'),
 ]
 
 PARLER_DEFAULT_LANGUAGE_CODE = "en"


### PR DESCRIPTION
Add localized language names to both frontend and admin language changers.

![translated-default](https://cloud.githubusercontent.com/assets/5107464/12468598/e2a3f160-bf99-11e5-91ce-d7760d312e15.png)

![translated-admin](https://cloud.githubusercontent.com/assets/5107464/12468592/d94e8cc4-bf99-11e5-89e1-7b811d5ee62f.png)

A language's localized name defaults to its Django default translation when its language name is set equal to its country code (i.e., ``("en", "en")``), however this can be overridden by specifying a localized display name, as below with 'ENGLISH':

    LANGUAGES = [
        ('en', 'ENGLISH'),
        ('fi', 'fi'),
        ('ja', 'ja'),
        ('zh-Hans', 'zh-Hans'),
    ]

![translated](https://cloud.githubusercontent.com/assets/5107464/12468588/d8c821c0-bf99-11e5-979f-c50385d2a10b.png)
