### PR TITLE
Enable custom AUTH_USER_MODEL with username field other than `username`.

### DIFF
--- a/shoop/testing/management/commands/shoop_populate_mock.py
+++ b/shoop/testing/management/commands/shoop_populate_mock.py
@@ -26,7 +26,8 @@ class Command(BaseCommand):
         translation.activate(settings.LANGUAGES[0][0])
         superuser_name = options.get("with_superuser")
         if superuser_name:
-            user = get_user_model().objects.filter(username=superuser_name).first()
+            filter_params = {get_user_model().USERNAME_FIELD: superuser_name}
+            user = get_user_model().objects.filter(**filter_params).first()
             if not user:
                 user = get_user_model().objects.create_superuser(
                     username=superuser_name,


### PR DESCRIPTION
This enables the usage of a custom AUTH_USER_MODEL in Shoop using mock data.