### PR TITLE
Fix basket dirty flag not always being correctly set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 python:
   - "2.7"
   - "3.4"
+  - "3.5"
 install:
   - pip install -U pip
   - pip install coveralls

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,10 @@ EXTRAS_REQUIRE = {
         'pep8-naming~=0.2',
     ],
 }
-EXTRAS_REQUIRE['everything'] = list(set(sum(EXTRAS_REQUIRE.values(), [])))
+EXTRAS_REQUIRE['everything'] = list(
+    set(sum(EXTRAS_REQUIRE.values(), [])) -  # All extras, but not...
+    set(REQUIRES_FOR_PYTHON2_ONLY)  # the Python 2 compatibility things
+)
 
 
 if __name__ == '__main__':

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -158,10 +158,30 @@ class BaseBasket(OrderSource):
 
     @property
     def _data_lines(self):
+        """
+        Get the line data (list of dicts).
+
+        If the list is edited, it must be re-assigned
+        to ``self._data_lines`` to ensure the `dirty`
+        flag gets set.
+
+        :return: List of data dicts
+        :rtype: list[dict]
+        """
         return self._load().setdefault("lines", [])
 
     @_data_lines.setter
     def _data_lines(self, new_lines):
+        """
+        Set the line data (list of dicts).
+
+        Note that this assignment must be made instead
+        of editing `_data_lines` in-place to ensure
+        the `dirty` bit gets set.
+
+        :param new_lines: New list of lines.
+        :type new_lines: list[dict]
+        """
         self._load()["lines"] = new_lines
         self.dirty = True
         self.uncache()
@@ -270,7 +290,7 @@ class BaseBasket(OrderSource):
             index = len(line_ids)
         self.delete_line(data_line["line_id"])
         self._data_lines.insert(index, data_line)
-        self.uncache()
+        self._data_lines = list(self._data_lines)  # This will set the dirty bit and call uncache.
 
     def add_product(self, supplier, shop, product, quantity, force_new_line=False, extra=None, parent_line=None):
         if not extra:

--- a/shoop_tests/front/test_basket.py
+++ b/shoop_tests/front/test_basket.py
@@ -67,3 +67,24 @@ def test_basket(rf, storage):
                 assert stats["tfs"] == sum(quantities) * 50
             else:
                 assert stats["tls"] == sum(quantities) * 50
+
+
+@pytest.mark.django_db
+def test_basket_dirtying_with_fnl(rf):
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=50)
+    request = rf.get("/")
+    request.session = {}
+    request.shop = shop
+    apply_request_middleware(request)
+    basket = get_basket(request)
+    line = basket.add_product(
+        supplier=supplier,
+        shop=shop,
+        product=product,
+        quantity=1,
+        force_new_line=True,
+        extra={"foo": "foo"}
+    )
+    assert basket.dirty  # The change should have dirtied the basket

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     setuptools>=8.0
     # Do not remove the following BEGIN/END comments. setup.py uses them
     # BEGIN testing deps
-    beautifulsoup4==4.3.2
+    beautifulsoup4==4.4.0
     mock==1.0.1
     pytest-cache==1.0
     pytest==2.8.4


### PR DESCRIPTION
Noticed this while working on an internal project.

Also, since my currently installed Py3 is 3.5, had to make things work with it too.