### PR TITLE
Add version limits to 3rd party packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,9 @@ REQUIRES = [
     'django-parler~=1.5',
     'django-parler-rest~=1.3a1',
     'django-polymorphic~=0.8.0',
-    'django-registration-redux~=1.2',
+    # django-registration-redux>=1.4 does not work with
+    # our custom get_success_url
+    'django-registration-redux~=1.2,<1.4',
     'django-timezone-field~=1.2',
 
     # djangorestframework>=3.3.0 does not work with

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ REQUIRES = [
     'djangorestframework~=3.1,<3.3.0',
 
     'factory-boy~=2.5',
-    'fake-factory~=0.5.0',
+    'fake-factory~=0.5.0,<0.5.4',
     'Jinja2~=2.8',
     'jsonfield~=1.0',
     'Markdown~=2.6',


### PR DESCRIPTION
* django-registration version 1.4 doesn't work with our custom get_success_url
* fake-facotry version 0.5.4 does not work with Shoop