### PR TITLE
Core: Add default contact groups

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add contacts automatically to type specific default groups
 - ``OrderCreator`` no longer requires a request
 - Add ``order_creator_finished`` signal under ``order_creator``
 - Move calculate_taxes_automatically from ``OrderSource`` to ``TaxModule``

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-27 04:56+0000\n"
+"POT-Creation-Date: 2016-02-18 17:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -323,6 +323,9 @@ msgstr ""
 msgid "contacts"
 msgstr ""
 
+msgid "Company Contacts"
+msgstr ""
+
 msgid "e.g. EIN in US or VAT code in Europe"
 msgstr ""
 
@@ -330,6 +333,9 @@ msgid "company"
 msgstr ""
 
 msgid "companies"
+msgstr ""
+
+msgid "Person Contacts"
 msgstr ""
 
 msgid "user"
@@ -345,6 +351,9 @@ msgid "person"
 msgstr ""
 
 msgid "persons"
+msgstr ""
+
+msgid "Anonymous Contacts"
 msgstr ""
 
 msgid "order reference"

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -35,6 +35,7 @@ def test_anonymity(admin_user, regular_user):
     assert AnonymousContact().is_anonymous
 
 
+@pytest.mark.django_db
 def test_anonymous_contact():
     a1 = AnonymousContact()
     a2 = AnonymousContact()
@@ -73,9 +74,9 @@ def test_anonymous_contact():
         a1.delete()
 
     assert isinstance(a1.groups, QuerySet)
-    assert a1.groups.count() == 0
-    assert len(a1.groups) == 0
-    assert not a1.groups
+    assert a1.groups.first().identifier == AnonymousContact.default_contact_group_identifier
+    assert a1.groups.count() == 1
+    assert len(a1.groups.all()) == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
* Default contact groups for anonymous, person and company contacts
* Groups is assigned during save
* Make ContactGroup TranslatableShoopModel

Refs SHOOP-1981 / SHOOP-2141