### PR TITLE
Add/remove contact group members

### DIFF
--- a/shoop/admin/forms/widgets.py
+++ b/shoop/admin/forms/widgets.py
@@ -16,7 +16,7 @@ from filer.models import File
 
 from shoop.admin.utils.forms import flatatt_filter
 from shoop.admin.utils.urls import get_model_url, NoModelUrl
-from shoop.core.models import Product
+from shoop.core.models import Contact, Product
 
 
 class BasePopupChoiceWidget(Widget):
@@ -103,3 +103,17 @@ class ProductChoiceWidget(BasePopupChoiceWidget):
 
     def get_object(self, value):
         return Product.objects.get(pk=value)
+
+
+class ContactChoiceWidget(BasePopupChoiceWidget):
+    browse_kind = "contact"
+
+    def get_object(self, value):
+        return Contact.objects.get(pk=value)
+
+    def get_browse_markup(self):
+        icon = "<i class='fa fa-user'></i>"
+        return "<button class='browse-btn btn btn-info btn-sm' type='button'>%(icon)s %(text)s</button>" % {
+            "icon": icon,
+            "text": _("Select")
+        }

--- a/shoop/admin/gulp_bits/js-packages.js
+++ b/shoop/admin/gulp_bits/js-packages.js
@@ -32,6 +32,13 @@ module.exports = {
             "js/language-changer.js"
         ]
     },
+    "contact-group": {
+        "es6": true,
+        "base": "./static_src/contact_group",
+        "files": [
+            "edit-members.js"
+        ]
+    },
     "dashboard": {
         "es6": true,
         "files": bowerFiles("./static_src/dashboard")

--- a/shoop/admin/modules/contact_groups/views/edit.py
+++ b/shoop/admin/modules/contact_groups/views/edit.py
@@ -8,9 +8,14 @@
 
 from __future__ import unicode_literals
 
+from django.db.transaction import atomic
+
+from shoop.admin.form_part import FormPartsViewMixin, SaveFormPartsMixin
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.core.models import ContactGroup
 from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
+
+from .forms import ContactGroupBaseFormPart, ContactGroupMembersFormPart
 
 
 class ContactGroupForm(MultiLanguageModelForm):
@@ -19,8 +24,12 @@ class ContactGroupForm(MultiLanguageModelForm):
         fields = ("name",)
 
 
-class ContactGroupEditView(CreateOrUpdateView):
+class ContactGroupEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView):
     model = ContactGroup
-    form_class = ContactGroupForm
     template_name = "shoop/admin/contact_groups/edit.jinja"
     context_object_name = "contact_group"
+    base_form_part_classes = [ContactGroupBaseFormPart, ContactGroupMembersFormPart]
+
+    @atomic
+    def form_valid(self, form):
+        return self.save_form_parts(form)

--- a/shoop/admin/modules/contact_groups/views/forms.py
+++ b/shoop/admin/modules/contact_groups/views/forms.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.conf import settings
+from django.contrib import messages
+from django.db.transaction import atomic
+from django.forms.formsets import (
+    BaseFormSet, DELETION_FIELD_NAME, formset_factory
+)
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ungettext
+
+from shoop.admin.form_part import FormPart, TemplatedFormDef
+from shoop.admin.forms.widgets import ContactChoiceWidget
+from shoop.core.models import Contact, ContactGroup
+from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
+
+
+class ContactGroupBaseForm(MultiLanguageModelForm):
+    class Meta:
+        model = ContactGroup
+        fields = ("name",)
+
+
+class ContactGroupBaseFormPart(FormPart):
+    priority = 0
+
+    def get_form_defs(self):
+        contact_group = self.object
+
+        yield TemplatedFormDef(
+            "base",
+            ContactGroupBaseForm,
+            template_name="shoop/admin/contact_groups/_edit_base_contact_group_form.jinja",
+            required=True,
+            kwargs={"instance": contact_group, "languages": settings.LANGUAGES}
+        )
+
+    def form_valid(self, form):
+        self.object = form["base"].save()
+
+
+class ContactGroupMembersForm(forms.Form):
+    member = forms.ModelChoiceField(
+        queryset=Contact.objects.all(),
+        widget=ContactChoiceWidget(empty_text=""),
+        label=_('member')
+    )
+
+
+class ContactGroupMembersFormSet(BaseFormSet):
+    def __init__(self, **kwargs):
+        kwargs.pop("empty_permitted", None)
+        self.request = kwargs.pop("request", None)
+        self.contact_group = kwargs.pop("contact_group")
+        if not self.contact_group.pk:
+            kwargs["initial"] = {}
+        else:
+            kwargs["initial"] = [
+                {"member": member}
+                for member
+                in self.contact_group.members.all()
+                ]
+        super(ContactGroupMembersFormSet, self).__init__(**kwargs)
+
+    def _construct_form(self, i, **kwargs):
+        form = super(ContactGroupMembersFormSet, self)._construct_form(i, **kwargs)
+        form.fields[DELETION_FIELD_NAME].label = _("Remove")
+        return form
+
+    def save(self):
+        contact_group = self.contact_group
+        current_members = set(contact_group.members.all())
+        selected_members, removed_members = self.get_selected_and_removed()
+
+        with atomic():
+            members_to_add = selected_members - current_members
+            members_to_remove = current_members & removed_members
+            for member in members_to_remove:
+                contact_group.members.remove(member)
+            for member in members_to_add:
+                contact_group.members.add(member)
+
+        message_parts = []
+        if members_to_add:
+            add_count = len(members_to_add)
+            message_parts.append(ungettext("%(count)s member added", "%(count)s members added",
+                                 add_count) % {"count": add_count})
+        if members_to_remove:
+            remove_count = len(members_to_remove)
+            message_parts.append(ungettext("%(count)s member removed", "%(count)s members removed",
+                                 remove_count) % {"count": remove_count})
+        if message_parts and self.request:
+            messages.success(self.request, ", ".join(message_parts) + ".")
+
+    def get_selected_and_removed(self):
+        deleted_forms = self.deleted_forms
+        removed_members = set()
+        selected_members = set()
+        for member_form in self.forms:
+            member = member_form.cleaned_data.get("member")
+            if not member:
+                continue
+            if member_form in deleted_forms:
+                removed_members.add(member)
+            else:
+                selected_members.add(member)
+        return (selected_members, removed_members)
+
+
+class ContactGroupMembersFormPart(FormPart):
+    priority = 1
+
+    def get_form_defs(self):
+        contact_group = self.object
+        form = formset_factory(ContactGroupMembersForm, ContactGroupMembersFormSet, extra=1, can_delete=True)
+        template_name = "shoop/admin/contact_groups/_edit_members_form.jinja"
+
+        if contact_group.pk:
+            yield TemplatedFormDef(
+                "members",
+                form,
+                template_name=template_name,
+                required=False,
+                kwargs={"contact_group": contact_group, "request": self.request}
+            )
+
+    def form_valid(self, form):
+        try:
+            member_formset = form["members"]
+        except KeyError:
+            return
+        member_formset.save()

--- a/shoop/admin/static_src/contact_group/edit-members.js
+++ b/shoop/admin/static_src/contact_group/edit-members.js
@@ -1,0 +1,42 @@
+/**
+ * This file is part of Shoop.
+ *
+ * Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+ *
+ * This source code is licensed under the AGPLv3 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+(function (){
+    "use strict";
+
+    var total = parseInt($("#id_members-TOTAL_FORMS").val());
+    var lastRow = $("#contact_group_form .browse-widget:last").closest("tr");
+    var blankRow = lastRow.clone();
+    var nextRow;
+    var newRow;
+
+    blankRow.find("input").each(function() {
+        var name = $(this).attr("name").replace("-" + (total - 1) + "-", "--");
+        $(this).attr({
+            "name": name
+        });
+    });
+
+    $("#add-more").on("click", function(event) {
+        event.preventDefault();
+        nextRow = blankRow.clone();
+        newRow = nextRow.clone();
+        newRow.find("input").each(function() {
+            var name = $(this).attr("name").replace("--","-" + total + "-");
+            var id = "id_" + name;
+            $(this).attr({
+                "name": name,
+                "id": id
+            }).val("");
+        });
+        total = total + 1;
+        $("#id_members-TOTAL_FORMS").val(total);
+        newRow.appendTo(lastRow.closest("tbody"));
+        lastRow = newRow;
+    });
+}());

--- a/shoop/admin/templates/shoop/admin/contact_groups/_edit_base_contact_group_form.jinja
+++ b/shoop/admin/templates/shoop/admin/contact_groups/_edit_base_contact_group_form.jinja
@@ -1,0 +1,9 @@
+{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% from "shoop/admin/macros/multilanguage.jinja" import language_dependent_content_tabs, render_monolingual_fields %}
+
+{% set base_formset = form["base"] %}
+
+{% call content_block(_("General information"), "fa-info-circle") %}
+    {{ language_dependent_content_tabs(base_formset) }}
+    {{ render_monolingual_fields(base_formset) }}
+{% endcall %}

--- a/shoop/admin/templates/shoop/admin/contact_groups/_edit_members_form.jinja
+++ b/shoop/admin/templates/shoop/admin/contact_groups/_edit_members_form.jinja
@@ -1,0 +1,24 @@
+{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% set members_formset = form["members"] %}
+
+{% call content_block(_("Members"), "fa-users") %}
+    {% for mf in members_formset.management_form %}{{ mf|safe }}{% endfor %}
+    <table class="table table-striped">
+        <tbody>
+        {% for f in members_formset %}
+            <tr>
+                <td>
+                    {% for fld in f.hidden_fields() %}{{ fld|safe }}{% endfor %}
+                    {{ f.member|safe }}
+                </td>
+                <td class="text-right">
+                    {% if f.DELETE and f.initial.member %}{{ bs3.field(f.DELETE) }}{% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    {% if members_formset.extra %}
+        <a href="#" type="button" class="btn btn-lg btn-text" id="add-more"><i class="fa fa-plus"></i> {% trans %}Add more{% endtrans %}</a>
+    {% endif %}
+{% endcall %}

--- a/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
+++ b/shoop/admin/templates/shoop/admin/contact_groups/edit.jinja
@@ -6,23 +6,14 @@
     {% call content_with_sidebar(content_id="contact_group_form") %}
         <form method="post" id="contact_group_form">
             {% csrf_token %}
-            {% call content_block(_("General information"), "fa-info-circle") %}
-                {{ language_dependent_content_tabs(form) }}
-                {{ render_monolingual_fields(form) }}
-            {% endcall %}
-            {% if contact_group.pk %}
-                {% call content_block(_("Members"), "fa-users") %}
-                    {# TODO: This is very bare-bones; should probably have UI to add/remove members etc... #}
-                    <ul>
-                    {% for member in contact_group.members.all() %}
-                        {% set u=shoop_admin.model_url(member, default="") %}
-                        <li>{% if u %}<a href="{{ u }}">{% endif %}{{ member }}{% if u %}</a>{% endif %}</li>
-                    {% else %}
-                        <li><i>{% trans %}No members.{% endtrans %}</i></li>
-                    {% endfor %}
-                    </ul>
-                {% endcall %}
-            {% endif %}
+            {% for form_def in form.form_defs.values() %}
+                {% include form_def.template_name %}
+            {% endfor %}
         </form>
     {% endcall %}
+{% endblock %}
+
+{% block extra_js %}
+    {{ super() }}
+    <script src="{{ static("shoop_admin/js/contact-group.js") }}"></script>
 {% endblock %}

--- a/shoop_tests/admin/test_contact_group_edit.py
+++ b/shoop_tests/admin/test_contact_group_edit.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.forms import formset_factory
+
+from shoop.admin.modules.contact_groups.views.edit import ContactGroupEditView
+from shoop.admin.modules.contact_groups.views.forms import ContactGroupMembersForm, ContactGroupMembersFormSet
+from shoop.testing.factories import create_random_person, get_default_customer_group
+from shoop_tests.utils.forms import get_form_data
+
+
+@pytest.mark.django_db
+def test_contact_group_members_formset(rf):
+    FormSet = formset_factory(ContactGroupMembersForm, ContactGroupMembersFormSet, extra=1, can_delete=True)
+    contact_group = get_default_customer_group()
+    person = create_random_person()
+
+    # No members
+    formset = FormSet(contact_group=contact_group)
+    assert formset.initial_form_count() == 0
+
+    # Add a member
+    data = dict(get_form_data(formset, True), **{"form-0-member": person.pk})
+    formset = FormSet(contact_group=contact_group, data=data)
+    formset.save()
+    assert contact_group.members.filter(pk=person.pk).exists()
+
+    # Remove a member
+    formset = FormSet(contact_group=contact_group)
+    assert formset.initial_form_count() == 1
+    data = dict(get_form_data(formset, True), **{"form-0-DELETE": "1"})
+    formset = FormSet(contact_group=contact_group, data=data)
+    formset.save()
+    assert not contact_group.members.exists()


### PR DESCRIPTION
Add ability to add/remove contact group members to/from groups, using the popup choice widget.

![edit_members_final](https://cloud.githubusercontent.com/assets/5107464/12933030/c838a716-cf3a-11e5-873c-0539f96e83c6.png)

When ``extra`` is set to 0 on formset, default behavior is to not display an "Add more" button. The "Add more" button copies an existing blank form and appends it to formset, and otherwise we couldn't guarantee a form would be available to copy (which seemed preferable to hard-coding the widget HTML into the JS file).

Refs SHOOP-1981