### PR TITLE
Core: Move calculate taxes automatically under TaxModule

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Move calculate_taxes_automatically from ``OrderSource`` to ``TaxModule``
 - Add contact address for ``Shop``
 - Add update_stock calls for ``SimpleSupplierModule``
 - Rename ``simple_pricing`` to ``customer_group_pricing``

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -124,7 +124,6 @@ class OrderSource(object):
         self.zero_price = shop.create_price(0)
         self.create_price = self.zero_price.new
 
-        self.calculate_taxes_automatically = False
         """
         Calculate taxes automatically when lines are added or processed.
 
@@ -314,8 +313,9 @@ class OrderSource(object):
             lines = self.__compute_lines()
             self._processed_lines_cache = lines
         if not self._taxes_calculated:
-            if with_taxes or self.calculate_taxes_automatically:
-                self._calculate_taxes(lines)
+            tax_module = taxing.get_tax_module()
+            if with_taxes or tax_module.calculate_taxes_automatically:
+                self._calculate_taxes(lines, tax_module)
         return lines
 
     def calculate_taxes(self, force_recalculate=False):
@@ -323,14 +323,14 @@ class OrderSource(object):
             self._taxes_calculated = False
         self.get_final_lines(with_taxes=True)
 
-    def _calculate_taxes(self, lines):
-        tax_module = taxing.get_tax_module()
+    def _calculate_taxes(self, lines, tax_module):
         tax_module.add_taxes(self, lines)
         self._taxes_calculated = True
 
     def calculate_taxes_or_raise(self):
         if not self._taxes_calculated:
-            if not self.calculate_taxes_automatically:
+            tax_module = taxing.get_tax_module()
+            if not tax_module.calculate_taxes_automatically:
                 raise TaxesNotCalculated('Taxes are not calculated')
             self.calculate_taxes()
 

--- a/shoop/core/settings.py
+++ b/shoop/core/settings.py
@@ -150,3 +150,6 @@ SHOOP_DEFAULT_CACHE_DURATION = 60 * 30
 #: Overrides for default cache durations by key namespace.
 #: These override possible defaults in `shoop.core.cache.impl.DEFAULT_CACHE_DURATIONS`.
 SHOOP_CACHE_DURATIONS = {}
+
+#: Whether taxes is calculated automatically in TaxModule
+SHOOP_CALCULATE_TAXES_AUTOMATICALLY = True

--- a/shoop/core/taxing/_module.py
+++ b/shoop/core/taxing/_module.py
@@ -7,6 +7,7 @@
 import abc
 
 import six
+from django.conf import settings
 
 from shoop.apps.provides import load_module
 
@@ -30,6 +31,10 @@ class TaxModule(six.with_metaclass(abc.ABCMeta)):
     name = None
 
     taxing_context_class = TaxingContext
+
+    @property
+    def calculate_taxes_automatically(self):
+        return settings.SHOOP_CALCULATE_TAXES_AUTOMATICALLY
 
     def get_context_from_request(self, request):
         customer = getattr(request, "customer", None)

--- a/shoop_tests/core/test_taxes.py
+++ b/shoop_tests/core/test_taxes.py
@@ -6,9 +6,16 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 import pytest
+
+from django.test.utils import override_settings
 from django.utils.translation import activate
 
-from shoop.core.models import CustomerTaxGroup
+from shoop.core.models import CustomerTaxGroup, OrderLineType
+from shoop.core.order_creator import TaxesNotCalculated
+from shoop.testing.factories import (
+    get_default_product, get_default_shop, get_default_supplier,
+)
+from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 
 
 @pytest.mark.django_db
@@ -23,3 +30,43 @@ def test_customertaxgroup():
     assert CustomerTaxGroup.objects.count() == 2
     assert company_group.identifier == "default_company_customers"
     assert company_group.name == "Company Customers"
+
+
+def get_source():
+    source = BasketishOrderSource(get_default_shop())
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=get_default_product(),
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+    )
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+    return source
+
+
+@pytest.mark.django_db
+def test_calculate_taxes_automatically_setting():
+    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY=True):
+        source = get_source()
+        source.get_final_lines()
+        assert source._taxes_calculated == True
+
+        source = get_source()
+        assert source._taxes_calculated == False
+        source.calculate_taxes_or_raise()
+        assert source._taxes_calculated == True
+
+
+    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY=False):
+        source = get_source()
+        source.get_final_lines()
+        assert source._taxes_calculated == False
+
+        with pytest.raises(TaxesNotCalculated):
+            source.calculate_taxes_or_raise()


### PR DESCRIPTION
Move calculate taxes automitacally from OrderSource to TaxModule.
Create setting SHOOP_CALCULATE_TAXES_AUTOMATICALLY.

Refs SHOOP-1911