### PR TITLE
Taxes: Changes to automatic tax calculations

### DIFF
--- a/shoop/core/settings.py
+++ b/shoop/core/settings.py
@@ -151,5 +151,5 @@ SHOOP_DEFAULT_CACHE_DURATION = 60 * 30
 #: These override possible defaults in `shoop.core.cache.impl.DEFAULT_CACHE_DURATIONS`.
 SHOOP_CACHE_DURATIONS = {}
 
-#: Whether taxes is calculated automatically in TaxModule
-SHOOP_CALCULATE_TAXES_AUTOMATICALLY = True
+#: Whether taxes should be calculated automatically in TaxModule
+SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE = True

--- a/shoop/core/taxing/__init__.py
+++ b/shoop/core/taxing/__init__.py
@@ -8,7 +8,9 @@ from shoop.utils import update_module_attributes
 
 from ._context import TaxingContext
 from ._line_tax import LineTax, SourceLineTax
-from ._module import get_tax_module, TaxModule
+from ._module import (
+    get_tax_module, should_calculate_taxes_automatically, TaxModule
+)
 from ._price import TaxedPrice
 from ._tax_summary import TaxSummary
 from ._taxable import TaxableItem
@@ -22,6 +24,7 @@ __all__ = [
     "TaxedPrice",
     "TaxingContext",
     "get_tax_module",
+    "should_calculate_taxes_automatically",
 ]
 
 update_module_attributes(__all__, __name__)

--- a/shoop/core/taxing/_module.py
+++ b/shoop/core/taxing/_module.py
@@ -23,18 +23,29 @@ def get_tax_module():
     return load_module("SHOOP_TAX_MODULE", "tax_module")()
 
 
+def should_calculate_taxes_automatically():
+    """
+    If ``settings.SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE``
+    is False taxes shouldn't be calculated automatically otherwise
+    use current tax module value ``TaxModule.calculating_is_cheap``
+    to determine whether taxes should be calculated automatically.
+
+    :rtype: bool
+    """
+    if not settings.SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE:
+        return False
+    return get_tax_module().calculating_is_cheap
+
+
 class TaxModule(six.with_metaclass(abc.ABCMeta)):
     """
     Module for calculating taxes.
     """
+    calculating_is_cheap = True
     identifier = None
     name = None
 
     taxing_context_class = TaxingContext
-
-    @property
-    def calculate_taxes_automatically(self):
-        return settings.SHOOP_CALCULATE_TAXES_AUTOMATICALLY
 
     def get_context_from_request(self, request):
         customer = getattr(request, "customer", None)

--- a/shoop_tests/core/test_taxes.py
+++ b/shoop_tests/core/test_taxes.py
@@ -52,7 +52,7 @@ def get_source():
 
 @pytest.mark.django_db
 def test_calculate_taxes_automatically_setting():
-    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY=True):
+    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE=True):
         source = get_source()
         source.get_final_lines()
         assert source._taxes_calculated == True
@@ -63,7 +63,7 @@ def test_calculate_taxes_automatically_setting():
         assert source._taxes_calculated == True
 
 
-    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY=False):
+    with override_settings(SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE=False):
         source = get_source()
         source.get_final_lines()
         assert source._taxes_calculated == False


### PR DESCRIPTION
Change the logic whether to calculate taxes automatically in OrderSource.

Rename setting ``SHOOP_CALCULATE_TAXES_AUTOMATICALLY`` to
``SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE``. If this
setting is False then taxes shouldn't be calculated automatically
otherwise use ``TaxModule.calculating_is_cheap`` to make that
decision.

Refs SHOOP-1911