### PR TITLE
Campaigns implementation (SHOOP-494)

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -17,6 +17,11 @@ file_filter = shoop/admin/locale/<lang>/LC_MESSAGES/djangojs.po
 source_lang = en
 type = PO
 
+[shoop.campaigns]
+file_filter = shoop/campaigns/locale/<lang>/LC_MESSAGES/django.po
+source_lang = en
+type = PO
+
 [shoop.core]
 file_filter = shoop/core/locale/<lang>/LC_MESSAGES/django.po
 source_lang = en

--- a/doc/api/shoop.campaigns.admin_module.rst
+++ b/doc/api/shoop.campaigns.admin_module.rst
@@ -1,0 +1,22 @@
+shoop.campaigns.admin_module package
+====================================
+
+Submodules
+----------
+
+shoop.campaigns.admin_module.views module
+-----------------------------------------
+
+.. automodule:: shoop.campaigns.admin_module.views
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: shoop.campaigns.admin_module
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.campaigns.models.rst
+++ b/doc/api/shoop.campaigns.models.rst
@@ -1,0 +1,46 @@
+shoop.campaigns.models package
+==============================
+
+Submodules
+----------
+
+shoop.campaigns.models.basket_conditions module
+-----------------------------------------------
+
+.. automodule:: shoop.campaigns.models.basket_conditions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.models.campaigns module
+---------------------------------------
+
+.. automodule:: shoop.campaigns.models.campaigns
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.models.catalog_filters module
+---------------------------------------------
+
+.. automodule:: shoop.campaigns.models.catalog_filters
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.models.context_conditions module
+------------------------------------------------
+
+.. automodule:: shoop.campaigns.models.context_conditions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: shoop.campaigns.models
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.campaigns.rst
+++ b/doc/api/shoop.campaigns.rst
@@ -1,0 +1,47 @@
+shoop.campaigns package
+=======================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    shoop.campaigns.admin_module
+    shoop.campaigns.models
+    shoop.campaigns.templates
+
+Submodules
+----------
+
+shoop.campaigns.apps module
+---------------------------
+
+.. automodule:: shoop.campaigns.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.forms module
+----------------------------
+
+.. automodule:: shoop.campaigns.forms
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.campaigns.modules module
+------------------------------
+
+.. automodule:: shoop.campaigns.modules
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: shoop.campaigns
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.campaigns.templates.rst
+++ b/doc/api/shoop.campaigns.templates.rst
@@ -1,0 +1,10 @@
+shoop.campaigns.templates package
+=================================
+
+Module contents
+---------------
+
+.. automodule:: shoop.campaigns.templates
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.rst
+++ b/doc/api/shoop.rst
@@ -10,6 +10,7 @@ Subpackages
     shoop.admin
     shoop.api
     shoop.apps
+    shoop.campaigns
     shoop.core
     shoop.default_tax
     shoop.discount_pricing

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,6 +18,7 @@ Core
 - Simplify ``PricingContext`` and require shop and customer for it
 - Add ``get_price_info`` etc. functions to ``shoop.core.pricing``
 - Add "codes" API to OrderSource and BaseBasket
+- Reword doc/provides.rst
 
 Localization
 ~~~~~~~~~~~~
@@ -26,10 +27,14 @@ Localization
 Admin
 ~~~~~
 
+- Add Campaigns management
+- Add Coupon management
 
 Front
 ~~~~~
 
+- Process given coupon codes in basket
+- Process discounts from new campaign engine
 
 Xtheme
 ~~~~~~
@@ -38,10 +43,13 @@ Xtheme
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 
+- Add Coupon use possibility to basket page
+
 
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 
+- Add campaigns module
 
 
 Version 3.0.0

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -9,6 +9,9 @@ the provides system in various ways.
 * ``shoop.admin`` uses Provides to load admin modules, form customizations etc.
 * ``shoop.front`` uses it for URLconf overrides etc.
 
+The provide categories used by Shoop are listed in :ref:`provide-categories` but you
+can also define your own categories as you wish.
+
 .. TODO:: Document the various ways better.
 
 Provides are grouped under different categories, such as ``admin_module``,
@@ -44,62 +47,100 @@ Provide management functions are found in the :mod:`shoop.apps.provides` module.
 In general, the :obj:`shoop.apps.provides.get_provide_objects` method is your most useful
 entry point.
 
+.. _provide-categories:
+
 Provide Categories
 ------------------
 
+Core
+~~~~
+
 ``admin_category_form_part``
     Additional ``FormPart`` classes for Category editing.
+
 ``admin_contact_form_part``
     Additional ``FormPart`` classes for Contact editing.
+
 ``admin_product_form_part``
     Additional ``FormPart`` classes for Product editing.
     (This is used by pricing modules, for instance.)
+
 ``admin_module``
     Admin module classes. Practically all of the functionality in the admin is built
     via admin modules.
+
 ``discount_module``
     `~shoop.core.pricing.DiscountModule` for pricing system.
+
 ``front_template_helper_namespace``
     Additional namespaces to install in the ``shoop`` "package" within
     template contexts.
     .. seealso:: :ref:`custom-template-helper-functions`
+
 ``admin_order_toolbar_button``
     Additional ``BaseActionButton`` subclasses for Order detail.
     Subclass init should take current order as a parameter.
+
 ``front_urls``
     Lists of frontend URLs to be appended to the usual frontend URLs.
+
 ``front_urls_post``
     Lists of frontend URLs to be appended to the usual frontend URLs, even after ``front_urls``.
     Most of the time, ``front_urls`` should do.
+
 ``front_urls_pre``
     Lists of frontend URLs to be prepended to the usual frontend URLs.
     Most of the time, ``front_urls`` should do.
+
 ``notify_action``
-    Notification framework :py:class:`~shoop.notify.Action` classes.
+    Notification framework `~shoop.notify.Action` classes.
+
 ``notify_condition``
-    Notification framework :py:class:`~shoop.notify.Condition` classes.
+    Notification framework `~shoop.notify.Condition` classes.
+
 ``notify_event``
-    Notification framework :py:class:`~shoop.notify.Event` classes.
+    Notification framework `~shoop.notify.Event` classes.
+
 ``order_source_modifier_module``
     `~shoop.core.order_creator.OrderSourceModifierModule` for modifying
     order source, e.g. in its
     `~shoop.core.order_creator.OrderSource.get_final_lines`.
+
 ``payment_method_module``
-    Payment method module classes (deriving from :py:class:`shoop.core.methods.base.BasePaymentMethodModule`),
-    as used by :py:class:`shoop.core.models.PaymentMethod`.
+    Payment method module classes (deriving from `~shoop.core.methods.base.BasePaymentMethodModule`),
+    as used by `~shoop.core.models.PaymentMethod`.
+
 ``pricing_module``
     Pricing module classes; the pricing module in use is set with the ``SHOOP_PRICING_MODULE`` setting.
+
 ``shipping_method_module``
-    Shipping method module classes (deriving from :py:class:`shoop.core.methods.base.BaseShippingMethodModule`),
-    as used by :py:class:`shoop.core.models.ShippingMethod`.
+    Shipping method module classes (deriving from `~shoop.core.methods.base.BaseShippingMethodModule`),
+    as used by `~shoop.core.models.ShippingMethod`.
+
 ``supplier_module``
-    Supplier module classes (deriving from :py:class:`shoop.core.suppliers.base.BaseSupplierModule`),
-    as used by :py:class:`shoop.core.models.Supplier`.
+    Supplier module classes (deriving from `~shoop.core.suppliers.base.BaseSupplierModule`),
+    as used by `~shoop.core.models.Supplier`.
+
 ``tax_module``
     Tax module classes; the tax module in use is set with the ``SHOOP_TAX_MODULE`` setting.
+
 ``xtheme``
     XTheme themes (full theme sets).
+
 ``xtheme_plugin``
     XTheme plugins (that are placed into placeholders within themes).
+
 ``xtheme_resource_injection``
     XTheme resources injection function that takes current context and content as parameters.
+
+Campaigns Provide Categories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``campaign_catalog_filter``
+    Filters that filter product catalog queryset to find the matching campaigns.
+
+``campaign_context_condition``
+    Context Conditions that matches against the current context in shop to see if campaign matches.
+
+``campaign_basket_condition``
+    Conditions that matches against the order source or source lines in basket.

--- a/shoop/admin/modules/products/views/forms.py
+++ b/shoop/admin/modules/products/views/forms.py
@@ -71,6 +71,7 @@ class ShopProductForm(forms.ModelForm):
         model = ShopProduct
         fields = (
             "default_price_value",
+            "minimum_price_value",
             "suppliers",
             "visible",
             "listed",

--- a/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
+++ b/shoop/admin/templates/shoop/admin/products/_edit_shop_form.jinja
@@ -15,6 +15,7 @@
 
 {% call content_block(shop_name_prefix ~ _("Purchasing"), "fa-shopping-cart") %}
     {{ bs3.field(shop_product_form.default_price_value) }}
+    {{ bs3.field(shop_product_form.minimum_price_value) }}
     {{ bs3.field(shop_product_form.suppliers) }}
     {{ bs3.field(shop_product_form.purchase_multiple) }}
     {{ bs3.field(shop_product_form.minimum_purchase_quantity) }}

--- a/shoop/admin/utils/bs3_renderers.py
+++ b/shoop/admin/utils/bs3_renderers.py
@@ -18,7 +18,6 @@ class AdminFieldRenderer(FieldRenderer):
         self.widget_class = kwargs.pop("widget_class", None)
         default_show_help_block = True
         if isinstance(field.field, ModelMultipleChoiceField):
-            default_show_help_block = False
             if not self.widget_class:
                 self.widget_class = "multiselect"
         if isinstance(field.field, DateTimeField):

--- a/shoop/admin/utils/picotable.py
+++ b/shoop/admin/utils/picotable.py
@@ -262,6 +262,9 @@ class Column(object):
         if isinstance(value, Manager):
             value = ", ".join("%s" % x for x in value.all())
 
+        if not value:
+            value = ""
+
         return force_text(value)
 
 

--- a/shoop/campaigns/__init__.py
+++ b/shoop/campaigns/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+default_app_config = "shoop.campaigns.apps.CampaignAppConfig"

--- a/shoop/campaigns/admin_module/__init__.py
+++ b/shoop/campaigns/admin_module/__init__.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.admin.base import AdminModule, MenuEntry
+from shoop.admin.utils.urls import derive_model_url, get_edit_and_list_urls
+
+
+class CampaignAdminModule(AdminModule):
+    name = _(u"Campaigns")
+
+    def get_urls(self):
+        basket_campaign_urls = get_edit_and_list_urls(
+            url_prefix="^campaigns/basket",
+            view_template="shoop.campaigns.admin_module.views.BasketCampaign%sView",
+            name_template="basket_campaigns.%s"
+        )
+
+        coupon_urls = get_edit_and_list_urls(
+            url_prefix="^campaigns/coupons",
+            view_template="shoop.campaigns.admin_module.views.Coupon%sView",
+            name_template="coupons.%s"
+        )
+
+        return basket_campaign_urls + coupon_urls + get_edit_and_list_urls(
+            url_prefix="^campaigns/catalog",
+            view_template="shoop.campaigns.admin_module.views.CatalogCampaign%sView",
+            name_template="catalog_campaigns.%s"
+        )
+
+    def get_menu_category_icons(self):
+        return {self.name: "fa fa-bullhorn"}
+
+    def get_menu_entries(self, request):
+        category = self.name
+        return [
+            MenuEntry(
+                text=_("Catalog Campaigns"), icon="fa fa-file-text",
+                url="shoop_admin:catalog_campaigns.list",
+                category=category, aliases=[_("Show Catalog Campaigns")]
+            ),
+            MenuEntry(
+                text=_("Basket Campaigns"), icon="fa fa-file-text",
+                url="shoop_admin:basket_campaigns.list",
+                category=category, aliases=[_("Show Basket Campaigns")]
+            ),
+            MenuEntry(
+                text=_("Coupons"), icon="fa fa-file-text",
+                url="shoop_admin:coupons.list",
+                category=category, aliases=[_("Show Coupons")]
+            )
+        ]
+
+    def get_model_url(self, object, kind):
+        if not hasattr(object, "admin_url_suffix"):
+            return super(CampaignAdminModule, self).get_model_url(object, kind)
+        admin_url = "shoop_admin:%s" % object.admin_url_suffix
+        return derive_model_url(type(object), admin_url, object, kind)

--- a/shoop/campaigns/admin_module/views.py
+++ b/shoop/campaigns/admin_module/views.py
@@ -1,0 +1,178 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from babel.dates import format_datetime
+from django.utils.timezone import localtime
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.admin.base import MenuEntry
+from shoop.admin.toolbar import NewActionButton, Toolbar
+from shoop.admin.utils.picotable import ChoicesFilter, Column, TextFilter
+from shoop.admin.utils.views import CreateOrUpdateView, PicotableListView
+from shoop.campaigns.forms import (
+    BasketCampaignForm, CatalogCampaignForm, CouponForm
+)
+from shoop.campaigns.models.campaigns import (
+    BasketCampaign, CatalogCampaign, Coupon
+)
+from shoop.utils.i18n import format_percent, get_current_babel_locale
+
+
+class _Breadcrumbed(object):
+    def get_breadcrumb_parents(self):
+        return [MenuEntry(text=self.parent_name, url=self.parent_url)]
+
+
+class CampaignListView(PicotableListView):
+    columns = [
+        Column(
+            "name", _(u"Title"), sort_field="translations__name", display="name", linked=True,
+            filter_config=TextFilter(operator="startswith")
+        ),
+        Column("discount_percentage", _("Discount percentage"), display="format_percentage"),
+        Column("discount_amount", _("Discount amount")),
+        Column("start_datetime", _("Starts")),
+        Column("end_datetime", _("Ends")),
+        Column("active", _("Active"), filter_config=ChoicesFilter(choices=[(0, _("No")), (1, _("Yes"))])),
+    ]
+
+    def format_percentage(self, instance, *args, **kwargs):
+        if not instance.discount_percentage:
+            return ""
+        return format_percent(instance.discount_percentage)
+
+    def start_datetime(self, instance, *args, **kwargs):
+        if not instance.start_datetime:
+            return ""
+        return self._formatted_datetime(instance.start_datetime)
+
+    def end_datetime(self, instance, *args, **kwargs):
+        if not instance.end_datetime:
+            return ""
+        return self._formatted_datetime(instance.end_datetime)
+
+    def _formatted_datetime(self, dt):
+        return format_datetime(localtime(dt), locale=get_current_babel_locale())
+
+    def add_columns(self, column_id, columns, after=True):
+        # TODO: Make better
+        added = False
+        for idx, column in enumerate(self.columns):
+            if column.id == column_id:
+                found_idx = idx + 1 if after else idx
+                start = self.columns[:found_idx]
+                end = self.columns[found_idx:]
+                self.columns = start + columns + end
+                added = True
+                break
+
+        if not added:
+            self.columns += columns
+
+    def get_object_abstract(self, instance, item):
+        return [
+            {"text": "%s" % (instance or _("CatalogCampaign")), "class": "header"},
+        ]
+
+
+class CatalogCampaignListView(CampaignListView):
+    model = CatalogCampaign
+
+    def __init__(self, **kwargs):
+        new_columns = [
+            Column("conditions", _("Used Conditions")),
+            Column("filters", _("Used filters")),
+        ]
+        self.add_columns("name", new_columns)
+        super(CatalogCampaignListView, self).__init__(**kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(CampaignListView, self).get_context_data(**kwargs)
+        context["toolbar"] = Toolbar([
+            NewActionButton("shoop_admin:catalog_campaigns.new", text=_("Create new Catalog Campaign")),
+        ])
+        return context
+
+
+class BasketCampaignListView(CampaignListView):
+    model = BasketCampaign
+
+    def __init__(self, **kwargs):
+        new_columns = [
+            Column("conditions", _("Used Conditions")),
+            Column("coupon", _("Discount Code")),
+        ]
+        self.add_columns("name", new_columns)
+        super(BasketCampaignListView, self).__init__(**kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(CampaignListView, self).get_context_data(**kwargs)
+        context["toolbar"] = Toolbar([
+            NewActionButton("shoop_admin:basket_campaigns.new", text=_("Create new Basket Campaign")),
+        ])
+        return context
+
+
+class CampaignEditView(CreateOrUpdateView):
+    template_name = "shoop/campaigns/admin/edit_campaigns.jinja"
+
+    context_object_name = "campaign"
+    add_form_errors_as_messages = True
+
+    def get_form_kwargs(self):
+        kwargs = super(CampaignEditView, self).get_form_kwargs()
+        kwargs["request"] = self.request
+        return kwargs
+
+
+class CatalogCampaignEditView(_Breadcrumbed, CampaignEditView):
+    model = CatalogCampaign
+    form_class = CatalogCampaignForm
+    parent_name = _("Catalog Campaign")
+    parent_url = "shoop_admin:catalog_campaigns.list"
+
+
+class BasketCampaignEditView(_Breadcrumbed, CampaignEditView):
+    model = BasketCampaign
+    form_class = BasketCampaignForm
+    parent_name = _("Basket Campaign")
+    parent_url = "shoop_admin:basket_campaigns.list"
+
+
+class CouponListView(PicotableListView):
+    model = Coupon
+    columns = [
+        Column(
+            "code", _(u"Code"), sort_field="code", display="code", linked=True,
+            filter_config=TextFilter(operator="startswith")
+        ),
+        Column("usages", _("Usages"), display="get_usages"),
+        Column("usage_limit_customer", _("Usages Limit per contact")),
+        Column("usage_limit", _("Usage Limit")),
+        Column("active", _("Active")),
+        Column("created_by", _(u"Created by")),
+        Column("created_on", _(u"Date created")),
+    ]
+
+    def get_usages(self, instance, *args, **kwargs):
+        return instance.usages.count()
+
+    def get_context_data(self, **kwargs):
+        context = super(CouponListView, self).get_context_data(**kwargs)
+        context["toolbar"] = Toolbar([
+            NewActionButton("shoop_admin:coupons.new", text=_("Create new Coupon")),
+        ])
+        return context
+
+
+class CouponEditView(_Breadcrumbed, CreateOrUpdateView):
+    model = Coupon
+    template_name = "shoop/campaigns/admin/edit_coupons.jinja"
+    form_class = CouponForm
+    context_object_name = "coupon"
+    add_form_errors_as_messages = True
+    parent_name = _("Coupon")
+    parent_url = "shoop_admin:coupons.list"

--- a/shoop/campaigns/apps.py
+++ b/shoop/campaigns/apps.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from shoop.apps import AppConfig
+
+
+class CampaignAppConfig(AppConfig):
+    name = "shoop.campaigns"
+    verbose_name = "Shoop Campaigns"
+    label = "campaigns"
+    provides = {
+        "discount_module": [
+            "shoop.campaigns.modules:CatalogCampaignModule"
+        ],
+        "order_source_modifier_module": [
+            "shoop.campaigns.modules:BasketCampaignModule"
+        ],
+        "admin_module": [
+            "shoop.campaigns.admin_module:CampaignAdminModule",
+        ],
+        "campaign_catalog_filter": [
+            "shoop.campaigns.models.catalog_filters:ProductTypeFilter",
+            "shoop.campaigns.models.catalog_filters:ProductFilter",
+            "shoop.campaigns.models.catalog_filters:CategoryFilter"
+        ],
+        "campaign_context_condition": [
+            "shoop.campaigns.models.context_conditions:ContactGroupCondition",
+        ],
+        "campaign_basket_condition": [
+            "shoop.campaigns.models.basket_conditions:BasketTotalProductAmountCondition",
+            "shoop.campaigns.models.basket_conditions:BasketTotalAmountCondition",
+            "shoop.campaigns.models.basket_conditions:ProductsInBasketCondition"
+        ]
+    }

--- a/shoop/campaigns/forms.py
+++ b/shoop/campaigns/forms.py
@@ -1,0 +1,233 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.core.exceptions import ValidationError
+from django.db.models import OneToOneField
+from django.forms import ChoiceField, ModelForm
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.admin.forms.fields import PercentageField
+from shoop.apps.provides import get_provide_objects
+from shoop.campaigns.models.campaigns import (
+    BasketCampaign, CatalogCampaign, Coupon
+)
+from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
+
+CAMPAIGN_COMMON_FIELDS = [
+    'name',
+    'shop',
+    "public_name",
+    'discount_percentage',
+    'discount_amount_value',
+    'active',
+    'start_datetime',
+    'end_datetime'
+]
+
+
+class CampaignFormMixin(object):
+    rule_ids = set()
+    existing_rules = []
+    rule_field = None
+    provide_keys = None
+
+    def _get_values_for_identifier(self, key, identifier):
+        """
+        Returns values from rule based on the key and the identifier.
+
+        Key can be either `condition` or `filter`.
+
+        `identifier` is an identifier string available in:
+          * `shoop.campaigns.basket_conditions.BasketCondition`
+          * `shoop.campaigns.catalog_filters.CatalogFilter`
+          * `shoop.campaigns.context_conditions.ContextCondition`
+
+        Returns a queryset of objects or a single value found from conditions or filters.
+        Returns `None` if nothing is found
+        """
+        object_set = getattr(self.instance, "%ss" % key)
+        for condition_or_filter in object_set.all():
+            if condition_or_filter.identifier == identifier:
+                if condition_or_filter.model:
+                    return condition_or_filter.values.all()
+                else:
+                    return condition_or_filter.value
+
+    def get_initial_value(self, identifier):
+        if self.instance.pk:
+            for key in ["condition", "filter"]:
+                if key in identifier:
+                    return self._get_values_for_identifier(key, identifier)
+
+    def __init__(self, *args, **kwargs):
+        self.request = kwargs.pop("request")
+        super(CampaignFormMixin, self).__init__(*args, **kwargs)
+
+        for provide_key in self.provide_keys:
+            for cls in sorted(get_provide_objects(provide_key), key=lambda x: x.name):
+                obj = cls()
+                if obj.identifier in self.fields:
+                    continue
+
+                for field in obj._meta.get_fields(include_parents=False):
+                    if isinstance(field, OneToOneField):
+                        continue
+
+                    kwargs = {
+                        "initial": self.get_initial_value(obj.identifier),
+                        "required": False,  # rules are not required by default, validation is made later on
+                        "help_text": obj.description
+                    }
+                    self.rule_ids.add(obj.identifier)
+                    self.fields[obj.identifier] = field.formfield(**kwargs)
+
+    def clean(self):
+        """ Ensure atleast one rule is set """
+        data = super(CampaignFormMixin, self).clean()
+
+        if data.get("discount_percentage") and data.get("discount_amount_value"):
+            raise ValidationError(_("You should only define either discount percentage or amount."))
+
+        if not any([data.get("discount_percentage"), data.get("discount_amount_value")]):
+            raise ValidationError(_("You must define discount percentage or amount."))
+
+        return data
+
+    def clean_discount_percentage(self):
+        percentage = self.cleaned_data.get("discount_percentage", 0)
+        if percentage and percentage < 0:
+            raise ValidationError(_("Discount percentage cannot be negative."))
+        return percentage
+
+    def clean_discount_amount_value(self):
+        amount = self.cleaned_data.get("discount_amount_value", 0)
+        if amount and amount < 0:
+            raise ValidationError(_("Discount amount cannot be negative."))
+        return amount
+
+    def clean_end_datetime(self):
+        end_datetime = self.cleaned_data.get("end_datetime")
+        # TODO: allow only end dates that are after start date
+        return end_datetime
+
+    def save(self, commit=True):
+        instance = super(CampaignFormMixin, self).save(commit)
+        if self.cleaned_data.get("coupon"):
+            instance.coupon = Coupon.objects.get(pk=self.cleaned_data.get("coupon"))
+
+        if hasattr(instance, "conditions"):
+            instance.conditions.clear()
+
+        if hasattr(instance, "filters"):
+            instance.filters.clear()
+
+        instance.save()
+
+        for provide_key in self.provide_keys:
+            for cls in get_provide_objects(provide_key):
+                if not self.cleaned_data[cls.identifier]:
+                    continue
+
+                field_value = self.cleaned_data[cls.identifier]
+                rule = cls.objects.create()
+                if rule.model:
+                    rule.values = rule.model.objects.filter(pk__in=field_value)
+                else:
+                    rule.value = field_value
+                rule.save()
+                if "condition" in cls.identifier:  # a bit weak but to rely this
+                    instance.conditions.add(rule)
+                else:
+                    instance.filters.add(rule)
+
+        instance.save()
+
+        if not instance.created_by:
+            instance.created_by = self.request.user
+            instance.modified_by = self.request.user
+            instance.save()
+
+        return instance
+
+
+class CatalogCampaignForm(CampaignFormMixin, MultiLanguageModelForm):
+    provide_keys = ["campaign_catalog_filter", "campaign_context_condition"]
+
+    discount_percentage = CatalogCampaign._meta.get_field("discount_percentage").formfield(form_class=PercentageField)
+
+    class Meta:
+        model = CatalogCampaign
+        fields = CAMPAIGN_COMMON_FIELDS
+
+    def clean(self):
+        data = super(CatalogCampaignForm, self).clean()
+        any_rules_set = any([data.get(rule_field, False) for rule_field in self.rule_ids])
+        if not any_rules_set:
+            raise ValidationError(_("You must set at least one rule for this campaign."), code="no_rules_set")
+        return data
+
+
+class BasketCampaignForm(CampaignFormMixin, MultiLanguageModelForm):
+    provide_keys = ["campaign_basket_condition"]
+
+    discount_percentage = CatalogCampaign._meta.get_field("discount_percentage").formfield(form_class=PercentageField)
+
+    class Meta:
+        model = BasketCampaign
+        fields = CAMPAIGN_COMMON_FIELDS
+
+    def __init__(self, *args, **kwargs):
+        super(BasketCampaignForm, self).__init__(*args, **kwargs)
+
+        # TODO (campaigns): add only those that are not being used
+        coupon_code_choices = [('', '')] + list(Coupon.objects.filter(active=True).values_list("pk", "code"))
+        field_kwargs = dict(choices=coupon_code_choices, required=False)
+        field_kwargs["help_text"] = _("Define the required coupon for this campaign.")
+        if self.instance.pk and self.instance.coupon:
+            field_kwargs["initial"] = self.instance.coupon.pk
+
+        self.fields["coupon"] = ChoiceField(**field_kwargs)
+
+    def clean(self):
+        """ Ensure atleast one rule is set """
+        data = super(BasketCampaignForm, self).clean()
+        any_rules_set = any([data.get(rule_field, False) for rule_field in self.rule_ids])
+        if not any_rules_set and self.cleaned_data.get("coupon"):
+            any_rules_set = True
+
+        if not any_rules_set:
+            raise ValidationError(
+                _("You must set atleast one rule or discount code for this campaign."),
+                code="no_rules_set")
+        return data
+
+
+class CouponForm(ModelForm):
+    autogenerate = forms.BooleanField(label=_("Autogenerate code"), required=False)
+
+    class Meta:
+        model = Coupon
+        fields = [
+            'code',
+            'usage_limit_customer',
+            'usage_limit',
+            'active'
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super(CouponForm, self).__init__(*args, **kwargs)
+        if self.instance.pk and self.instance.has_been_used():
+            self.fields["code"].readonly = True
+
+    def clean_code(self):
+        code = self.cleaned_data["code"]
+        qs = Coupon.objects.filter(code=code)
+        if self.instance.pk:
+            qs = qs.exclude(pk=self.instance.pk)
+        if qs.exists():
+            raise ValidationError(_("Discount Code already in use."))
+        return code

--- a/shoop/campaigns/locale/en/LC_MESSAGES/django.po
+++ b/shoop/campaigns/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,331 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-01 18:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Campaigns"
+msgstr ""
+
+msgid "Catalog Campaigns"
+msgstr ""
+
+msgid "Show Catalog Campaigns"
+msgstr ""
+
+msgid "Basket Campaigns"
+msgstr ""
+
+msgid "Show Basket Campaigns"
+msgstr ""
+
+msgid "Coupons"
+msgstr ""
+
+msgid "Show Coupons"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Discount percentage"
+msgstr ""
+
+msgid "Discount amount"
+msgstr ""
+
+msgid "Starts"
+msgstr ""
+
+msgid "Ends"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "CatalogCampaign"
+msgstr ""
+
+msgid "Used Conditions"
+msgstr ""
+
+msgid "Used filters"
+msgstr ""
+
+msgid "Create new Catalog Campaign"
+msgstr ""
+
+msgid "Discount Code"
+msgstr ""
+
+msgid "Create new Basket Campaign"
+msgstr ""
+
+msgid "Catalog Campaign"
+msgstr ""
+
+msgid "Basket Campaign"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Usages"
+msgstr ""
+
+msgid "Usages Limit per contact"
+msgstr ""
+
+msgid "Usage Limit"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Date created"
+msgstr ""
+
+msgid "Create new Coupon"
+msgstr ""
+
+msgid "Coupon"
+msgstr ""
+
+msgid "You should only define either discount percentage or amount."
+msgstr ""
+
+msgid "You must define discount percentage or amount."
+msgstr ""
+
+msgid "Discount percentage cannot be negative."
+msgstr ""
+
+msgid "Discount amount cannot be negative."
+msgstr ""
+
+msgid "You must set at least one rule for this campaign."
+msgstr ""
+
+msgid "Define the required coupon for this campaign."
+msgstr ""
+
+msgid "You must set atleast one rule or discount code for this campaign."
+msgstr ""
+
+msgid "Autogenerate code"
+msgstr ""
+
+msgid "Discount Code already in use."
+msgstr ""
+
+msgid "Basket condition"
+msgstr ""
+
+msgid "Basket product count"
+msgstr ""
+
+msgid "product count in basket"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has atleast the product count entered "
+"here."
+msgstr ""
+
+msgid "Basket total value"
+msgstr ""
+
+msgid "basket total amount"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has at least the total value entered "
+"here worth of products."
+msgstr ""
+
+msgid "Products in basket"
+msgstr ""
+
+msgid "products"
+msgstr ""
+
+msgid "Limit the campaign to have the selected products in basket."
+msgstr ""
+
+msgid "shop"
+msgstr ""
+
+msgid "The shop where campaign is active."
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "The name for this campaign."
+msgstr ""
+
+msgid "discount percentage"
+msgstr ""
+
+msgid "The discount percentage for this campaign."
+msgstr ""
+
+msgid "discount amount value"
+msgstr ""
+
+msgid "Flat amount of discount. Mutually exclusive with percentage."
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "start date and time"
+msgstr ""
+
+msgid "end date and time"
+msgstr ""
+
+msgid "created by"
+msgstr ""
+
+msgid "modified by"
+msgstr ""
+
+msgid "created on"
+msgstr ""
+
+msgid "modified on"
+msgstr ""
+
+msgid "Campaign"
+msgstr ""
+
+#, python-format
+msgid "Catalog Campaign: %(name)s"
+msgstr ""
+
+msgid "basket line text"
+msgstr ""
+
+msgid "This text will be shown in basket."
+msgstr ""
+
+#, python-format
+msgid "Basket Campaign: %(name)s"
+msgstr ""
+
+msgid "usage limit per customer"
+msgstr ""
+
+msgid "Limit the amount of usages per a single customer."
+msgstr ""
+
+msgid "usage limit"
+msgstr ""
+
+msgid ""
+"Set the absolute limit of usages for this coupon. If the limit is zero (0) "
+"coupon cannot be used."
+msgstr ""
+
+msgid "is active"
+msgstr ""
+
+msgid "Cannot have two same codes active at the same time."
+msgstr ""
+
+msgid "Base Catalog Filter"
+msgstr ""
+
+msgid "Product type"
+msgstr ""
+
+msgid "product Types"
+msgstr ""
+
+msgid "Limit the campaign to selected product types."
+msgstr ""
+
+msgid "Product"
+msgstr ""
+
+msgid "product"
+msgstr ""
+
+msgid "Limit the campaign to selected products."
+msgstr ""
+
+msgid "Product Category"
+msgstr ""
+
+msgid "categories"
+msgstr ""
+
+msgid "Limit the campaign to products in selected categories."
+msgstr ""
+
+msgid "Context Condition"
+msgstr ""
+
+msgid "Contact Group"
+msgstr ""
+
+msgid "Contact group"
+msgstr ""
+
+msgid "contact groups"
+msgstr ""
+
+msgid "Limit the campaign to members of the selected contact groups."
+msgstr ""
+
+msgid "Campaign Basket Discounts"
+msgstr ""
+
+msgid "Coupon Code:"
+msgstr ""
+
+msgid "New Campaign"
+msgstr ""
+
+msgid "General information"
+msgstr ""
+
+msgid "Campaign Rules"
+msgstr ""
+
+msgid "Matching Rules"
+msgstr ""
+
+msgid ""
+"The following fields determine when this campaign applies. You must select "
+"atleast one rule to be able to save this campaign."
+msgstr ""
+
+msgid "New Discount Code"
+msgstr ""
+
+msgid "Generate"
+msgstr ""
+
+#, python-format
+msgid "%(coupons)s used"
+msgstr ""

--- a/shoop/campaigns/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shoop/campaigns/locale/fi_FI/LC_MESSAGES/django.po
@@ -1,0 +1,331 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-01 18:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Campaigns"
+msgstr ""
+
+msgid "Catalog Campaigns"
+msgstr ""
+
+msgid "Show Catalog Campaigns"
+msgstr ""
+
+msgid "Basket Campaigns"
+msgstr ""
+
+msgid "Show Basket Campaigns"
+msgstr ""
+
+msgid "Coupons"
+msgstr ""
+
+msgid "Show Coupons"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Discount percentage"
+msgstr ""
+
+msgid "Discount amount"
+msgstr ""
+
+msgid "Starts"
+msgstr ""
+
+msgid "Ends"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "CatalogCampaign"
+msgstr ""
+
+msgid "Used Conditions"
+msgstr ""
+
+msgid "Used filters"
+msgstr ""
+
+msgid "Create new Catalog Campaign"
+msgstr ""
+
+msgid "Discount Code"
+msgstr ""
+
+msgid "Create new Basket Campaign"
+msgstr ""
+
+msgid "Catalog Campaign"
+msgstr ""
+
+msgid "Basket Campaign"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Usages"
+msgstr ""
+
+msgid "Usages Limit per contact"
+msgstr ""
+
+msgid "Usage Limit"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Date created"
+msgstr ""
+
+msgid "Create new Coupon"
+msgstr ""
+
+msgid "Coupon"
+msgstr ""
+
+msgid "You should only define either discount percentage or amount."
+msgstr ""
+
+msgid "You must define discount percentage or amount."
+msgstr ""
+
+msgid "Discount percentage cannot be negative."
+msgstr ""
+
+msgid "Discount amount cannot be negative."
+msgstr ""
+
+msgid "You must set at least one rule for this campaign."
+msgstr ""
+
+msgid "Define the required coupon for this campaign."
+msgstr ""
+
+msgid "You must set atleast one rule or discount code for this campaign."
+msgstr ""
+
+msgid "Autogenerate code"
+msgstr ""
+
+msgid "Discount Code already in use."
+msgstr ""
+
+msgid "Basket condition"
+msgstr ""
+
+msgid "Basket product count"
+msgstr ""
+
+msgid "product count in basket"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has atleast the product count entered "
+"here."
+msgstr ""
+
+msgid "Basket total value"
+msgstr ""
+
+msgid "basket total amount"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has at least the total value entered "
+"here worth of products."
+msgstr ""
+
+msgid "Products in basket"
+msgstr ""
+
+msgid "products"
+msgstr ""
+
+msgid "Limit the campaign to have the selected products in basket."
+msgstr ""
+
+msgid "shop"
+msgstr ""
+
+msgid "The shop where campaign is active."
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "The name for this campaign."
+msgstr ""
+
+msgid "discount percentage"
+msgstr ""
+
+msgid "The discount percentage for this campaign."
+msgstr ""
+
+msgid "discount amount value"
+msgstr ""
+
+msgid "Flat amount of discount. Mutually exclusive with percentage."
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "start date and time"
+msgstr ""
+
+msgid "end date and time"
+msgstr ""
+
+msgid "created by"
+msgstr ""
+
+msgid "modified by"
+msgstr ""
+
+msgid "created on"
+msgstr ""
+
+msgid "modified on"
+msgstr ""
+
+msgid "Campaign"
+msgstr ""
+
+#, python-format
+msgid "Catalog Campaign: %(name)s"
+msgstr ""
+
+msgid "basket line text"
+msgstr ""
+
+msgid "This text will be shown in basket."
+msgstr ""
+
+#, python-format
+msgid "Basket Campaign: %(name)s"
+msgstr ""
+
+msgid "usage limit per customer"
+msgstr ""
+
+msgid "Limit the amount of usages per a single customer."
+msgstr ""
+
+msgid "usage limit"
+msgstr ""
+
+msgid ""
+"Set the absolute limit of usages for this coupon. If the limit is zero (0) "
+"coupon cannot be used."
+msgstr ""
+
+msgid "is active"
+msgstr ""
+
+msgid "Cannot have two same codes active at the same time."
+msgstr ""
+
+msgid "Base Catalog Filter"
+msgstr ""
+
+msgid "Product type"
+msgstr ""
+
+msgid "product Types"
+msgstr ""
+
+msgid "Limit the campaign to selected product types."
+msgstr ""
+
+msgid "Product"
+msgstr ""
+
+msgid "product"
+msgstr ""
+
+msgid "Limit the campaign to selected products."
+msgstr ""
+
+msgid "Product Category"
+msgstr ""
+
+msgid "categories"
+msgstr ""
+
+msgid "Limit the campaign to products in selected categories."
+msgstr ""
+
+msgid "Context Condition"
+msgstr ""
+
+msgid "Contact Group"
+msgstr ""
+
+msgid "Contact group"
+msgstr ""
+
+msgid "contact groups"
+msgstr ""
+
+msgid "Limit the campaign to members of the selected contact groups."
+msgstr ""
+
+msgid "Campaign Basket Discounts"
+msgstr ""
+
+msgid "Coupon Code:"
+msgstr ""
+
+msgid "New Campaign"
+msgstr ""
+
+msgid "General information"
+msgstr ""
+
+msgid "Campaign Rules"
+msgstr ""
+
+msgid "Matching Rules"
+msgstr ""
+
+msgid ""
+"The following fields determine when this campaign applies. You must select "
+"atleast one rule to be able to save this campaign."
+msgstr ""
+
+msgid "New Discount Code"
+msgstr ""
+
+msgid "Generate"
+msgstr ""
+
+#, python-format
+msgid "%(coupons)s used"
+msgstr ""

--- a/shoop/campaigns/locale/ja_JP/LC_MESSAGES/django.po
+++ b/shoop/campaigns/locale/ja_JP/LC_MESSAGES/django.po
@@ -1,0 +1,331 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-01 18:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Campaigns"
+msgstr ""
+
+msgid "Catalog Campaigns"
+msgstr ""
+
+msgid "Show Catalog Campaigns"
+msgstr ""
+
+msgid "Basket Campaigns"
+msgstr ""
+
+msgid "Show Basket Campaigns"
+msgstr ""
+
+msgid "Coupons"
+msgstr ""
+
+msgid "Show Coupons"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Discount percentage"
+msgstr ""
+
+msgid "Discount amount"
+msgstr ""
+
+msgid "Starts"
+msgstr ""
+
+msgid "Ends"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "CatalogCampaign"
+msgstr ""
+
+msgid "Used Conditions"
+msgstr ""
+
+msgid "Used filters"
+msgstr ""
+
+msgid "Create new Catalog Campaign"
+msgstr ""
+
+msgid "Discount Code"
+msgstr ""
+
+msgid "Create new Basket Campaign"
+msgstr ""
+
+msgid "Catalog Campaign"
+msgstr ""
+
+msgid "Basket Campaign"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Usages"
+msgstr ""
+
+msgid "Usages Limit per contact"
+msgstr ""
+
+msgid "Usage Limit"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Date created"
+msgstr ""
+
+msgid "Create new Coupon"
+msgstr ""
+
+msgid "Coupon"
+msgstr ""
+
+msgid "You should only define either discount percentage or amount."
+msgstr ""
+
+msgid "You must define discount percentage or amount."
+msgstr ""
+
+msgid "Discount percentage cannot be negative."
+msgstr ""
+
+msgid "Discount amount cannot be negative."
+msgstr ""
+
+msgid "You must set at least one rule for this campaign."
+msgstr ""
+
+msgid "Define the required coupon for this campaign."
+msgstr ""
+
+msgid "You must set atleast one rule or discount code for this campaign."
+msgstr ""
+
+msgid "Autogenerate code"
+msgstr ""
+
+msgid "Discount Code already in use."
+msgstr ""
+
+msgid "Basket condition"
+msgstr ""
+
+msgid "Basket product count"
+msgstr ""
+
+msgid "product count in basket"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has atleast the product count entered "
+"here."
+msgstr ""
+
+msgid "Basket total value"
+msgstr ""
+
+msgid "basket total amount"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has at least the total value entered "
+"here worth of products."
+msgstr ""
+
+msgid "Products in basket"
+msgstr ""
+
+msgid "products"
+msgstr ""
+
+msgid "Limit the campaign to have the selected products in basket."
+msgstr ""
+
+msgid "shop"
+msgstr ""
+
+msgid "The shop where campaign is active."
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "The name for this campaign."
+msgstr ""
+
+msgid "discount percentage"
+msgstr ""
+
+msgid "The discount percentage for this campaign."
+msgstr ""
+
+msgid "discount amount value"
+msgstr ""
+
+msgid "Flat amount of discount. Mutually exclusive with percentage."
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "start date and time"
+msgstr ""
+
+msgid "end date and time"
+msgstr ""
+
+msgid "created by"
+msgstr ""
+
+msgid "modified by"
+msgstr ""
+
+msgid "created on"
+msgstr ""
+
+msgid "modified on"
+msgstr ""
+
+msgid "Campaign"
+msgstr ""
+
+#, python-format
+msgid "Catalog Campaign: %(name)s"
+msgstr ""
+
+msgid "basket line text"
+msgstr ""
+
+msgid "This text will be shown in basket."
+msgstr ""
+
+#, python-format
+msgid "Basket Campaign: %(name)s"
+msgstr ""
+
+msgid "usage limit per customer"
+msgstr ""
+
+msgid "Limit the amount of usages per a single customer."
+msgstr ""
+
+msgid "usage limit"
+msgstr ""
+
+msgid ""
+"Set the absolute limit of usages for this coupon. If the limit is zero (0) "
+"coupon cannot be used."
+msgstr ""
+
+msgid "is active"
+msgstr ""
+
+msgid "Cannot have two same codes active at the same time."
+msgstr ""
+
+msgid "Base Catalog Filter"
+msgstr ""
+
+msgid "Product type"
+msgstr ""
+
+msgid "product Types"
+msgstr ""
+
+msgid "Limit the campaign to selected product types."
+msgstr ""
+
+msgid "Product"
+msgstr ""
+
+msgid "product"
+msgstr ""
+
+msgid "Limit the campaign to selected products."
+msgstr ""
+
+msgid "Product Category"
+msgstr ""
+
+msgid "categories"
+msgstr ""
+
+msgid "Limit the campaign to products in selected categories."
+msgstr ""
+
+msgid "Context Condition"
+msgstr ""
+
+msgid "Contact Group"
+msgstr ""
+
+msgid "Contact group"
+msgstr ""
+
+msgid "contact groups"
+msgstr ""
+
+msgid "Limit the campaign to members of the selected contact groups."
+msgstr ""
+
+msgid "Campaign Basket Discounts"
+msgstr ""
+
+msgid "Coupon Code:"
+msgstr ""
+
+msgid "New Campaign"
+msgstr ""
+
+msgid "General information"
+msgstr ""
+
+msgid "Campaign Rules"
+msgstr ""
+
+msgid "Matching Rules"
+msgstr ""
+
+msgid ""
+"The following fields determine when this campaign applies. You must select "
+"atleast one rule to be able to save this campaign."
+msgstr ""
+
+msgid "New Discount Code"
+msgstr ""
+
+msgid "Generate"
+msgstr ""
+
+#, python-format
+msgid "%(coupons)s used"
+msgstr ""

--- a/shoop/campaigns/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/shoop/campaigns/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1,0 +1,332 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-02-01 18:04+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "Campaigns"
+msgstr ""
+
+msgid "Catalog Campaigns"
+msgstr ""
+
+msgid "Show Catalog Campaigns"
+msgstr ""
+
+msgid "Basket Campaigns"
+msgstr ""
+
+msgid "Show Basket Campaigns"
+msgstr ""
+
+msgid "Coupons"
+msgstr ""
+
+msgid "Show Coupons"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Discount percentage"
+msgstr ""
+
+msgid "Discount amount"
+msgstr ""
+
+msgid "Starts"
+msgstr ""
+
+msgid "Ends"
+msgstr ""
+
+msgid "Active"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "Yes"
+msgstr ""
+
+msgid "CatalogCampaign"
+msgstr ""
+
+msgid "Used Conditions"
+msgstr ""
+
+msgid "Used filters"
+msgstr ""
+
+msgid "Create new Catalog Campaign"
+msgstr ""
+
+msgid "Discount Code"
+msgstr ""
+
+msgid "Create new Basket Campaign"
+msgstr ""
+
+msgid "Catalog Campaign"
+msgstr ""
+
+msgid "Basket Campaign"
+msgstr ""
+
+msgid "Code"
+msgstr ""
+
+msgid "Usages"
+msgstr ""
+
+msgid "Usages Limit per contact"
+msgstr ""
+
+msgid "Usage Limit"
+msgstr ""
+
+msgid "Created by"
+msgstr ""
+
+msgid "Date created"
+msgstr ""
+
+msgid "Create new Coupon"
+msgstr ""
+
+msgid "Coupon"
+msgstr ""
+
+msgid "You should only define either discount percentage or amount."
+msgstr ""
+
+msgid "You must define discount percentage or amount."
+msgstr ""
+
+msgid "Discount percentage cannot be negative."
+msgstr ""
+
+msgid "Discount amount cannot be negative."
+msgstr ""
+
+msgid "You must set at least one rule for this campaign."
+msgstr ""
+
+msgid "Define the required coupon for this campaign."
+msgstr ""
+
+msgid "You must set atleast one rule or discount code for this campaign."
+msgstr ""
+
+msgid "Autogenerate code"
+msgstr ""
+
+msgid "Discount Code already in use."
+msgstr ""
+
+msgid "Basket condition"
+msgstr ""
+
+msgid "Basket product count"
+msgstr ""
+
+msgid "product count in basket"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has atleast the product count entered "
+"here."
+msgstr ""
+
+msgid "Basket total value"
+msgstr ""
+
+msgid "basket total amount"
+msgstr ""
+
+msgid ""
+"Limit the campaign to match when it has at least the total value entered "
+"here worth of products."
+msgstr ""
+
+msgid "Products in basket"
+msgstr ""
+
+msgid "products"
+msgstr ""
+
+msgid "Limit the campaign to have the selected products in basket."
+msgstr ""
+
+msgid "shop"
+msgstr ""
+
+msgid "The shop where campaign is active."
+msgstr ""
+
+msgid "name"
+msgstr ""
+
+msgid "The name for this campaign."
+msgstr ""
+
+msgid "discount percentage"
+msgstr ""
+
+msgid "The discount percentage for this campaign."
+msgstr ""
+
+msgid "discount amount value"
+msgstr ""
+
+msgid "Flat amount of discount. Mutually exclusive with percentage."
+msgstr ""
+
+msgid "active"
+msgstr ""
+
+msgid "start date and time"
+msgstr ""
+
+msgid "end date and time"
+msgstr ""
+
+msgid "created by"
+msgstr ""
+
+msgid "modified by"
+msgstr ""
+
+msgid "created on"
+msgstr ""
+
+msgid "modified on"
+msgstr ""
+
+msgid "Campaign"
+msgstr ""
+
+#, python-format
+msgid "Catalog Campaign: %(name)s"
+msgstr ""
+
+msgid "basket line text"
+msgstr ""
+
+msgid "This text will be shown in basket."
+msgstr ""
+
+#, python-format
+msgid "Basket Campaign: %(name)s"
+msgstr ""
+
+msgid "usage limit per customer"
+msgstr ""
+
+msgid "Limit the amount of usages per a single customer."
+msgstr ""
+
+msgid "usage limit"
+msgstr ""
+
+msgid ""
+"Set the absolute limit of usages for this coupon. If the limit is zero (0) "
+"coupon cannot be used."
+msgstr ""
+
+msgid "is active"
+msgstr ""
+
+msgid "Cannot have two same codes active at the same time."
+msgstr ""
+
+msgid "Base Catalog Filter"
+msgstr ""
+
+msgid "Product type"
+msgstr ""
+
+msgid "product Types"
+msgstr ""
+
+msgid "Limit the campaign to selected product types."
+msgstr ""
+
+msgid "Product"
+msgstr ""
+
+msgid "product"
+msgstr ""
+
+msgid "Limit the campaign to selected products."
+msgstr ""
+
+msgid "Product Category"
+msgstr ""
+
+msgid "categories"
+msgstr ""
+
+msgid "Limit the campaign to products in selected categories."
+msgstr ""
+
+msgid "Context Condition"
+msgstr ""
+
+msgid "Contact Group"
+msgstr ""
+
+msgid "Contact group"
+msgstr ""
+
+msgid "contact groups"
+msgstr ""
+
+msgid "Limit the campaign to members of the selected contact groups."
+msgstr ""
+
+msgid "Campaign Basket Discounts"
+msgstr ""
+
+msgid "Coupon Code:"
+msgstr ""
+
+msgid "New Campaign"
+msgstr ""
+
+msgid "General information"
+msgstr ""
+
+msgid "Campaign Rules"
+msgstr ""
+
+msgid "Matching Rules"
+msgstr ""
+
+msgid ""
+"The following fields determine when this campaign applies. You must select "
+"atleast one rule to be able to save this campaign."
+msgstr ""
+
+msgid "New Discount Code"
+msgstr ""
+
+msgid "Generate"
+msgstr ""
+
+#, python-format
+msgid "%(coupons)s used"
+msgstr ""

--- a/shoop/campaigns/migrations/0001_initial.py
+++ b/shoop/campaigns/migrations/0001_initial.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import shoop.core.fields
+import django.db.models.deletion
+import shoop.utils.properties
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('shoop', '0015_product_minimum_price'),
+        ('contenttypes', '0002_remove_content_type_name'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='BasketCampaign',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('name', models.CharField(help_text='The name for this campaign.', verbose_name='name', max_length=120)),
+                ('identifier', shoop.core.fields.InternalIdentifierField(null=True, editable=False, unique=True, max_length=64, blank=True)),
+                ('discount_percentage', models.DecimalField(help_text='The discount percentage for this campaign.', null=True, max_digits=6, decimal_places=5, verbose_name='discount percentage', blank=True)),
+                ('discount_amount_value', shoop.core.fields.MoneyValueField(help_text='Flat amount of discount. Mutually exclusive with percentage.', null=True, max_digits=36, decimal_places=9, verbose_name='discount amount value', blank=True, default=None)),
+                ('active', models.BooleanField(verbose_name='active', default=False)),
+                ('start_datetime', models.DateTimeField(null=True, blank=True, verbose_name='start date and time')),
+                ('end_datetime', models.DateTimeField(null=True, blank=True, verbose_name='end date and time')),
+                ('created_on', models.DateTimeField(verbose_name='created on', auto_now_add=True)),
+                ('modified_on', models.DateTimeField(verbose_name='modified on', auto_now=True)),
+                ('basket_line_text', models.CharField(help_text='This text will be shown in basket.', verbose_name='basket line text', max_length=120)),
+            ],
+            options={
+                'verbose_name_plural': 'Campaigns',
+                'verbose_name': 'Campaign',
+                'abstract': False,
+            },
+            bases=(shoop.utils.properties.MoneyPropped, models.Model),
+        ),
+        migrations.CreateModel(
+            name='BasketCampaignTranslation',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('language_code', models.CharField(max_length=15, verbose_name='Language', db_index=True)),
+                ('public_name', models.CharField(max_length=120)),
+                ('master', models.ForeignKey(related_name='translations', null=True, editable=False, to='campaigns.BasketCampaign')),
+            ],
+            options={
+                'managed': True,
+                'db_table': 'campaigns_basketcampaign_translation',
+                'db_tablespace': '',
+                'default_permissions': (),
+                'verbose_name': 'Campaign Translation',
+            },
+        ),
+        migrations.CreateModel(
+            name='BasketCondition',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('active', models.BooleanField(default=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='CatalogCampaign',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('name', models.CharField(help_text='The name for this campaign.', verbose_name='name', max_length=120)),
+                ('identifier', shoop.core.fields.InternalIdentifierField(null=True, editable=False, unique=True, max_length=64, blank=True)),
+                ('discount_percentage', models.DecimalField(help_text='The discount percentage for this campaign.', null=True, max_digits=6, decimal_places=5, verbose_name='discount percentage', blank=True)),
+                ('discount_amount_value', shoop.core.fields.MoneyValueField(help_text='Flat amount of discount. Mutually exclusive with percentage.', null=True, max_digits=36, decimal_places=9, verbose_name='discount amount value', blank=True, default=None)),
+                ('active', models.BooleanField(verbose_name='active', default=False)),
+                ('start_datetime', models.DateTimeField(null=True, blank=True, verbose_name='start date and time')),
+                ('end_datetime', models.DateTimeField(null=True, blank=True, verbose_name='end date and time')),
+                ('created_on', models.DateTimeField(verbose_name='created on', auto_now_add=True)),
+                ('modified_on', models.DateTimeField(verbose_name='modified on', auto_now=True)),
+            ],
+            options={
+                'verbose_name_plural': 'Campaigns',
+                'verbose_name': 'Campaign',
+                'abstract': False,
+            },
+            bases=(shoop.utils.properties.MoneyPropped, models.Model),
+        ),
+        migrations.CreateModel(
+            name='CatalogCampaignTranslation',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('language_code', models.CharField(max_length=15, verbose_name='Language', db_index=True)),
+                ('public_name', models.CharField(max_length=120, blank=True)),
+                ('master', models.ForeignKey(related_name='translations', null=True, editable=False, to='campaigns.CatalogCampaign')),
+            ],
+            options={
+                'managed': True,
+                'db_table': 'campaigns_catalogcampaign_translation',
+                'db_tablespace': '',
+                'default_permissions': (),
+                'verbose_name': 'Campaign Translation',
+            },
+        ),
+        migrations.CreateModel(
+            name='CatalogFilter',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('active', models.BooleanField(verbose_name='active', default=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='ContextCondition',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('active', models.BooleanField(default=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='Coupon',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('code', models.CharField(max_length=12)),
+                ('usage_limit_customer', models.PositiveIntegerField(help_text='Limit the amount of usages per a single customer.', null=True, blank=True, verbose_name='usage limit per customer')),
+                ('usage_limit', models.PositiveIntegerField(help_text='Set the absolute limit of usages for this coupon. If the limit is zero (0) coupon cannot be used.', null=True, blank=True, verbose_name='usage limit')),
+                ('active', models.BooleanField(verbose_name='is active', default=False)),
+                ('created_on', models.DateTimeField(verbose_name='created on', auto_now_add=True)),
+                ('modified_on', models.DateTimeField(verbose_name='modified on', auto_now=True)),
+                ('created_by', models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='created by', blank=True)),
+                ('modified_by', models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='modified by', blank=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='CouponUsage',
+            fields=[
+                ('id', models.AutoField(primary_key=True, auto_created=True, verbose_name='ID', serialize=False)),
+                ('created_on', models.DateTimeField(verbose_name='created on', auto_now_add=True)),
+                ('modified_on', models.DateTimeField(verbose_name='modified on', auto_now=True)),
+                ('coupon', models.ForeignKey(related_name='usages', to='campaigns.Coupon')),
+                ('created_by', models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='created by', blank=True)),
+                ('modified_by', models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='modified by', blank=True)),
+                ('order', models.ForeignKey(related_name='coupon_usages', to='shoop.Order')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='BasketTotalAmountCondition',
+            fields=[
+                ('basketcondition_ptr', models.OneToOneField(primary_key=True, to='campaigns.BasketCondition', parent_link=True, serialize=False, auto_created=True)),
+                ('amount_value', shoop.core.fields.MoneyValueField(null=True, max_digits=36, decimal_places=9, verbose_name='basket total amount', blank=True, default=None)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=(shoop.utils.properties.MoneyPropped, 'campaigns.basketcondition'),
+        ),
+        migrations.CreateModel(
+            name='BasketTotalProductAmountCondition',
+            fields=[
+                ('basketcondition_ptr', models.OneToOneField(primary_key=True, to='campaigns.BasketCondition', parent_link=True, serialize=False, auto_created=True)),
+                ('product_count', models.DecimalField(null=True, blank=True, max_digits=6, verbose_name='product count in basket', decimal_places=5)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.basketcondition',),
+        ),
+        migrations.CreateModel(
+            name='CategoryFilter',
+            fields=[
+                ('catalogfilter_ptr', models.OneToOneField(primary_key=True, to='campaigns.CatalogFilter', parent_link=True, serialize=False, auto_created=True)),
+                ('categories', models.ManyToManyField(verbose_name='categories', to='shoop.Category')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.catalogfilter',),
+        ),
+        migrations.CreateModel(
+            name='ContactGroupCondition',
+            fields=[
+                ('contextcondition_ptr', models.OneToOneField(primary_key=True, to='campaigns.ContextCondition', parent_link=True, serialize=False, auto_created=True)),
+                ('contact_groups', models.ManyToManyField(verbose_name='contact groups', to='shoop.ContactGroup')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.contextcondition',),
+        ),
+        migrations.CreateModel(
+            name='ProductFilter',
+            fields=[
+                ('catalogfilter_ptr', models.OneToOneField(primary_key=True, to='campaigns.CatalogFilter', parent_link=True, serialize=False, auto_created=True)),
+                ('products', models.ManyToManyField(verbose_name='product', to='shoop.Product')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.catalogfilter',),
+        ),
+        migrations.CreateModel(
+            name='ProductsInBasketCondition',
+            fields=[
+                ('basketcondition_ptr', models.OneToOneField(primary_key=True, to='campaigns.BasketCondition', parent_link=True, serialize=False, auto_created=True)),
+                ('products', models.ManyToManyField(to='shoop.Product', verbose_name='products', blank=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.basketcondition',),
+        ),
+        migrations.CreateModel(
+            name='ProductTypeFilter',
+            fields=[
+                ('catalogfilter_ptr', models.OneToOneField(primary_key=True, to='campaigns.CatalogFilter', parent_link=True, serialize=False, auto_created=True)),
+                ('product_types', models.ManyToManyField(verbose_name='product Types', to='shoop.ProductType')),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('campaigns.catalogfilter',),
+        ),
+        migrations.AddField(
+            model_name='contextcondition',
+            name='polymorphic_ctype',
+            field=models.ForeignKey(related_name='polymorphic_campaigns.contextcondition_set+', null=True, editable=False, to='contenttypes.ContentType'),
+        ),
+        migrations.AddField(
+            model_name='catalogfilter',
+            name='polymorphic_ctype',
+            field=models.ForeignKey(related_name='polymorphic_campaigns.catalogfilter_set+', null=True, editable=False, to='contenttypes.ContentType'),
+        ),
+        migrations.AddField(
+            model_name='catalogcampaign',
+            name='conditions',
+            field=models.ManyToManyField(related_name='campaign', to='campaigns.ContextCondition', blank=True),
+        ),
+        migrations.AddField(
+            model_name='catalogcampaign',
+            name='created_by',
+            field=models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='created by', blank=True),
+        ),
+        migrations.AddField(
+            model_name='catalogcampaign',
+            name='filters',
+            field=models.ManyToManyField(related_name='campaign', to='campaigns.CatalogFilter', blank=True),
+        ),
+        migrations.AddField(
+            model_name='catalogcampaign',
+            name='modified_by',
+            field=models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='modified by', blank=True),
+        ),
+        migrations.AddField(
+            model_name='catalogcampaign',
+            name='shop',
+            field=models.ForeignKey(help_text='The shop where campaign is active.', verbose_name='shop', to='shoop.Shop'),
+        ),
+        migrations.AddField(
+            model_name='basketcondition',
+            name='polymorphic_ctype',
+            field=models.ForeignKey(related_name='polymorphic_campaigns.basketcondition_set+', null=True, editable=False, to='contenttypes.ContentType'),
+        ),
+        migrations.AddField(
+            model_name='basketcampaign',
+            name='conditions',
+            field=models.ManyToManyField(related_name='campaign', to='campaigns.BasketCondition', blank=True),
+        ),
+        migrations.AddField(
+            model_name='basketcampaign',
+            name='coupon',
+            field=models.ForeignKey(related_name='campaign', null=True, to='campaigns.Coupon', blank=True),
+        ),
+        migrations.AddField(
+            model_name='basketcampaign',
+            name='created_by',
+            field=models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='created by', blank=True),
+        ),
+        migrations.AddField(
+            model_name='basketcampaign',
+            name='modified_by',
+            field=models.ForeignKey(related_name='+', null=True, to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.SET_NULL, verbose_name='modified by', blank=True),
+        ),
+        migrations.AddField(
+            model_name='basketcampaign',
+            name='shop',
+            field=models.ForeignKey(help_text='The shop where campaign is active.', verbose_name='shop', to='shoop.Shop'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='catalogcampaigntranslation',
+            unique_together=set([('language_code', 'master')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='basketcampaigntranslation',
+            unique_together=set([('language_code', 'master')]),
+        ),
+    ]

--- a/shoop/campaigns/models/__init__.py
+++ b/shoop/campaigns/models/__init__.py
@@ -1,0 +1,20 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from .basket_conditions import BasketCondition
+from .campaigns import BasketCampaign, Campaign, CatalogCampaign, Coupon
+from .catalog_filters import CatalogFilter
+from .context_conditions import ContextCondition
+
+__all__ = [
+    'BasketCampaign',
+    'BasketCondition',
+    'Campaign',
+    'CatalogCampaign',
+    'CatalogFilter',
+    'ContextCondition',
+    'Coupon',
+]

--- a/shoop/campaigns/models/basket_conditions.py
+++ b/shoop/campaigns/models/basket_conditions.py
@@ -1,0 +1,96 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.db import models
+from django.utils.encoding import force_text
+from django.utils.translation import ugettext_lazy as _
+from polymorphic.models import PolymorphicModel
+
+from shoop.core.fields import MoneyValueField
+from shoop.core.models import Product
+from shoop.utils.properties import MoneyPropped, PriceProperty
+
+
+class BasketCondition(PolymorphicModel):
+    model = None
+    active = models.BooleanField(default=True)
+    name = _("Basket condition")
+
+    def matches(self, basket, lines):
+        return False
+
+    def __str__(self):
+        return force_text(self.name)
+
+
+class BasketTotalProductAmountCondition(BasketCondition):
+    identifier = "basket_product_condition"
+    name = _("Basket product count")
+
+    product_count = models.DecimalField(
+        verbose_name=_("product count in basket"), blank=True, null=True, max_digits=6, decimal_places=5)
+
+    def matches(self, basket, lines):
+        return (basket.product_count >= self.product_count)
+
+    @property
+    def description(self):
+        return _("Limit the campaign to match when basket has atleast the product count entered here.")
+
+    @property
+    def value(self):
+        return self.product_count
+
+    @value.setter
+    def value(self, value):
+        self.product_count = value
+
+
+class BasketTotalAmountCondition(MoneyPropped, BasketCondition):
+    identifier = "basket_amount_condition"
+    name = _("Basket total value")
+
+    amount = PriceProperty("amount_value", "campaign.shop.currency", "campaign.shop.prices_include_tax")
+    amount_value = MoneyValueField(default=None, blank=True, null=True, verbose_name=_("basket total amount"))
+
+    def matches(self, basket, lines):
+        return (basket.total_price_of_products.value >= self.amount_value)
+
+    @property
+    def description(self):
+        return _("Limit the campaign to match when it has at least the total value entered here worth of products.")
+
+    @property
+    def value(self):
+        return self.amount_value
+
+    @value.setter
+    def value(self, value):
+        self.amount_value = value
+
+
+class ProductsInBasketCondition(BasketCondition):
+    identifier = "basket_products_condition"
+    name = _("Products in basket")
+
+    model = Product
+
+    products = models.ManyToManyField(Product, verbose_name=_("products"), blank=True)
+
+    def matches(self, basket, lines):
+        return any((product_id in basket.product_ids) for product_id in self.products.values_list("pk", flat=True))
+
+    @property
+    def description(self):
+        return _("Limit the campaign to have the selected products in basket.")
+
+    @property
+    def values(self):
+        return self.products
+
+    @values.setter
+    def values(self, value):
+        self.products = value

--- a/shoop/campaigns/models/campaigns.py
+++ b/shoop/campaigns/models/campaigns.py
@@ -1,0 +1,291 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import random
+import string
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils.encoding import force_text
+from django.utils.timezone import now
+from django.utils.translation import ugettext_lazy as _
+from parler.models import TranslatableModel, TranslatedFields
+
+from shoop.core.fields import InternalIdentifierField, MoneyValueField
+from shoop.core.models import Order, Shop, ShopProduct
+from shoop.utils.properties import MoneyPropped, PriceProperty
+
+
+class Campaign(MoneyPropped, TranslatableModel):
+    admin_url_suffix = None
+
+    shop = models.ForeignKey(Shop, verbose_name=_("shop"), help_text=_("The shop where campaign is active."))
+    name = models.CharField(max_length=120, verbose_name=_("name"), help_text=_("The name for this campaign."))
+
+    # translations in subclass
+
+    identifier = InternalIdentifierField(unique=True)
+    discount_percentage = models.DecimalField(
+        max_digits=6, decimal_places=5, blank=True, null=True,
+        verbose_name=_("discount percentage"),
+        help_text=_("The discount percentage for this campaign."))
+    discount_amount = PriceProperty("discount_amount_value", "shop.currency", "shop.prices_include_tax")
+    discount_amount_value = MoneyValueField(
+        default=None, blank=True, null=True,
+        verbose_name=_("discount amount value"),
+        help_text=_("Flat amount of discount. Mutually exclusive with percentage."))
+    active = models.BooleanField(default=False, verbose_name=_("active"))
+    start_datetime = models.DateTimeField(null=True, blank=True, verbose_name=_("start date and time"))
+    end_datetime = models.DateTimeField(null=True, blank=True, verbose_name=_("end date and time"))
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("created by"))
+    modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("modified by"))
+    created_on = models.DateTimeField(auto_now_add=True, editable=False, verbose_name=_("created on"))
+    modified_on = models.DateTimeField(auto_now=True, editable=False, verbose_name=_("modified on"))
+
+    # objects = CampaignManager()
+
+    class Meta:
+        abstract = True
+        verbose_name = _('Campaign')
+        verbose_name_plural = _('Campaigns')
+
+    def is_available(self):
+        if not self.active:  # move to manager?
+            return False
+        if self.start_datetime and self.end_datetime:
+            if self.start_datetime <= now() <= self.end_datetime:
+                return True
+            return False
+        elif self.start_datetime and not self.end_datetime:
+            if self.start_datetime > now():
+                return False
+        elif not self.start_datetime and self.end_datetime:
+            if self.end_datetime < now():
+                return False
+        return True
+
+    def save(self, **kwargs):
+        if self.discount_percentage and self.discount_amount_value:
+            raise ValidationError(_("You should only define either discount percentage or amount."))
+
+        if not (self.discount_percentage or self.discount_amount_value):
+            raise ValidationError(_("You must define discount percentage or amount."))
+
+        super(Campaign, self).save(**kwargs)
+
+
+class CatalogCampaign(Campaign):
+    _queryset = None
+
+    admin_url_suffix = "catalog_campaigns"
+    conditions = models.ManyToManyField('ContextCondition', blank=True, related_name='campaign')
+    filters = models.ManyToManyField('CatalogFilter', blank=True, related_name='campaign')
+
+    translations = TranslatedFields(public_name=models.CharField(max_length=120, blank=True))
+
+    def __str__(self):
+        return force_text(_("Catalog Campaign: %(name)s" % dict(name=self.name)))
+
+    def rules_match(self, context, shop_product):
+        if not self.is_available():
+            return False
+
+        if not self._queryset:
+            queryset = ShopProduct.objects.filter(shop=self.shop)
+            for catalog_filter in self.filters.all():
+                queryset = catalog_filter.filter_queryset(queryset)
+            self._queryset = queryset
+        filters_match = self._queryset.filter(pk=shop_product.pk).exists()
+
+        conditions_match = all(condition.matches(context) for condition in self.conditions.all())
+
+        return (conditions_match and filters_match)
+
+    @classmethod
+    def get_matching(cls, context, product):
+        matching = []
+        for campaign in cls.objects.filter(active=True, shop=context.shop):
+            if campaign.rules_match(context, product):
+                matching.append(campaign)
+        return matching
+
+
+class BasketCampaign(Campaign):
+    admin_url_suffix = "basket_campaigns"
+
+    basket_line_text = models.CharField(
+        max_length=120, verbose_name=_("basket line text"), help_text=_("This text will be shown in basket."))
+
+    conditions = models.ManyToManyField('BasketCondition', blank=True, related_name='campaign')
+    coupon = models.ForeignKey('Coupon', null=True, blank=True, related_name='campaign')
+
+    translations = TranslatedFields(
+        public_name=models.CharField(max_length=120)
+    )
+
+    def __str__(self):
+        return force_text(_("Basket Campaign: %(name)s" % dict(name=self.name)))
+
+    @classmethod
+    def get_matching(cls, basket, lines):
+        matching = []
+        for campaign in cls.objects.filter(active=True, shop=basket.shop):
+            if campaign.rules_match(basket, lines):
+                matching.append(campaign)
+        return matching
+
+    def rules_match(self, basket, lines):
+        """
+        Check if basket rules match.
+
+        They will not match if
+        1) The campaign is not active
+        2) The campaign has attached coupon
+           which doesn't match or is not active
+        3) Any of the attached rules doesn't match
+        """
+        if not self.is_available():
+            return False
+
+        if self.coupon and not self.coupon.active:
+            return False
+
+        matching_rules = [rule.matches(basket, lines) for rule in self.conditions.all()]
+
+        if self.coupon:
+            matching_rules.append((self.coupon.code in basket.codes))
+        return all(matching_rules)
+
+
+class CouponUsage(models.Model):
+    coupon = models.ForeignKey('Coupon', related_name='usages')
+    order = models.ForeignKey(Order, related_name='coupon_usages')
+
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("created by"))
+    modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("modified by"))
+
+    created_on = models.DateTimeField(auto_now_add=True, editable=False, verbose_name=_("created on"))
+    modified_on = models.DateTimeField(auto_now=True, editable=False, verbose_name=_("modified on"))
+
+    @classmethod
+    def add_usage(cls, order, coupon):
+        return cls.objects.create(order=order, coupon=coupon)
+
+
+class Coupon(models.Model):
+    admin_url_suffix = "coupons"
+
+    code = models.CharField(max_length=12)
+
+    usage_limit_customer = models.PositiveIntegerField(
+        blank=True, null=True,
+        verbose_name=_("usage limit per customer"), help_text=_("Limit the amount of usages per a single customer."))
+    usage_limit = models.PositiveIntegerField(
+        blank=True, null=True,
+        verbose_name=_("usage limit"),
+        help_text=_("Set the absolute limit of usages for this coupon. "
+                    "If the limit is zero (0) coupon cannot be used."))
+
+    active = models.BooleanField(default=False, verbose_name=_("is active"))
+
+    created_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("created by"))
+    modified_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL, blank=True, null=True,
+        related_name="+", on_delete=models.SET_NULL,
+        verbose_name=_("modified by"))
+
+    created_on = models.DateTimeField(auto_now_add=True, editable=False, verbose_name=_("created on"))
+    modified_on = models.DateTimeField(auto_now=True, editable=False, verbose_name=_("modified on"))
+
+    @classmethod
+    def generate_code(cls, length=6):
+        if length > 12:
+            length = 12
+        return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(length))
+
+    @property
+    def exhausted(self):
+        val = bool(self.usage_limit and self.usages.count() >= self.usage_limit)
+        return val
+
+    @property
+    def attached(self):
+        return BasketCampaign.objects.filter(coupon=self).exists()
+
+    def attach_to_campaign(self, campaign):
+        if not self.attached:
+            self.campaign = campaign
+
+    @classmethod
+    def is_usable(cls, code, customer):
+        try:
+            code = cls.objects.get(code=code)
+            return code.can_use_code(customer)
+        except cls.DoesNotExist:
+            return False
+
+    def can_use_code(self, customer):
+        """
+        Check if customer can use the code
+
+        :param customer:
+        :type customer: `Contact` or None
+        :rtype: True|False
+        """
+        if not self.active:
+            return False
+
+        if not self.attached:
+            return False
+
+        if self.usage_limit_customer:
+            if not customer or customer.is_anonymous:
+                return False
+            if (self.usages.filter(order__customer=customer, coupon=self).count() >= self.usage_limit_customer):
+                return False
+
+        return not self.exhausted
+
+    def use(self, order):
+        return CouponUsage.add_usage(order=order, coupon=self)
+
+    def increase_customer_usage_limit_by(self, amount):
+        if self.usage_limit_customer:
+            new_limit = self.usage_limit_customer + amount
+        else:
+            new_limit = self.usages.count() + amount
+        self.usage_limit_customer = new_limit
+
+    def increase_usage_limit_by(self, amount):
+        self.usage_limit = self.usage_limit + amount if self.usage_limit else (self.usages.count() + amount)
+
+    def has_been_used(self, usage_count=1):
+        """ See if code is used the times given """
+        return CouponUsage.objects.filter(coupon=self).count() >= usage_count
+
+    def save(self, **kwargs):
+        if Coupon.objects.filter(code=self.code, active=True).exclude(pk=self.pk).exists():
+            raise ValidationError(_("Cannot have two same codes active at the same time."))
+        return super(Coupon, self).save(**kwargs)
+
+    def __str__(self):
+        return self.code

--- a/shoop/campaigns/models/catalog_filters.py
+++ b/shoop/campaigns/models/catalog_filters.py
@@ -1,0 +1,92 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from polymorphic.models import PolymorphicModel
+
+from shoop.core.models import Category, Product, ProductType
+
+
+class CatalogFilter(PolymorphicModel):
+    model = None
+
+    identifier = "base_catalog_filter"
+    name = _("Base Catalog Filter")
+
+    active = models.BooleanField(default=True, verbose_name=_("active"))
+
+    def filter_queryset(self, queryset):
+        raise NotImplementedError("Subclasses should implement `filter_queryset`")
+
+
+class ProductTypeFilter(CatalogFilter):
+    model = ProductType
+    identifier = "product_type_filter"
+    name = _("Product type")
+
+    product_types = models.ManyToManyField(ProductType, verbose_name=_("product Types"))
+
+    def filter_queryset(self, queryset):
+        return queryset.filter(product__type__in=self.values.all())
+
+    @property
+    def description(self):
+        return _("Limit the campaign to selected product types.")
+
+    @property
+    def values(self):
+        return self.product_types
+
+    @values.setter
+    def values(self, values):
+        self.product_types = values
+
+
+class ProductFilter(CatalogFilter):
+    model = Product
+    identifier = "product_filter"
+    name = _("Product")
+
+    products = models.ManyToManyField(Product, verbose_name=_("product"))
+
+    def filter_queryset(self, queryset):
+        return queryset.filter(product__in=self.products.all())
+
+    @property
+    def description(self):
+        return _("Limit the campaign to selected products.")
+
+    @property
+    def values(self):
+        return self.products
+
+    @values.setter
+    def values(self, values):
+        self.products = values
+
+
+class CategoryFilter(CatalogFilter):
+    model = Category
+    identifier = "category_filter"
+    name = _("Product Category")
+
+    categories = models.ManyToManyField(Category, verbose_name=_("categories"))
+
+    def filter_queryset(self, queryset):
+        return queryset.filter(categories__in=self.categories.all())
+
+    @property
+    def description(self):
+        return _("Limit the campaign to products in selected categories.")
+
+    @property
+    def values(self):
+        return self.categories
+
+    @values.setter
+    def values(self, values):
+        self.categories = values

--- a/shoop/campaigns/models/context_conditions.py
+++ b/shoop/campaigns/models/context_conditions.py
@@ -1,0 +1,50 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+from polymorphic.models import PolymorphicModel
+
+from shoop.core.models import ContactGroup
+
+
+class ContextCondition(PolymorphicModel):
+    model = None
+    identifier = "context_condition"
+    name = _("Context Condition")
+    description = _("Context Condition")
+
+    active = models.BooleanField(default=True)
+
+    def matches(self, context):
+        return False
+
+
+class ContactGroupCondition(ContextCondition):
+    model = ContactGroup
+    identifier = "contact_group_condition"
+    name = _("Contact Group")
+    description = _("Contact group")
+
+    contact_groups = models.ManyToManyField(ContactGroup, verbose_name=_("contact groups"))
+
+    @property
+    def description(self):
+        return _("Limit the campaign to members of the selected contact groups.")
+
+    def matches(self, context):
+        if context.customer:
+            contact_groups = context.customer.groups.all().values_list("pk", flat=True)
+            return self.contact_groups.filter(pk__in=contact_groups).exists()
+        return False
+
+    @property
+    def values(self):
+        return self.contact_groups
+
+    @values.setter
+    def values(self, values):
+        self.contact_groups = values

--- a/shoop/campaigns/modules.py
+++ b/shoop/campaigns/modules.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import random
+
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.campaigns.models.campaigns import BasketCampaign, CatalogCampaign
+from shoop.core.models import OrderLineType
+from shoop.core.order_creator import OrderSourceModifierModule
+from shoop.core.pricing import DiscountModule
+
+
+class CatalogCampaignModule(DiscountModule):
+    identifier = "catalog_campaigns"
+    name = _("Campaigns")
+
+    def discount_price(self, context, product, price_info):
+        """
+        Get the discounted price for context.
+
+        Best discount is selected.
+        Minimum price will be selected if the cheapest price is under that.
+        """
+        create_price = context.shop.create_price
+        shop_product = product.get_shop_instance(context.shop)
+
+        best_discount = None
+        for campaign in CatalogCampaign.get_matching(context, shop_product):
+            price = price_info.price
+            if campaign.discount_amount_value:
+                price -= create_price(campaign.discount_amount_value)
+            else:
+                price -= (price * campaign.discount_percentage)
+
+            if best_discount is None:
+                best_discount = price
+
+            if price < best_discount:
+                best_discount = price
+
+        if best_discount:
+            if shop_product.minimum_price and best_discount < shop_product.minimum_price:
+                best_discount = shop_product.minimum_price
+
+            if best_discount < create_price("0"):
+                best_discount = create_price("0")
+
+            price_info.price = best_discount
+
+        return price_info
+
+
+class BasketCampaignModule(OrderSourceModifierModule):
+    identifier = "basket_campaigns"
+    name = _("Campaign Basket Discounts")
+
+    def get_new_lines(self, order_source, lines):
+        price_so_far = sum((x.price for x in lines), order_source.zero_price)
+
+        def get_discount_line(campaign, amount, price_so_far):
+            new_amount = min(amount, price_so_far)
+            price_so_far -= new_amount
+            return self._get_campaign_line(campaign, new_amount, order_source)
+
+        best_discount = None
+        best_discount_campaign = None
+        for campaign in BasketCampaign.get_matching(order_source, lines):
+            if campaign.discount_amount:
+                discount_amount = campaign.discount_amount
+            else:
+                discount_amount = order_source.total_price_of_products * campaign.discount_percentage
+
+            # if campaign has coupon, match it to order_source.codes
+            if campaign.coupon:
+                # campaign was found because discount code matched. This line is always added
+                yield get_discount_line(campaign, discount_amount, price_so_far)
+            elif best_discount is None or discount_amount > best_discount:
+                best_discount = discount_amount
+                best_discount_campaign = campaign
+
+        if best_discount is not None:
+            yield get_discount_line(best_discount_campaign, best_discount, price_so_far)
+
+    def _get_campaign_line(self, campaign, highest_discount, order_source):
+        text = campaign.public_name
+
+        if campaign.coupon:
+            text += " (%s %s)" % (_("Coupon Code:"), campaign.coupon.code)
+        return order_source.create_line(
+            line_id="discount_%s" % str(random.randint(0, 0x7FFFFFFF)),
+            type=OrderLineType.DISCOUNT,
+            quantity=1,
+            discount_amount=campaign.shop.create_price(highest_discount),
+            text=text
+        )
+
+    def can_use_code(self, order_source, code):
+        campaigns = BasketCampaign.objects.filter(active=True, coupon__code=code, coupon__active=True)
+        for campaign in campaigns:
+            if not campaign.is_available():
+                continue
+            return campaign.coupon.can_use_code(order_source.customer)
+        return False
+
+    def use_code(self, order, code):
+        campaigns = BasketCampaign.objects.filter(active=True, coupon__code=code, coupon__active=True)
+        for campaign in campaigns:
+            campaign.coupon.use(order)

--- a/shoop/campaigns/templates/shoop/campaigns/admin/edit_campaigns.jinja
+++ b/shoop/campaigns/templates/shoop/campaigns/admin/edit_campaigns.jinja
@@ -1,0 +1,43 @@
+{% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs %}
+{% block title %}{{ campaign.name or _("New Campaign") }}{% endblock %}
+
+{% block content %}
+    {% call content_with_sidebar(content_id="campaign_form") %}
+        <form method="post" id="campaign_form">
+            {% csrf_token %}
+
+            {% call content_block(_("General information"), "fa-clock-o") %}
+                {{ bs3.field(form.name) }}
+                {{ language_dependent_content_tabs(form) }}
+                {{ bs3.field(form.basket_line_text) }}
+                {{ bs3.field(form.shop) }}
+
+                {{ bs3.field(form.active) }}
+                {{ bs3.field(form.start_datetime) }}
+                {{ bs3.field(form.end_datetime) }}
+                {{ bs3.field(form.discount_percentage) }}
+                {{ bs3.field(form.discount_amount_value) }}
+            {% endcall %}
+
+            {% call content_block(_("Campaign Rules"), "fa-clock-o") %}
+                <div class="row">
+                    <div class="col-sm-8 col-sm-push-4 col-lg-6 col-lg-push-3">
+                        <h3>{{ _("Matching Rules") }}</h3>
+
+                        <p>{{ _("The following fields determine when this campaign applies. You must select atleast one rule to be able to save this campaign.") }}</p>
+
+                    </div>
+                </div>
+                {% for rule_id in form.rule_ids %}
+                    {{ bs3.field(form[rule_id]) }}
+                {% endfor %}
+                {% if form.coupon %}
+                {{ bs3.field(form.coupon) }}
+                {% endif %}
+            {% endcall %}
+        </form>
+    {% endcall %}
+
+{% endblock %}

--- a/shoop/campaigns/templates/shoop/campaigns/admin/edit_coupons.jinja
+++ b/shoop/campaigns/templates/shoop/campaigns/admin/edit_coupons.jinja
@@ -1,0 +1,45 @@
+{% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_block, content_with_sidebar %}
+
+{% block title %}{{ coupon.code or _("New Discount Code") }}{% endblock %}
+
+{% block content %}
+    {% call content_with_sidebar(content_id="coupon_form") %}
+        <form method="post" id="coupon_form">
+            {% csrf_token %}
+            {% call content_block(_("General information"), "fa-clock-o") %}
+                {% set addon_after = "<a href='#' id='id_autogenerate'>%s</a>" % _("Generate") %}
+                {{ bs3.field(form.code, addon_after=addon_after) }}
+                {{ bs3.field(form.usage_limit_customer) }}
+                {% set usage_limit_addon = "<small>%s</small>" % _("%(coupons)s used", coupons=coupon.usages.count()) %}
+                {{ bs3.field(form.usage_limit, addon_after=usage_limit_addon) }}
+                {{ bs3.field(form.active) }}
+            {% endcall %}
+        </form>
+    {% endcall %}
+{% endblock %}
+
+{% block extra_js %}
+    <script>
+    function generateDiscountCode() {
+        var $field = $("#id_code");
+        if($field.val().length) {
+            alert(gettext("Please empty the code value before using autogenerate."))
+        }
+        else {
+            var code = "";
+            var possible = "ACDEFGHKMNPQRSTVWX4679";
+            for (var i=0; i < 8; i++)
+                code += possible.charAt(Math.floor(Math.random() * possible.length));
+
+            $field.val(code);
+        }
+    }
+    $(document).ready(function(){
+        $(document).on('click', '#id_autogenerate', function(e){
+            e.preventDefault();
+            generateDiscountCode();
+        });
+    });
+    </script>
+{% endblock %}

--- a/shoop/core/order_creator/__init__.py
+++ b/shoop/core/order_creator/__init__.py
@@ -11,11 +11,13 @@ from shoop.utils import update_module_attributes
 from ._creator import OrderCreator
 from ._source import OrderSource, SourceLine, TaxesNotCalculated
 from ._source_modifier import (
-    get_order_source_modifier_modules, OrderSourceModifierModule
+    get_order_source_modifier_modules, is_code_usable,
+    OrderSourceModifierModule
 )
 
 __all__ = [
     "get_order_source_modifier_modules",
+    "is_code_usable",
     "OrderCreator",
     "OrderSource",
     "OrderSourceModifierModule",

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -288,6 +288,9 @@ class OrderSource(object):
         """
         return sum([line.quantity for line in self.get_product_lines()])
 
+    def create_line(self, **kwargs):
+        return SourceLine(source=self, **kwargs)
+
     def get_final_lines(self, with_taxes=False):
         """
         Get lines with processed lines added.

--- a/shoop/core/order_creator/_source_modifier.py
+++ b/shoop/core/order_creator/_source_modifier.py
@@ -19,6 +19,13 @@ def get_order_source_modifier_modules():
         "SHOOP_ORDER_SOURCE_MODIFIER_MODULES", "order_source_modifier_module")
 
 
+def is_code_usable(order_source, code):
+    return any(
+        module.can_use_code(order_source, code)
+        for module in get_order_source_modifier_modules()
+    )
+
+
 class OrderSourceModifierModule(object):
     def get_new_lines(self, order_source, lines):
         """
@@ -29,3 +36,9 @@ class OrderSourceModifierModule(object):
         :rtype: Iterable[shoop.core.order_creator.SourceLine]
         """
         return []
+
+    def can_use_code(self, order_source, code):
+        return False
+
+    def use_code(self, order, code):
+        pass

--- a/shoop/core/settings.py
+++ b/shoop/core/settings.py
@@ -69,12 +69,12 @@ SHOOP_PRICING_MODULE = "simple_pricing"
 #:
 #: Each discount module may change the price of a product.  See
 #: `shoop.core.pricing.DiscountModule` for details.
-SHOOP_DISCOUNT_MODULES = []
+SHOOP_DISCOUNT_MODULES = ["catalog_campaigns"]
 
 #: List of identifiers of order source modifier modules.
 #:
 #: See `shoop.core.order_creator.OrderSourceModifierModule` for details.
-SHOOP_ORDER_SOURCE_MODIFIER_MODULES = []
+SHOOP_ORDER_SOURCE_MODIFIER_MODULES = ["basket_campaigns"]
 
 #: The identifier of the tax module to use for determining taxes of products and order lines.
 #:

--- a/shoop/front/basket/commands.py
+++ b/shoop/front/basket/commands.py
@@ -15,6 +15,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.core.models import Product, ProductVariationResult
+from shoop.core.order_creator import is_code_usable
 from shoop.utils.importing import cached_load
 from shoop.utils.numbers import parse_decimal_string
 
@@ -118,6 +119,15 @@ def handle_clear(request, basket, **kwargs):
 
     basket.clear_all()
     return {'ok': True}
+
+
+def handle_add_campaign_code(request, basket, code):
+    if not code:
+        return {"ok": False}
+
+    if is_code_usable(basket, code):
+        return {"ok": basket.add_code(code)}
+    return {"ok": False}
 
 
 def handle_update(request, basket, **kwargs):

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/basket.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/basket.less
@@ -101,6 +101,18 @@
     }
 
     .basket-summary {
+        .basket-discount-code {
+            margin-top: 30px;
+
+            a {
+                color: @text-muted;
+                text-transform: uppercase;
+                font-size: 1.3rem;
+            }
+            .input-group {
+                margin-top: 15px;
+            }
+        }
         .total-price {
             h2 { margin: 0; }
         }

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/default_basket.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/default_basket.jinja
@@ -41,6 +41,37 @@
         $("#update_basket_form .quantity :input").change(function() {
             $("#update_basket_form").submit();
         });
+
+        $("#submit-code").click(function(e){
+            e.preventDefault();
+            const coupon = $("#discount-code").val();
+
+            if (coupon.length) {
+                // ajax request to command
+                const data = {
+                    "command": "add_campaign_code",
+                    "code": coupon
+                };
+
+                $.ajax({
+                    url: "",
+                    method: "POST",
+                    data: data,
+                    success: function(response) {
+                        if (response.ok) {
+                            location.reload();
+                        }
+                        else {
+                            alert("{% trans %}Coupon is not available.{% endtrans %}")
+                        }
+                    },
+                    error: function() {
+                        alert("{% trans %}Error when adding coupon.{% endtrans %}")
+                    }
+                });
+            }
+        });
     })
+
 </script>
 {% endblock %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
@@ -6,20 +6,20 @@
             {% set product = line.product %}
             {% set shop_product = line.shop_product %}
             <div class="single-item">
+                {% if product %}
                 <div class="product-image">
-                    {% if product %}
-                        {% set image = product.primary_image %}
-                        {% if image %}
-                            <a class="product-name" href="{{ shoop.urls.model_url(product) }}">
-                                <img class="img-responsive" src="{{ image|thumbnail(size=(200, 200)) }}" alt="{{ line.text }}">
-                            </a>
-                        {% else %}
-                            <a class="product-name" href="{{ shoop.urls.model_url(product) }}">
-                                <img class="img-responsive" src="{{ STATIC_URL }}classic_gray/img/no_image_thumbnail.png">
-                            </a>
-                        {% endif %}
+                    {% set image = product.primary_image %}
+                    {% if image %}
+                        <a class="product-name" href="{{ shoop.urls.model_url(product) }}">
+                            <img class="img-responsive" src="{{ image|thumbnail(size=(200, 200)) }}" alt="{{ line.text }}">
+                        </a>
+                    {% else %}
+                        <a class="product-name" href="{{ shoop.urls.model_url(product) }}">
+                            <img class="img-responsive" src="{{ STATIC_URL }}classic_gray/img/no_image_thumbnail.png">
+                        </a>
                     {% endif %}
                 </div>
+                {% endif %}
                 <div class="product-details">
                     <h4 class="name">
                         {% if product %}
@@ -57,17 +57,30 @@
                 </div>
                 <div class="delete">
                     {% if line.can_delete %}
-                        <button type="submit" class="btn btn-sm" name="delete_{{ line.line_id }}" title="{% trans %}Remove product from basket{% endtrans %}">
-                            <i class="fa fa-times"></i>
-                        </button>
+                    <button type="submit" class="btn btn-sm" name="delete_{{ line.line_id }}" title="{% trans %}Remove product from basket{% endtrans %}">
+                        <i class="fa fa-times"></i>
+                    </button>
                     {% endif %}
                 </div>
             </div>
         {% endfor %}
         <div class="basket-summary">
-            <div class="row">
-                <div class="col-sm-6 col-sm-offset-6">
+            <div class="row basket-discount-code">
+                <div class="col-sm-6 pull-right">
+                    <a class="coupon-toggler" role="button" data-toggle="collapse" href="#collapseCoupon" aria-expanded="false" aria-controls="collapseCoupon">{% trans %}Have a coupon code? Enter it here{% endtrans %}</a>
+                    <div class="collapse" id="collapseCoupon">
+                        <div class="input-group">
+                            <input type="text" class="form-control" name="code" id="discount-code" placeholder="{% trans %}Coupon Code{% endtrans %}">
+                            <span class="input-group-btn">
+                                <button type="submit" id="submit-code" class="btn btn-primary">{% trans %}Submit Code{% endtrans %}</button>
+                            </span>
+                        </div>
+                    </div>
                     <hr>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-6 pull-right">
                     <div class="row">
                         <div class="col-xs-6"><h4><strong>{% trans %}Total{% endtrans %}</strong></h4></div>
                         <div class="total-price text-right col-xs-6"><h2>{{ basket.total_price|money }}</h2></div>

--- a/shoop_tests/campaigns/__init__.py
+++ b/shoop_tests/campaigns/__init__.py
@@ -1,0 +1,25 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import activate
+from shoop.testing.factories import get_shop, get_default_customer_group, create_random_person
+from shoop.testing.utils import apply_request_middleware
+
+
+def initialize_test(rf, include_tax=False):
+    activate("en")
+    shop = get_shop(prices_include_tax=include_tax)
+
+    group = get_default_customer_group()
+    customer = create_random_person()
+    customer.groups.add(group)
+    customer.save()
+
+    request = rf.get("/")
+    request.shop = shop
+    apply_request_middleware(request)
+    request.customer = customer
+    return request, shop, group

--- a/shoop_tests/campaigns/test_admin.py
+++ b/shoop_tests/campaigns/test_admin.py
@@ -1,0 +1,109 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+# test that admin actually saves catalog
+import pytest
+from django.utils.translation import activate
+from shoop.campaigns.admin_module.views import CatalogCampaignEditView, BasketCampaignEditView
+from shoop.campaigns.models.campaigns import CatalogCampaign, Coupon
+from shoop.testing.factories import get_default_shop, get_default_supplier, create_product
+from shoop.testing.utils import apply_request_middleware
+from shoop_tests.utils import printable_gibberish
+from shoop_tests.utils.forms import get_form_data
+
+
+@pytest.mark.django_db
+def test_admin_campaign_edit_view_works(rf, admin_user):
+    shop = get_default_shop()
+    view_func = CatalogCampaignEditView.as_view()
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    campaign = CatalogCampaign.objects.create(name="test campaign", discount_amount_value="20", active=True, shop=shop)
+
+    response = view_func(request, pk=campaign.pk)
+    assert campaign.name in response.rendered_content
+
+    response = view_func(request, pk=None)
+    assert response.rendered_content
+
+
+@pytest.mark.django_db
+def test_admin_catalog_campaign_edit_view(rf, admin_user):
+    shop = get_default_shop()
+    view = CatalogCampaignEditView(request=apply_request_middleware(rf.get("/"), user=admin_user))
+    form_class = view.get_form_class()
+    form_kwargs = view.get_form_kwargs()
+    form = form_class(**form_kwargs)
+
+    assert not form.is_bound
+
+    data = get_form_data(form)
+    data.update({
+        "shop": shop.pk,
+        "name": "test",
+    })
+    form = form_class(**dict(form_kwargs, data=data))
+    form.full_clean()
+    assert "You must define discount percentage or amount" in form.errors["__all__"][0]
+
+    data.update({"discount_amount_value": "20"})
+    form = form_class(**dict(form_kwargs, data=data))
+    form.full_clean()
+
+    # atleast 1 rule is required
+    assert "You must set at least one rule for this campaign" in form.errors["__all__"][0]
+
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price="20")
+    data.update({"product_filter": [1]})
+
+    form = form_class(**dict(form_kwargs, data=data))
+    form.full_clean()
+    assert not form.errors
+
+    campaign = form.save()
+    assert campaign.filters.count() == 1
+
+
+@pytest.mark.django_db
+def test_admin_basket_campaign_edit_view(rf, admin_user):
+    activate("en")
+    shop = get_default_shop()
+    view = BasketCampaignEditView(request=apply_request_middleware(rf.get("/"), user=admin_user))
+    form_class = view.get_form_class()
+    form_kwargs = view.get_form_kwargs()
+    form = form_class(**form_kwargs)
+
+    assert not form.is_bound
+
+    data = get_form_data(form)
+    data.update({
+        "shop": shop.pk,
+        "name": "test",
+        "public_name__en": "test",
+    })
+    form = form_class(**dict(form_kwargs, data=data))
+    form.full_clean()
+    assert "You must define discount percentage or amount" in form.errors["__all__"][0]
+
+    data.update({"discount_amount_value": "20"})
+    form = form_class(**dict(form_kwargs, data=data))
+    form.full_clean()
+
+    # atleast 1 rule or coupon is required
+    assert "You must set atleast one rule or discount code for this campaign." in form.errors["__all__"][0]
+
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price="20")
+
+    coupon = Coupon.objects.create(code="TEST-CODE", active=True)
+    data.update({"coupon": coupon.pk})
+    form = form_class(**dict(form_kwargs, data=data))
+
+    form.full_clean()
+    assert not form.errors
+
+    campaign = form.save()
+    assert campaign.coupon.pk == coupon.pk

--- a/shoop_tests/campaigns/test_basket_campaigns.py
+++ b/shoop_tests/campaigns/test_basket_campaigns.py
@@ -1,0 +1,251 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from decimal import Decimal
+
+import pytest
+from shoop.campaigns.models.basket_conditions import BasketTotalProductAmountCondition, BasketTotalAmountCondition
+from shoop.campaigns.models.campaigns import BasketCampaign, Coupon, CouponUsage
+from shoop.core.models import ShippingMethod, OrderLineType
+from shoop.core.order_creator import OrderCreator
+from shoop.front.basket import get_basket
+from shoop.front.basket.commands import handle_add_campaign_code
+from shoop.testing.factories import create_product, get_default_supplier, get_default_tax_class, get_default_product
+from shoop.testing.utils import apply_request_middleware
+from shoop_tests.campaigns import initialize_test
+from shoop_tests.core.test_order_creator import seed_source
+from shoop_tests.utils import printable_gibberish
+
+"""
+These tests provides proof for following requirements:
+case 1: Define if this discount is available only if customer has X amount of products in their basket
+case 2: Define if this discount is available if customer has products in their basket for certain amount of money (shipping excluded)
+"""
+
+@pytest.mark.django_db
+def test_basket_campaign_module_case1(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    single_product_price = "50"
+    discount_amount_value = "10"
+
+     # create basket rule that requires 2 products in basket
+    basket_rule1 = BasketTotalProductAmountCondition.objects.create(value="2")
+
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+
+    line = basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.save()
+
+    assert basket.product_count == 1
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_amount_value=discount_amount_value, active=True)
+    campaign.conditions.add(basket_rule1)
+    campaign.save()
+
+    assert len(basket.get_final_lines()) == 1  # case 1
+    assert basket.total_price == price(single_product_price) # case 1
+
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+    basket.save()
+
+    assert len(basket.get_final_lines()) == 2  # case 1
+    assert basket.product_count == 2
+    assert basket.total_price == (price(single_product_price) * basket.product_count - price(discount_amount_value))
+    assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
+
+
+@pytest.mark.django_db
+def test_basket_campaign_case2(rf):
+
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+     # create a basket rule that requires atleast value of 200
+    rule = BasketTotalAmountCondition.objects.create(value="200")
+
+    single_product_price = "50"
+    discount_amount_value = "10"
+
+    unique_shipping_method = ShippingMethod(tax_class=get_default_tax_class(), module_data={"price": 50})
+    unique_shipping_method.save()
+
+    for x in range(3):
+        product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+        basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    assert basket.product_count == 3
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_amount_value=discount_amount_value, active=True)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+    assert len(basket.get_final_lines()) == 3
+    assert basket.total_price == price(single_product_price) * basket.product_count
+
+    # check that shipping method affects campaign
+    basket.shipping_method = unique_shipping_method
+    basket.save()
+    basket.uncache()
+    assert len(basket.get_final_lines()) == 4  # Shipping should not affect the rule being triggered
+
+    line_types = [l.type for l in basket.get_final_lines()]
+    assert OrderLineType.DISCOUNT not in line_types
+
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=single_product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    assert len(basket.get_final_lines()) == 6  # Discount included
+    assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
+
+
+@pytest.mark.django_db
+def test_only_cheapest_price_is_selected(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+     # create a basket rule that requires atleast value of 200
+    rule = BasketTotalAmountCondition.objects.create(value="200")
+
+    product_price = "200"
+
+    discount1 = "10"
+    discount2 = "20"  # should be selected
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_amount_value=discount1, active=True)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_amount_value=discount2, active=True)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+    assert len(basket.get_final_lines()) == 2
+    line_types = [l.type for l in basket.get_final_lines()]
+    assert OrderLineType.DISCOUNT in line_types
+
+    for line in basket.get_final_lines():
+        if line.type == OrderLineType.DISCOUNT:
+            assert line.discount_amount == price(discount2)
+
+
+@pytest.mark.django_db
+def test_multiple_campaigns_match_with_coupon(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+     # create a basket rule that requires atleast value of 200
+    rule = BasketTotalAmountCondition.objects.create(value="200")
+
+    product_price = "200"
+
+    discount1 = "10"
+    discount2 = "20"
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_amount_value=discount1, active=True)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+    dc = Coupon.objects.create(code="TEST", active=True)
+    campaign2 = BasketCampaign.objects.create(
+            shop=shop, public_name="test",
+            name="test",
+            coupon=dc,
+            discount_amount_value=discount2,
+            active=True
+    )
+
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    resp = handle_add_campaign_code(request, basket, dc.code)
+    assert resp.get("ok")
+
+    discount_lines_values = [line.discount_amount for line in basket.get_final_lines()]
+    assert price(discount1) in discount_lines_values
+    assert price(discount2) in discount_lines_values
+    assert basket.total_price == (price(product_price) * basket.product_count - price(discount1) - price(discount2))
+
+
+@pytest.mark.django_db
+def test_percentage_campaign(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+     # create a basket rule that requires atleast value of 200
+    rule = BasketTotalAmountCondition.objects.create(value="200")
+
+    product_price = "200"
+
+    discount_percentage = "0.1"
+
+    expected_discounted_price = price(product_price) - (price(product_price) * Decimal(discount_percentage))
+
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price=product_price)
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    campaign = BasketCampaign.objects.create(shop=shop, public_name="test", name="test", discount_percentage=discount_percentage, active=True)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+
+    assert len(basket.get_final_lines()) == 2
+    assert basket.product_count == 1
+    assert basket.total_price == expected_discounted_price
+
+
+@pytest.mark.django_db
+def test_order_creation_adds_usage(rf, admin_user):
+    request, shop, group = initialize_test(rf, False)
+
+    source = seed_source(admin_user)
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=get_default_product(),
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+    )
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+
+    # add coupon
+    coupon = Coupon.objects.create(active=True, code="asdf")
+
+    campaign = BasketCampaign.objects.create(
+        active=True,
+        shop=shop,
+        name="test",
+        public_name="test",
+        discount_percentage="0.1",
+        coupon=coupon)
+
+    source.add_code(coupon.code)
+
+    request = apply_request_middleware(rf.get("/"))
+    creator = OrderCreator(request)
+    order = creator.create_order(source)
+
+    assert CouponUsage.objects.count() == 1

--- a/shoop_tests/campaigns/test_catalog_campaigns.py
+++ b/shoop_tests/campaigns/test_catalog_campaigns.py
@@ -1,0 +1,349 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from decimal import Decimal
+
+import datetime
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils.timezone import now
+from django.utils.translation import activate
+from shoop.campaigns.models.campaigns import CatalogCampaign
+from shoop.campaigns.models.catalog_filters import CategoryFilter
+from shoop.campaigns.models.context_conditions import ContactGroupCondition
+from shoop.core.models import Category
+from shoop.testing.factories import create_product, get_default_customer_group
+from shoop_tests.campaigns import initialize_test
+
+
+@pytest.mark.django_db
+def test_campaign_creation(rf):
+    activate("en")
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    condition = ContactGroupCondition.objects.create()
+    condition.contact_groups = request.customer.groups.all()
+    condition.save()
+
+    assert condition.values.first() == request.customer.groups.first()
+
+    condition.values = request.customer.groups.all()
+    condition.save()
+    assert condition.values.first() == request.customer.groups.first()
+
+    category_filter = CategoryFilter.objects.create()
+    category_filter.categories.add(cat)
+    category_filter.save()
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=20, active=True)
+    campaign.conditions.add(condition)
+    campaign.filters.add(category_filter)
+    campaign.save()
+
+
+@pytest.mark.django_db
+def test_condition_doesnt_match(rf):
+    activate("en")
+    request, shop, group = initialize_test(rf, False)
+    condition = ContactGroupCondition.objects.create()
+    condition.contact_groups = [get_default_customer_group()]
+    condition.save()
+
+    request.customer = None
+
+    assert not condition.matches(request)
+
+
+@pytest.mark.django_db
+def test_condition_affects_price(rf):
+    activate("en")
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    contact_condition = ContactGroupCondition.objects.create()
+    contact_condition.contact_groups = request.customer.groups.all()
+    contact_condition.save()
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=20, active=True)
+    campaign.conditions.add(contact_condition)
+    campaign.save()
+
+    price = shop.create_price
+
+    product = create_product("Just-A-Product-Too", shop, default_price=199)
+
+    assert product.get_price_info(request, quantity=1).price == price(179)
+
+
+@pytest.mark.django_db
+def test_filter_affects_price(rf):
+    activate("en")
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    category_filter = CategoryFilter.objects.create()
+    category_filter.categories.add(cat)
+    category_filter.save()
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=20, active=True)
+    campaign.filters.add(category_filter)
+    campaign.save()
+
+    price = shop.create_price
+
+    product = create_product("Just-A-Product-Too", shop, default_price=199)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+    assert product.get_price_info(request, quantity=1).price == price(179)
+
+
+@pytest.mark.django_db
+def test_campaign_all_rules_must_match1(rf):
+    activate("en")
+    discount_amount = "20.53"
+    original_price = "199.20"
+
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1 = ContactGroupCondition.objects.create()
+    rule1.contact_groups = request.customer.groups.all()
+    rule1.save()
+
+    rule2 = CategoryFilter.objects.create()
+    rule2.categories.add(cat)
+    rule2.save()
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=discount_amount, active=True)
+    campaign.conditions.add(rule1)
+    campaign.filters.add(rule2)
+    campaign.save()
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+
+    price = shop.create_price
+    # price should not be discounted because the request.category is faulty
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+    # now the category is set, so both rules match, disconut should be given
+    assert product.get_price_info(request, quantity=1).price == (price(original_price) - price(discount_amount))
+
+
+@pytest.mark.django_db
+def test_campaign_save_validation(rf):
+    # Discount percentage, or Discount amount in shop currency
+    request, shop, group = initialize_test(rf, False)
+    with pytest.raises(ValidationError):
+        campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value="20", discount_percentage="0.20")
+
+    with pytest.raises(ValidationError):
+        campaign = CatalogCampaign.objects.create(shop=shop, name="test")
+
+@pytest.mark.django_db
+def test_percentage_campaigns(rf):
+    activate("en")
+    discount_percentage = "0.14"
+    original_price = "123.47"
+
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1 = ContactGroupCondition.objects.create()
+    rule1.contact_groups = request.customer.groups.all()
+    rule1.save()
+
+    rule2 = CategoryFilter.objects.create()
+    rule2.categories.add(cat)
+    rule2.save()
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_percentage=discount_percentage, active=True)
+    campaign.conditions.add(rule1)
+    campaign.filters.add(rule2)
+    campaign.save()
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+
+    price = shop.create_price
+    # price should not be discounted because the request.category is faulty
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+    # now the category is set, so both rules match, discount should be given
+    discounted_price = price(original_price) - (price(original_price) * Decimal(campaign.discount_percentage))
+    assert product.get_price_info(request, quantity=1).price == discounted_price
+
+
+@pytest.mark.django_db
+def test_only_best_price_affects(rf):
+    activate("en")
+    discount_amount = "20.53"
+    original_price = "199.20"
+    best_discount_amount = "40.00"
+
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+
+    rule1, rule2 = create_condition_and_filter(cat, request)
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=discount_amount, active=True)
+    campaign.conditions.add(rule1)
+    campaign.filters.add(rule2)
+    campaign.save()
+
+    rule3, rule4 = create_condition_and_filter(cat, request)
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=best_discount_amount, active=True)
+    campaign.conditions.add(rule3)
+    campaign.filters.add(rule4)
+    campaign.save()
+
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+
+    price = shop.create_price
+    # price should not be discounted because the request.category is faulty
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+    # now the category is set, so both rules match, disconut should be given
+    assert product.get_price_info(request, quantity=1).price == (price(original_price) - price(best_discount_amount))
+
+
+@pytest.mark.django_db
+def test_minimum_price_is_forced(rf):
+    activate("en")
+    discount_amount = "20.53"
+    original_price = "199.20"
+    allowed_minimum_price = "190.20"
+
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1, rule2 = create_condition_and_filter(cat, request)
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=discount_amount, active=True)
+    campaign.conditions.add(rule1)
+    campaign.filters.add(rule2)
+    campaign.save()
+
+    price = shop.create_price
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.minimum_price = price(allowed_minimum_price)
+    shop_product.save()
+
+    # price should not be discounted because the request.category is faulty
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    shop_product.categories.add(cat)
+    shop_product.save()
+    # now the category is set, so both rules match, discount should be given
+    assert product.get_price_info(request, quantity=1).price == shop_product.minimum_price
+
+
+@pytest.mark.django_db
+def test_price_cannot_be_under_zero(rf):
+
+    activate("en")
+    discount_amount = "200"
+    original_price = "199.20"
+
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1, rule2 = create_condition_and_filter(cat, request)
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value=discount_amount, active=True)
+    campaign.conditions.add(rule1)
+    campaign.filters.add(rule2)
+    campaign.save()
+
+    price = shop.create_price
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+
+    assert product.get_price_info(request, quantity=1).price == price("0")
+
+
+def create_condition_and_filter(cat, request):
+    rule1 = ContactGroupCondition.objects.create()
+    rule1.contact_groups = request.customer.groups.all()
+    rule1.save()
+    rule2 = CategoryFilter.objects.create()
+    rule2.categories.add(cat)
+    rule2.save()
+    return rule1, rule2
+
+
+@pytest.mark.django_db
+def test_start_end_dates(rf):
+    activate("en")
+    original_price = "180"
+    discounted_price = "160"
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1, rule2 = create_condition_and_filter(cat, request)
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value="20", active=True)
+    campaign.conditions.add(rule1)
+    campaign.save()
+    price = shop.create_price
+
+    product = create_product("Just-A-Product-Too", shop, default_price=original_price)
+
+    today = now()
+
+    # starts in future
+    campaign.start_datetime = (today + datetime.timedelta(days=2))
+    campaign.save()
+    assert not campaign.is_available()
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    # has already started
+    campaign.start_datetime = (today - datetime.timedelta(days=2))
+    campaign.save()
+    assert product.get_price_info(request, quantity=1).price == price(discounted_price)
+
+    # already ended
+    campaign.end_datetime = (today - datetime.timedelta(days=1))
+    campaign.save()
+    assert not campaign.is_available()
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+    # not ended yet
+    campaign.end_datetime = (today + datetime.timedelta(days=1))
+    campaign.save()
+    assert product.get_price_info(request, quantity=1).price == price(discounted_price)
+
+    # no start datetime
+    campaign.start_datetime = None
+    campaign.save()
+    assert product.get_price_info(request, quantity=1).price == price(discounted_price)
+
+    # no start datetime but ended
+    campaign.end_datetime = (today - datetime.timedelta(days=1))
+    campaign.save()
+    assert not campaign.is_available()
+    assert product.get_price_info(request, quantity=1).price == price(original_price)
+
+
+@pytest.mark.django_db
+def test_availability(rf):
+    activate("en")
+    request, shop, group = initialize_test(rf, False)
+    cat = Category.objects.create(name="test")
+    rule1, rule2 = create_condition_and_filter(cat, request)
+
+    campaign = CatalogCampaign.objects.create(shop=shop, name="test", discount_amount_value="20", active=False)
+    campaign.conditions.add(rule1)
+    campaign.save()
+
+    assert not campaign.is_available()
+

--- a/shoop_tests/campaigns/test_conditions.py
+++ b/shoop_tests/campaigns/test_conditions.py
@@ -1,0 +1,72 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from decimal import Decimal
+
+import pytest
+from django.utils.encoding import force_text
+from shoop.campaigns.models.basket_conditions import ProductsInBasketCondition, BasketTotalAmountCondition, \
+    BasketTotalProductAmountCondition
+from shoop.front.basket import get_basket
+from shoop.testing.factories import get_default_supplier, create_product
+from shoop_tests.campaigns import initialize_test
+
+
+@pytest.mark.django_db
+def test_product_in_basket_condition(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    condition = ProductsInBasketCondition.objects.create()
+    condition.values = [product]
+    condition.save()
+
+    assert condition.values.first() == product
+
+    assert condition.matches(basket, [])
+
+
+@pytest.mark.django_db
+def test_basket_total_amount_condition(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    condition = BasketTotalAmountCondition.objects.create()
+    condition.value = 1
+    condition.save()
+    assert condition.value == 1
+    assert condition.matches(basket, [])
+
+
+@pytest.mark.django_db
+def test_basket_total_value_condition(rf):
+    request, shop, group = initialize_test(rf, False)
+    price = shop.create_price
+
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    condition = BasketTotalProductAmountCondition.objects.create()
+    condition.value = 1
+    condition.save()
+    assert condition.value == 1
+    assert condition.matches(basket, [])
+    assert "basket has atleast the product count entered here" in force_text(condition.description)

--- a/shoop_tests/campaigns/test_discount_codes.py
+++ b/shoop_tests/campaigns/test_discount_codes.py
@@ -1,0 +1,153 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+1) Check if the discount is only available with a discount code and type the code, or generate it with a click of a button
+2) If discount code: How many available
+3) If discount code: How many available for each user
+"""
+import pytest
+from django.core.exceptions import ValidationError
+from shoop.campaigns.models.basket_conditions import BasketTotalProductAmountCondition
+from shoop.campaigns.models.campaigns import Coupon, BasketCampaign
+from shoop.core.models import OrderLineType
+from shoop.front.basket import get_basket
+from shoop.testing.factories import create_random_person, get_default_shop, create_product, get_default_supplier, \
+    create_random_order
+from shoop_tests.campaigns import initialize_test
+from shoop_tests.utils import printable_gibberish
+
+
+def get_default_campaign(coupon=None):
+    shop = get_default_shop()
+    return BasketCampaign.objects.create(
+            shop=shop, public_name="test",
+            name="test", discount_amount_value=shop.create_price("20"),
+            coupon=coupon, active=True
+    )
+
+
+@pytest.mark.django_db
+def test_coupon_generation():
+    original_code = "random"
+    coupon = Coupon.objects.create(code=original_code, active=True)
+    coupon.code = Coupon.generate_code()
+    coupon.save()
+    assert coupon.code != original_code
+
+
+@pytest.mark.django_db
+def test_coupon_user_limit():
+    coupon = Coupon.objects.create(code="TEST", active=True)
+    get_default_campaign(coupon)
+    contact = create_random_person()
+    shop = get_default_shop()
+    product = create_product("test", shop=shop, supplier=get_default_supplier(), default_price="12")
+    order = create_random_order(customer=contact)
+    for x in range(50):
+       coupon.use(order)
+
+    assert coupon.usages.count() == 50
+
+    # set limit to coupon_usage
+    coupon.increase_customer_usage_limit_by(5)
+    coupon.save()
+
+    assert coupon.usage_limit_customer == 55
+    assert coupon.can_use_code(contact)
+    for x in range(5):
+        coupon.use(order)
+    assert coupon.usages.count() == 55
+
+    assert not Coupon.is_usable(coupon.code, order.customer)
+    assert coupon.usages.count() == 55  # no change, limit met
+
+
+@pytest.mark.django_db
+def test_coupon_amount_limit():
+    coupon = Coupon.objects.create(code="TEST", active=True)
+    get_default_campaign(coupon)
+
+    contact = create_random_person()
+    shop = get_default_shop()
+    product = create_product("test", shop=shop, supplier=get_default_supplier(), default_price="12")
+    order = create_random_order(customer=contact)
+
+    for x in range(50):
+       coupon.use(order)
+
+    assert coupon.usages.count() == 50
+    coupon.increase_usage_limit_by(5)
+    coupon.save()
+
+    assert coupon.usage_limit == 55
+    assert coupon.can_use_code(contact)
+
+    for x in range(5):
+        coupon.use(order)
+
+    assert coupon.usages.count() == 55
+
+    assert not Coupon.is_usable(coupon.code, order.customer)
+    assert coupon.usages.count() == 55  # no change, limit met
+
+
+@pytest.mark.django_db
+def test_no_two_same_codes_active():
+    # allow two discount codes with same code as they are inactive
+    dc1 = Coupon.objects.create(code="TEST")
+    dc2 = Coupon.objects.create(code="TEST")
+
+    dc1.active = True
+    dc1.save()
+
+    dc2.active = True
+    with pytest.raises(ValidationError):
+        dc2.save()
+    dc2.code = "changed_code"
+    dc2.save()
+
+
+@pytest.mark.django_db
+def test_campaign_with_coupons(rf):
+    request, shop, group = initialize_test(rf, False)
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+
+    for x in range(2):
+        product = create_product(printable_gibberish(), shop, default_price="50")
+        basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    dc = Coupon.objects.create(code="TEST", active=True)
+    campaign = BasketCampaign.objects.create(
+            shop=shop,
+            name="test", public_name="test",
+            coupon=dc,
+            discount_amount_value=shop.create_price("20"),
+            active=True
+    )
+    rule = BasketTotalProductAmountCondition.objects.create(value=2)
+    campaign.conditions.add(rule)
+    campaign.save()
+
+    assert len(basket.get_final_lines()) == 2  # no discount was applied because coupon is required
+
+    basket.add_code(dc.code)
+
+    assert len(basket.get_final_lines()) == 3  # now basket has codes so they will be applied too
+    assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
+
+    # Ensure codes persist between requests, so do what the middleware would, i.e.
+    basket.save()
+    # and then reload the basket:
+    del request.basket
+    basket = get_basket(request)
+
+    assert basket.codes == [dc.code]
+    assert len(basket.get_final_lines()) == 3  # now basket has codes so they will be applied too
+    assert OrderLineType.DISCOUNT in [l.type for l in basket.get_final_lines()]
+

--- a/shoop_tests/campaigns/test_filters.py
+++ b/shoop_tests/campaigns/test_filters.py
@@ -1,0 +1,84 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.utils.encoding import force_text
+from shoop.campaigns.models.catalog_filters import CategoryFilter, ProductFilter, ProductTypeFilter, CatalogFilter
+from shoop.core.models import Category, ShopProduct
+from shoop.testing.factories import get_default_category, create_product
+from shoop_tests.campaigns import initialize_test
+
+
+@pytest.mark.django_db
+def test_category_filter(rf):
+    request, shop, group = initialize_test(rf, False)
+
+    cat = get_default_category()
+    cat_filter = CategoryFilter.objects.create()
+    cat_filter.categories.add(cat)
+    cat_filter.save()
+
+    assert cat_filter.values.first() == cat
+    category = Category.objects.create(
+        parent=None,
+        identifier="testcat",
+        name="catcat",
+    )
+    cat_filter.values = [cat, category]
+    cat_filter.save()
+
+    assert cat_filter.values.count() == 2
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+    shop_product = product.get_shop_instance(shop)
+    shop_product.categories.add(cat)
+    shop_product.save()
+
+    assert cat_filter.filter_queryset(ShopProduct.objects.all()).exists()  # filter matches
+
+
+@pytest.mark.django_db
+def test_product_filter(rf):
+    request, shop, group = initialize_test(rf, False)
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+
+    product_filter = ProductFilter.objects.create()
+    product_filter.products.add(product)
+    product_filter.save()
+
+    assert product_filter.values.first() == product
+
+    product2 = create_product("asdfasf", shop, default_price="20")
+    product_filter.values = [product, product2]
+    product_filter.save()
+
+    assert product_filter.values.count() == 2
+
+    assert product_filter.filter_queryset(ShopProduct.objects.all()).exists()  # filter matches
+
+
+@pytest.mark.django_db
+def test_product_type_filter(rf):
+    request, shop, group = initialize_test(rf, False)
+
+    product = create_product("Just-A-Product-Too", shop, default_price="200")
+
+    product_type_filter = ProductTypeFilter.objects.create()
+    product_type_filter.product_types.add(product.type)
+    product_type_filter.save()
+
+    assert product_type_filter.values.first() == product.type
+
+    product2 = create_product("asdfasf", shop, default_price="20")
+    product_type_filter.values = [product.type, product2.type]
+    product_type_filter.save()
+
+    assert product_type_filter.values.count() == 1  # both have same product type so only 1 value here
+
+    assert product_type_filter.filter_queryset(ShopProduct.objects.all()).exists()  # filter matches
+
+    assert product_type_filter.name.lower() in force_text(product_type_filter.description)

--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = add_enabled_addons(SHOOP_ENABLED_ADDONS_FILE, [
     'shoop.notify',
     'shoop.simple_cms',
     'shoop.simple_pricing',
+    'shoop.campaigns',
     'shoop.simple_supplier',
     'shoop.order_printouts',
     'shoop.testing',
@@ -58,7 +59,6 @@ INSTALLED_APPS = add_enabled_addons(SHOOP_ENABLED_ADDONS_FILE, [
     'filer',
     'registration',
     'rest_framework',
-
     'shoop.discount_pricing'
 ])
 

--- a/shoop_workbench/settings/base_settings.py
+++ b/shoop_workbench/settings/base_settings.py
@@ -167,7 +167,7 @@ LOGIN_URL = "/login"
 
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 
-SHOOP_PRICING_MODULE = "discount_pricing"
+SHOOP_PRICING_MODULE = "simple_pricing"
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',


### PR DESCRIPTION
Add campaign module to Shoop.

This module will replace the basic discount modules like `discount_pricing` as the same rules can be created here. Campaigns are separated into two different flows: `CatalogCampaigns` and `BasketCampaigns` both of these have their own rulesets. 

Refs SHOOP-494 