### PR TITLE
Add `next` context variable in registration process

### DIFF
--- a/shoop/front/apps/auth/views.py
+++ b/shoop/front/apps/auth/views.py
@@ -30,6 +30,11 @@ class LoginView(FormView):
     template_name = 'shoop/user/login.jinja'
     form_class = EmailAuthenticationForm
 
+    def get_context_data(self, **kwargs):
+        context = super(LoginView, self).get_context_data(**kwargs)
+        context[REDIRECT_FIELD_NAME] = self.request.REQUEST.get(REDIRECT_FIELD_NAME)
+        return context
+
     def get_form(self, form_class=None):
         form = super(LoginView, self).get_form(form_class)
         form.fields[REDIRECT_FIELD_NAME] = forms.CharField(

--- a/shoop/front/apps/registration/views.py
+++ b/shoop/front/apps/registration/views.py
@@ -7,7 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.shortcuts import redirect
+from django.utils.http import is_safe_url
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import View
 from registration.backends.default import views as default_views
@@ -33,6 +35,9 @@ class RegistrationViewMixin(object):
     template_name = "shoop/registration/register.jinja"
 
     def get_success_url(self, request, user):
+        url = self.request.REQUEST.get(REDIRECT_FIELD_NAME)
+        if url and is_safe_url(url, request.get_host()):
+            return url
         return ('shoop:registration_complete', (), {})
 
 

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_navigation.jinja
@@ -84,7 +84,7 @@
                         {% endif %}
                         {% if shoop.urls.has_url("shoop:registration_register") %}
                         <li>
-                            <a href="{{ url("shoop:registration_register") }}">
+                            <a href="{{ url("shoop:registration_register") }}{% if next %}?next={{next}}{% endif %}">
                                 <i class="fa fa-edit fa-fw"></i> {% trans %}New user? Register here!{% endtrans %}
                             </a>
                         </li>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/user/login.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/user/login.jinja
@@ -41,7 +41,7 @@
                     </form>
                 </div>
                 {% if shoop.urls.has_url("shoop:registration_register") %}
-                    <a class="col-sm-12 text-center text-muted" href="{{ url("shoop:registration_register") }}">
+                    <a class="col-sm-12 text-center text-muted" href="{{ url("shoop:registration_register") }}{% if next %}?next={{next}}{% endif %}">
                         {% trans %}New user? Register here!{% endtrans %}
                     </a>
                 {% endif %}

--- a/shoop_tests/front/test_registration.py
+++ b/shoop_tests/front/test_registration.py
@@ -44,6 +44,28 @@ def test_registration(django_user_model, client, requiring_activation):
         else:
             assert user.is_active
 
+@pytest.mark.django_db
+@pytest.mark.parametrize("requiring_activation", (False, True))
+def test_registration_2(django_user_model, client, requiring_activation):
+    if "shoop.front.apps.registration" not in settings.INSTALLED_APPS:
+        pytest.skip("shoop.front.apps.registration required in installed apps")
+
+    get_default_shop()
+
+    with override_settings(
+        SHOOP_REGISTRATION_REQUIRES_ACTIVATION=requiring_activation,
+    ):
+        response = client.post(reverse("shoop:registration_register"), data={
+            "username": username,
+            "email": email,
+            "password1": "password",
+            "password2": "password",
+            "next": reverse('shoop:checkout')
+        })
+        user = django_user_model.objects.get(username=username)
+        assert response.status_code == 302 #redirect
+        assert response.url.endswith(reverse('shoop:checkout'))
+
 
 def test_settings_has_account_activation_days():
     assert hasattr(settings, 'ACCOUNT_ACTIVATION_DAYS')


### PR DESCRIPTION
The `next` context variable contains an URL to redirect the user after a successful registration. It is optional and may allow redirects to certain pages after the registration.