### PR TITLE
Themes: Add product cross sells plugin to classic_gray (SHOOP-1970)

### DIFF
--- a/shoop/themes/classic_gray/__init__.py
+++ b/shoop/themes/classic_gray/__init__.py
@@ -73,7 +73,8 @@ class ClassicGrayThemeAppConfig(AppConfig):
         "xtheme": "shoop.themes.classic_gray:ClassicGrayTheme",
         "xtheme_plugin": [
             "shoop.themes.classic_gray.plugins:ProductHighlightPlugin",
-        ]
+            "shoop.themes.classic_gray.plugins:ProductCrossSellsPlugin",
+        ],
     }
 
 

--- a/shoop/themes/classic_gray/plugins.py
+++ b/shoop/themes/classic_gray/plugins.py
@@ -50,3 +50,37 @@ class ProductHighlightPlugin(TemplatedPlugin):
             "title": self.get_translated_value("title"),
             "products": products
         }
+
+
+class ProductCrossSellsPlugin(TemplatedPlugin):
+    identifier = "classic_gray.product_cross_sells"
+    name = _("Product Cross Sells")
+    template_name = "classic_gray/cross_sells_plugin.jinja"
+    required_context_variables = ["product"]
+    fields = [
+        ("title", TranslatableField(label=_("Title"), required=False, initial="")),
+        ("type", forms.ChoiceField(label=_("Type"), choices=[
+            ("related", "Related"),
+            ("recommended", "Recommended"),
+            ("computed", "Computed"),
+        ], initial="related")),
+        ("count", forms.IntegerField(label=_("Count"), min_value=1, initial=4)),
+        ("orderable_only", forms.BooleanField(label=_("Only show in-stock and orderable items"),
+                                              initial=True,
+                                              required=False))
+    ]
+
+    def get_context_data(self, context):
+        count = self.config.get("count", 4)
+        product = context.get("product", None)
+        orderable_only = self.config.get("orderable_only", True)
+        type = self.config.get("type", "related")
+
+        return {
+            "request": context["request"],
+            "title": self.get_translated_value("title"),
+            "product": product,
+            "type": type,
+            "count": count,
+            "orderable_only": orderable_only,
+        }

--- a/shoop/themes/classic_gray/templates/classic_gray/cross_sells_plugin.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/cross_sells_plugin.jinja
@@ -1,0 +1,13 @@
+{%- import "shoop/front/macros.jinja" as macros with context -%}
+{%- set cross_sell_products = shoop.product.get_product_cross_sells(product, type, count=count, orderable_only=orderable_only) %}
+{% if cross_sell_products %}
+    <hr>
+    {% if title %}<h3>{{ title }}</h3>{% endif %}
+    <div class="row">
+        {% for product in cross_sell_products %}
+            <div class="col-md-3">
+                {{ macros.product_box(product) }}
+            </div>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/macros.jinja
@@ -34,21 +34,6 @@
     </div>
 {% endmacro %}
 
-{% macro render_cross_sell_products(product, relation_type="", title="") %}
-    {%- set cross_sell_products = shoop.product.get_product_cross_sells(product, relation_type) %}
-    {% if cross_sell_products %}
-        <hr>
-        {% if title %}<h3>{{ title }}</h3>{% endif %}
-        <div class="row">
-            {% for product in cross_sell_products %}
-                <div class="col-md-3">
-                    {{ product_box(product) }}
-                </div>
-            {% endfor %}
-        </div>
-    {% endif %}
-{% endmacro %}
-
 {% macro render_field(field, classes="") %}
     {% if field.field.widget.is_hidden %}
         {{ field.as_widget()|safe }}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/product/detail.jinja
@@ -128,8 +128,27 @@
             {% endif %}
         </div>
     </div>
-
-    {% placeholder "product_extra_bottom" %}{% endplaceholder %}
+    
+    {% placeholder "product_bottom" %}
+        {% row %}
+            {% plugin "classic_gray.product_cross_sells" %}
+                type = "related"
+                title = "Related Products"
+            {% endplugin %}
+        {% endrow %}
+        {% row %}
+            {% plugin "classic_gray.product_cross_sells" %}
+                type = "recommended"
+                title = "We recommend these products"
+            {% endplugin %}
+        {% endrow %}
+        {% row %}
+            {% plugin "classic_gray.product_cross_sells" %}
+                type = "computed"
+                title = "Users who bought this product also bought"
+            {% endplugin %}
+        {% endrow %}
+    {% endplaceholder %}
 
     {% if package_children %}
         <hr>
@@ -153,18 +172,6 @@
             {% endfor %}
         </div>
     {% endif %}
-
-    {{ macros.render_cross_sell_products(
-        product, relation_type="related", title=_("Related products")
-    ) }}
-
-    {{ macros.render_cross_sell_products(
-        product, relation_type="recommended", title=_("We recommend these products")
-    ) }}
-
-    {{ macros.render_cross_sell_products(
-        product, relation_type="computed", title=_("Users who bought this product also bought")
-    ) }}
 
 {% endblock %}
 

--- a/shoop_tests/front/test_product_template_helpers.py
+++ b/shoop_tests/front/test_product_template_helpers.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shoop.core.models import ProductCrossSell, StockBehavior
+from shoop.front.template_helpers import product as product_helpers
+from shoop.testing.factories import (
+    create_product, get_default_shop, get_default_supplier
+)
+from shoop_tests.front.fixtures import get_jinja_context
+
+
+def _create_cross_sell_products(product, shop, type, product_count):
+    for count in range(product_count):
+        related_product = create_product(
+            "{}-test-sku-{}".format(type, count),
+            shop=shop,
+            stock_behavior=StockBehavior.UNSTOCKED
+        )
+        ProductCrossSell.objects.create(product1=product, product2=related_product, type=type)
+
+
+@pytest.mark.django_db
+def test_cross_sell_plugin_type():
+    """
+    Test that template helper returns correct number of cross sells when shop contains multiple
+    relation types
+    """
+    shop = get_default_shop()
+    product = create_product("test-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
+    context = get_jinja_context(product=product)
+    type_counts = (("related", 1),
+                   ("recommended", 2),
+                   ("computed", 3))
+
+    # Create cross sell products and relations in different quantities
+    for type, count in type_counts:
+        _create_cross_sell_products(product, shop, type, count)
+        assert ProductCrossSell.objects.filter(product1=product, type=type).count() == count
+
+    # Make sure quantites returned by plugin match
+    for type, count in type_counts:
+        assert len(list(product_helpers.get_product_cross_sells(context, product, type, count))) == count
+
+
+@pytest.mark.django_db
+def test_cross_sell_plugin_count():
+    shop = get_default_shop()
+    product = create_product("test-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
+    context = get_jinja_context(product=product)
+    total_count = 5
+    trim_count = 3
+
+    _create_cross_sell_products(product, shop, "related", total_count)
+    assert ProductCrossSell.objects.filter(product1=product, type="related").count() == total_count
+
+    assert len(list(product_helpers.get_product_cross_sells(context, product, type, trim_count))) == trim_count

--- a/shoop_tests/themes/classic_gray/test_plugins.py
+++ b/shoop_tests/themes/classic_gray/test_plugins.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+
+from shoop.core.models import Product, ProductCrossSell, StockBehavior
+from shoop.testing.factories import create_product, get_default_shop
+from shoop.themes.classic_gray.plugins import ProductCrossSellsPlugin
+from shoop_tests.front.fixtures import get_jinja_context
+
+
+@pytest.mark.django_db
+def test_cross_sell_plugin_renders():
+    """
+    Test that the plugin renders a product
+    """
+    shop = get_default_shop()
+    product = create_product("test-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
+    computed = create_product("test-computed-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
+    type ="computed"
+
+    ProductCrossSell.objects.create(product1=product, product2=computed, type=type)
+    assert ProductCrossSell.objects.filter(product1=product, type=type).count() == 1
+
+    context = get_jinja_context(product=product)
+    rendered  = ProductCrossSellsPlugin({"type": type}).render(context)
+    assert computed.sku in rendered


### PR DESCRIPTION
Add a product cross sells xtheme plugin to classic_gray theme, replacing
hard-coded sections in theme templates.

Refs SHOOP-1970