### PR TITLE
BasketStorage: fix mis-call of `delete` in `finalize`

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -40,6 +40,7 @@ Admin
 Front
 ~~~~~
 
+- Fix bug: BasketStorage.finalize() never called delete() correctly
 - Check product quantity already in basket while adding
 - Process given coupon codes in basket
 - Process discounts from new campaign engine

--- a/shoop/front/basket/storage.py
+++ b/shoop/front/basket/storage.py
@@ -91,7 +91,7 @@ class BasketStorage(six.with_metaclass(abc.ABCMeta)):
         """
         pass
 
-    def finalize(self, basket):  # pragma: no cover
+    def finalize(self, basket):
         """
         Mark the basket as "finalized" (i.e. completed) in the storage.
 
@@ -99,7 +99,7 @@ class BasketStorage(six.with_metaclass(abc.ABCMeta)):
 
         :type basket: shoop.front.basket.objects.BaseBasket
         """
-        self.delete()
+        self.delete(basket=basket)
 
 
 class DirectSessionBasketStorage(BasketStorage):

--- a/shoop_tests/front/test_basket.py
+++ b/shoop_tests/front/test_basket.py
@@ -71,6 +71,8 @@ def test_basket(rf, storage):
             else:
                 assert stats["tls"] == sum(quantities) * 50
 
+        basket.finalize()
+
 
 @pytest.mark.django_db
 def test_basket_dirtying_with_fnl(rf):


### PR DESCRIPTION
`finalize` never called `delete` correctly (it obviously requires the `basket` argument).

This was noticed by yours truly and @RauliL while working on a client project.