### PR TITLE
Addons: Enable upgrade, migrations and collectstatic

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -71,6 +71,11 @@ General/miscellaneous
 
 - Add campaigns module
 
+Addons
+~~~~~~
+
+- Enable upgrade, migrations and collectstatic from admin
+
 
 Version 3.0.0
 -------------

--- a/shoop/addons/installer.py
+++ b/shoop/addons/installer.py
@@ -35,6 +35,7 @@ class PackageInstaller(object):
         cmd = [
             get_pip_path(),
             "install",
+            "--upgrade",
             "--verbose",
             "--require-venv",
             package_path

--- a/shoop/addons/locale/en/LC_MESSAGES/django.po
+++ b/shoop/addons/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-29 18:55+0000\n"
+"POT-Creation-Date: 2016-02-10 20:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
-"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -98,7 +98,24 @@ msgid ""
 "yourself (or have a system administrator handy)."
 msgstr ""
 
-msgid "Reload initiated"
+msgid "Reload steps"
+msgstr ""
+
+msgid ""
+"Finalize installations for newly installed addons (migrate and collect "
+"static resources)"
+msgstr ""
+
+msgid "Reload application server"
+msgstr ""
+
+msgid "Reload initiated."
+msgstr ""
+
+msgid "Error while reloading application."
+msgstr ""
+
+msgid "Finalizing installations."
 msgstr ""
 
 msgid "Your Shoop seems to be back up!"

--- a/shoop/addons/templates/shoop/admin/addons/reload.jinja
+++ b/shoop/addons/templates/shoop/admin/addons/reload.jinja
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="container-fluid">
-        <form method="post" id="addon_reload_form" target="reload-target" onsubmit="beginCheckReload()">
+        <form method="post" id="addon_reload_form" target="reload-target" onsubmit="beginReload()">
             {% csrf_token %}
             {% call content_block(_("Reload Application Server"), "fa-refresh") %}
                 {{ bs3.field(form.reload_method) }}
@@ -14,14 +14,20 @@
                             <p><strong>{% trans %}When you reload the application server, it may take some time for the new instance of your application to properly initialize.{% endtrans %}</strong></p>
                             <p><strong>{% trans %}In addition, there is always a chance for the server to not properly initialize at all, in which case you may need to troubleshoot the problem yourself (or have a system administrator handy).{% endtrans %}</strong></p>
                         </div>
+                        <h3>{% trans %}Reload steps{% endtrans %}</h3>
+                        <ol>
+                            <li>{% trans %}Finalize installations for newly installed addons (migrate and collect static resources){% endtrans %}</li>
+                            <li>{% trans %}Reload application server{% endtrans %}</li>
+                        </ol>
                         <hr>
-                        <button type="submit" class="btn btn-warning">
+                        <button id="reload-button" type="submit" class="btn btn-warning">
                             <i class="fa fa-refresh"></i>
                             {% trans %}Reload Application Server{% endtrans %}
                         </button>
                         <iframe name="reload-target" src="about:blank" frameborder="0" style="display: none"></iframe>
                     </div>
                 </div>
+                <div id="reload-log"></div>
             {% endcall %}
         </form>
     </div>
@@ -30,7 +36,10 @@
 {% block extra_js %}
 <script>
     var reloadCheckTimer = null;
+    var started_migrating = false;
+    var reloadUrl = {{ request.path|json }};
     var reloadCheckUrl = {{ (request.path + "?ping=1")|json }};
+    var finalizeUrl = {{ (request.path + "?finalize=1")|json }};
 
     function stopCheckReload() {
         if(reloadCheckTimer) {
@@ -38,10 +47,39 @@
             reloadCheckTimer = null;
         }
     }
-    function beginCheckReload() {
+
+    function reloadApplication() {
         stopCheckReload();
         reloadCheckTimer = setInterval(checkReload, 2000);
-        Messages.enqueue({tags: "info", text: "{% trans %}Reload initiated{% endtrans %}."});
+        Messages.enqueue({tags: "info", text: "{% trans %}Reload initiated.{% endtrans %}"});
+        $.ajax({type: "POST", url: reloadUrl, data: $("#addon_reload_form").serialize()});
+    }
+
+    function beginReload() {
+        event.preventDefault();
+        $("#reload-button").attr("disabled", true);
+        finalizeInstallations();
+    }
+
+    function sendCommand(url, next) {
+        $.ajax({
+            type: "GET",
+            url: url,
+            success: function (data) {
+                $("#reload-log").append("<pre><code>" + data.message + "</code></pre>");
+                next();
+            },
+            error: function (response) {
+                Messages.enqueue({tags: "error", text: "{% trans %}Error while reloading application.{% endtrans %}"});
+                $("#reload-log").append("<pre><code>" + response.responseJSON.message + "</code></pre>");
+            }
+        });
+    }
+
+    function finalizeInstallations() {
+        started_migrating = true;
+        Messages.enqueue({tags: "info", text: "{% trans %}Finalizing installations.{% endtrans %}"});
+        sendCommand(finalizeUrl, reloadApplication);
     }
 
     function checkReload() {

--- a/shoop/apps/settings.py
+++ b/shoop/apps/settings.py
@@ -105,3 +105,13 @@ def validate_templates_configuration():
         "The `django_jinja` template backend was not encountered in your TEMPLATES configuration. "
         "See the Shoop or Django-Jinja documentation on more information how to configure things correctly."
     )
+
+
+def reload_apps():
+    import django
+    _KNOWN_SETTINGS.clear()
+    django.apps.apps.app_configs.clear()
+    django.apps.apps.ready = False
+    django.setup()
+    # Rebuild any AppDirectoriesFinder instance.
+    django.contrib.staticfiles.finders.get_finder.cache_clear()


### PR DESCRIPTION
* Use upgrade flag while installing new addons. This allows
updating old addons.
* Run migrations command while reloading application
* Run collectstatic command while reloading application

Refs SHOOP-2106 / SHOOP-1770