### PR TITLE
Campaign fixes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -104,6 +104,7 @@ Localization
 Admin
 ~~~~~
 
+- Bump bootstrap-datetimepicker version to 2.3.8
 - Show Shoop version number in Admin
 - Fix order list sorting and filtering by total price
 - Fix CMS page list sorting by title

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -134,6 +134,7 @@ Xtheme
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 
+- Basket: Hide line base price when it's not positive
 - Show product media at order history and product detail pages
 - Add language changer to navigation
 - Add possibility for other future brand colors

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -151,6 +151,11 @@ Default Theme
 - Remove Default theme from Shoop Base. Moved to
   https://github.com/shoopio/shoop-simple-theme
 
+Campaigns
+~~~~~~~~~
+
+- Fix admin list view sorting
+
 General/miscellaneous
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/shoop/admin/static_src/vendor/bower.json
+++ b/shoop/admin/static_src/vendor/bower.json
@@ -26,6 +26,6 @@
     "jquery.easing": "1.3.1",
     "bootstrap-select": "1.6.5",
     "jquery.scrollbar": "0.2.10",
-    "smalot-bootstrap-datetimepicker": "2.3.5"
+    "smalot-bootstrap-datetimepicker": "2.3.8"
   }
 }

--- a/shoop/campaigns/admin_module/views.py
+++ b/shoop/campaigns/admin_module/views.py
@@ -29,11 +29,11 @@ class _Breadcrumbed(object):
 class CampaignListView(PicotableListView):
     columns = [
         Column(
-            "name", _(u"Title"), sort_field="translations__name", display="name", linked=True,
+            "name", _(u"Title"), sort_field="name", display="name", linked=True,
             filter_config=TextFilter(operator="startswith")
         ),
         Column("discount_percentage", _("Discount percentage"), display="format_percentage"),
-        Column("discount_amount", _("Discount amount")),
+        Column("discount_amount", _("Discount amount"), sort_field="discount_amount_value"),
         Column("start_datetime", _("Starts")),
         Column("end_datetime", _("Ends")),
         Column("active", _("Active"), filter_config=ChoicesFilter(choices=[(0, _("No")), (1, _("Yes"))])),

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/basket/partials/_basket_content.jinja
@@ -50,7 +50,7 @@
                 <div class="product-sum">
                     <h4 class="price text-right">
                         <small>{% trans %}Total{% endtrans %}: </small>{{ line.price|money }}
-                        {% if line.is_discounted %}
+                        {% if line.is_discounted and line.base_price.value > 0 %}
                             <br><small><s class="text-muted">{{ line.base_price|money }}</s></small>
                         {% endif %}
                     </h4>


### PR DESCRIPTION
* Campaigns: Make admin sorting with name and discount amount work
* Classic gray: Modify basket lines
* Admin: Bump bootstrap-datetimepicker version to 2.3.8

Refs SHOOP-2118 / SHOOP-2119 / SHOOP-2121 / SHOOP-494