### PR TITLE
Move order_creator_finished signal etc. (SHOOP-2114)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -34,6 +34,7 @@ Localization
 Admin
 ~~~~~
 
+- Make all enabled shipping and payment methods available in order creator
 - Check product quantities in order creation
 - Add option to add action buttons to Order edit view
 - Add Campaigns management

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- ``OrderCreator`` no longer requires a request
 - Add ``order_creator_finished`` signal under ``order_creator``
 - Move calculate_taxes_automatically from ``OrderSource`` to ``TaxModule``
 - Add shop product validation for OrderSource

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``order_creator_finished`` signal under ``order_creator``
 - Move calculate_taxes_automatically from ``OrderSource`` to ``TaxModule``
 - Add shop product validation for OrderSource
 - Add option to create payments with REST API
@@ -43,6 +44,7 @@ Front
 
 - Fix bug: BasketStorage.finalize() never called delete() correctly
 - Check product quantity already in basket while adding
+- Move ``order_creator_finished`` signal under core
 - Process given coupon codes in basket
 - Process discounts from new campaign engine
 

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -175,7 +175,7 @@ class JsonOrderCreator(object):
             customer = PersonContact(**fields)
         return customer
 
-    def _initialize_source_from_state(self, state, creator, save):
+    def _initialize_source_from_state(self, state, creator, ip_address, save):
         shop_data = state.pop("shop", None).get("selected", {})
         shop = self.safe_get_first(Shop, pk=shop_data.pop("id", None))
         if not shop:
@@ -225,6 +225,7 @@ class JsonOrderCreator(object):
 
         source.update(
             creator=creator,
+            ip_address=ip_address,
             customer=customer,
             billing_address=billing_address,
             shipping_address=shipping_address,
@@ -239,7 +240,8 @@ class JsonOrderCreator(object):
         if comment:
             order.add_log_entry(comment, kind=LogEntryKind.NOTE, user=order.creator)
 
-    def create_source_from_state(self, state, creator=None, save=False):
+    def create_source_from_state(self, state, creator=None, ip_address=None,
+                                 save=False):
         """
         Create an order source from a state dict unserialized from JSON.
 
@@ -259,7 +261,8 @@ class JsonOrderCreator(object):
         state = deepcopy(state)
 
         # First, initialize an OrderSource.
-        source = self._initialize_source_from_state(state, creator, save)
+        source = self._initialize_source_from_state(
+            state, creator=creator, ip_address=ip_address, save=save)
         if not source:
             return None
 
@@ -276,7 +279,7 @@ class JsonOrderCreator(object):
 
         return source
 
-    def create_order_from_state(self, state, creator=None):
+    def create_order_from_state(self, state, creator=None, ip_address=None):
         """
         Create an order from a state dict unserialized from JSON.
 
@@ -284,10 +287,13 @@ class JsonOrderCreator(object):
         :type state: dict
         :param creator: Creator user
         :type creator: django.contrib.auth.models.User|None
+        :param ip_address: Remote IP address (IPv4 or IPv6)
+        :type ip_address: str
         :return: The created order, or None if something failed along the way
         :rtype: Order|None
         """
-        source = self.create_source_from_state(state, creator, save=True)
+        source = self.create_source_from_state(
+            state, creator=creator, ip_address=ip_address, save=True)
 
         # Then create an OrderCreator and try to get things done!
         creator = OrderCreator()

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -290,7 +290,7 @@ class JsonOrderCreator(object):
         source = self.create_source_from_state(state, creator, save=True)
 
         # Then create an OrderCreator and try to get things done!
-        creator = OrderCreator(request=None)
+        creator = OrderCreator()
         try:
             order = creator.create_order(order_source=source)
             self._postprocess_order(order, state)

--- a/shoop/admin/modules/orders/views/create.py
+++ b/shoop/admin/modules/orders/views/create.py
@@ -16,7 +16,6 @@ from django.core import serializers
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.urlresolvers import reverse
 from django.db import transaction
-from django.db.models import Q
 from django.http.response import HttpResponse, JsonResponse
 from django.test.client import RequestFactory
 from django.utils.encoding import force_text
@@ -114,12 +113,8 @@ class OrderCreateView(TemplateView):
 
     def get_config(self):
         shops = [encode_shop(shop) for shop in Shop.objects.filter(status=ShopStatus.ENABLED)]
-        shipping_methods = ShippingMethod.objects.filter(
-            Q(status=MethodStatus.ENABLED), Q(module_identifier="default_shipping") | Q(module_identifier="")
-        )
-        payment_methods = PaymentMethod.objects.filter(
-            Q(status=MethodStatus.ENABLED), Q(module_identifier="default_payment") | Q(module_identifier="")
-        )
+        shipping_methods = ShippingMethod.objects.filter(status=MethodStatus.ENABLED)
+        payment_methods = PaymentMethod.objects.filter(status=MethodStatus.ENABLED)
         return {
             "shops": shops,
             "countries": [{"id": code, "name": name} for code, name in list(countries)],

--- a/shoop/admin/modules/orders/views/create.py
+++ b/shoop/admin/modules/orders/views/create.py
@@ -202,7 +202,11 @@ class OrderCreateView(TemplateView):
     @transaction.atomic
     def _handle_source_data(self, request):
         state = json.loads(request.body.decode("utf-8"))["state"]
-        source = create_source_from_state(state, creator=request.user)
+        source = create_source_from_state(
+            state,
+            creator=request.user,
+            ip_address=request.META.get("REMOTE_ADDR"),
+        )
         # Calculate final lines for confirmation
         source.calculate_taxes(force_recalculate=True)
         return {
@@ -217,7 +221,11 @@ class OrderCreateView(TemplateView):
     @transaction.atomic
     def _handle_create(self, request):
         state = json.loads(request.body.decode("utf-8"))["state"]
-        order = create_order_from_state(state, creator=request.user)
+        order = create_order_from_state(
+            state,
+            creator=request.user,
+            ip_address=request.META.get("REMOTE_ADDR"),
+        )
         messages.success(request, _("Order %(identifier)s created.") % vars(order))
         return JsonResponse({
             "success": True,

--- a/shoop/core/order_creator/_creator.py
+++ b/shoop/core/order_creator/_creator.py
@@ -13,9 +13,9 @@ import six
 from django.utils.encoding import force_text
 
 from shoop.core.models import Order, OrderLine, OrderLineType
+from shoop.core.order_creator.signals import order_creator_finished
 from shoop.core.shortcuts import update_order_line_from_product
 from shoop.core.utils.users import real_user_or_none
-from shoop.front.signals import order_creator_finished
 from shoop.utils.numbers import bankers_round
 
 from ._source_modifier import get_order_source_modifier_modules

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -117,6 +117,7 @@ class OrderSource(object):
         self.customer_comment = u""
         self.marketing_permission = False
         self.language = None
+        self.ip_address = None  # type: str
         self.order_date = now()
         self.status_id = None
         self.payment_data = {}
@@ -166,6 +167,7 @@ class OrderSource(object):
             language=order.language,
             display_currency=order.display_currency,
             display_currency_rate=order.display_currency_rate,
+            ip_address=order.ip_address,
             order_date=order.order_date,
             status_id=order.status_id,
             payment_data=order.payment_data,

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -130,14 +130,6 @@ class OrderSource(object):
         self.zero_price = shop.create_price(0)
         self.create_price = self.zero_price.new
 
-        """
-        Calculate taxes automatically when lines are added or processed.
-
-        Set to False to minimize costs and latency, since it is possible
-        that the current TaxModule implemements tax calculations with an
-        integration to a remote system which charges per transaction.
-        """
-
         self._taxes_calculated = False
         self._processed_lines_cache = None
 

--- a/shoop/core/order_creator/signals.py
+++ b/shoop/core/order_creator/signals.py
@@ -8,3 +8,4 @@ from django.core.signals import Signal
 
 post_compute_source_lines = Signal(
     providing_args=["source", "lines"], use_caching=True)
+order_creator_finished = Signal(providing_args=["order", "source", "request"], use_caching=True)

--- a/shoop/core/order_creator/signals.py
+++ b/shoop/core/order_creator/signals.py
@@ -8,4 +8,5 @@ from django.core.signals import Signal
 
 post_compute_source_lines = Signal(
     providing_args=["source", "lines"], use_caching=True)
-order_creator_finished = Signal(providing_args=["order", "source", "request"], use_caching=True)
+order_creator_finished = Signal(
+    providing_args=["order", "source"], use_caching=True)

--- a/shoop/core/pricing/_context.py
+++ b/shoop/core/pricing/_context.py
@@ -47,6 +47,10 @@ class PricingContext(PricingContextable):
         :type customer: shoop.core.models.Contact
         :type time: datetime.datetime|None
         """
+        assert shop is not None, "shop is required"
+        assert customer is not None, (
+            "customer is required (may be AnonymousContact though)")
+
         self.shop = shop
         self.customer = customer
         self.time = (time if time is not None else now())

--- a/shoop/core/pricing/_module.py
+++ b/shoop/core/pricing/_module.py
@@ -55,13 +55,17 @@ class PricingModule(six.with_metaclass(abc.ABCMeta)):
             shop=request.shop
         )
 
-    def get_context_from_data(self, **context_data):
+    def get_context_from_data(self, shop, customer, time=None, **kwargs):
         """
-        Create pricing context from keyword arguments.
+        Create pricing context from given arguments.
 
+        :type shop: shoop.core.models.Shop
+        :type customer: shoop.core.models.Contact
+        :type time: datetime.datetime|None
         :rtype: PricingContext
         """
-        return self.pricing_context_class(**context_data)
+        return self.pricing_context_class(
+            shop=shop, customer=customer, time=time, **kwargs)
 
     @abc.abstractmethod
     def get_price_info(self, context, product, quantity=1):

--- a/shoop/core/shortcuts/__init__.py
+++ b/shoop/core/shortcuts/__init__.py
@@ -15,7 +15,10 @@ def update_order_line_from_product(
 
     This is a convenience method for simple applications.
 
-    :type pricing_context: shoop.core.pricing.PricingContextable
+    :type pricing_context: shoop.core.pricing.PricingContextable|None
+    :param pricing_context:
+      Pricing context to use for pricing the line.  If None is given,
+      the line will get zero price and zero discount amount.
     :type order_line: shoop.core.models.OrderLine
     :type product: shoop.core.models.Product
     :type quantity: int|decimal.Decimal
@@ -28,7 +31,6 @@ def update_order_line_from_product(
     if not product:  # pragma: no cover
         raise Exception("set_from_product may not be used without product")
 
-    price_info = product.get_price_info(pricing_context, quantity=quantity)
     order_line.supplier = supplier
     order_line.type = OrderLineType.PRODUCT
     order_line.product = product
@@ -38,6 +40,11 @@ def update_order_line_from_product(
     order_line.accounting_identifier = product.accounting_identifier
     order_line.require_verification = bool(getattr(product, "require_verification", False))
     order_line.verified = False
-    order_line.base_unit_price = price_info.base_unit_price
-    order_line.discount_amount = price_info.discount_amount
-    assert order_line.price == price_info.price
+    if pricing_context:
+        price_info = product.get_price_info(pricing_context, quantity=quantity)
+        order_line.base_unit_price = price_info.base_unit_price
+        order_line.discount_amount = price_info.discount_amount
+        assert order_line.price == price_info.price
+    else:
+        order_line.base_unit_price_value = 0
+        order_line.discount_amount_value = 0

--- a/shoop/front/basket/__init__.py
+++ b/shoop/front/basket/__init__.py
@@ -8,7 +8,7 @@
 from shoop.utils.importing import cached_load
 
 
-def get_basket_order_creator(request):
+def get_basket_order_creator(request=None):
     return cached_load("SHOOP_BASKET_ORDER_CREATOR_SPEC")(request=request)
 
 

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -90,6 +90,8 @@ class BaseBasket(OrderSource):
         super(BaseBasket, self).__init__(request.shop)
         self.basket_name = basket_name
         self.request = request
+        if request:
+            self.ip_address = request.META.get("REMOTE_ADDR")
         self.storage = get_storage()
         self._data = None
         self.dirty = False

--- a/shoop/front/checkout/confirm.py
+++ b/shoop/front/checkout/confirm.py
@@ -67,7 +67,7 @@ class ConfirmPhase(CheckoutPhaseViewMixin, FormView):
         basket.customer = self.request.customer
         basket.creator = self.request.user
         basket.status = OrderStatus.objects.get_default_initial()
-        order_creator = get_basket_order_creator(request=self.request)
+        order_creator = get_basket_order_creator()
         order = order_creator.create_order(basket)
         basket.finalize()
         return order

--- a/shoop/front/checkout/single_page.py
+++ b/shoop/front/checkout/single_page.py
@@ -123,7 +123,7 @@ class SingleCheckoutPhase(CheckoutPhaseViewMixin, FormView):
         if order_data:  # pragma: no cover
             raise ValueError("`order_data` should be empty by now")
 
-        order_creator = get_basket_order_creator(request=self.request)
+        order_creator = get_basket_order_creator()
         order = order_creator.create_order(basket)
         basket.finalize()
         self.checkout_process.complete()

--- a/shoop/front/notify_events.py
+++ b/shoop/front/notify_events.py
@@ -7,10 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 from django.dispatch import receiver
 
+from shoop.core.order_creator.signals import order_creator_finished
 from shoop.notify import Event, Variable
 from shoop.notify.typology import Email, Language, Model, Phone
-
-from .signals import order_creator_finished
 
 
 class OrderReceived(Event):

--- a/shoop/front/signals.py
+++ b/shoop/front/signals.py
@@ -12,5 +12,4 @@ get_basket_command_handler = Signal(providing_args=["command"], use_caching=True
 get_method_validation_errors = Signal(providing_args=["method", "source"], use_caching=True)
 
 # Completion signals
-order_creator_finished = Signal(providing_args=["order", "source", "request"], use_caching=True)
 order_complete_viewed = Signal(providing_args=["order", "request"], use_caching=True)

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -649,7 +649,7 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
         )
         assert line.price == price_info.price
     with atomic():
-        oc = OrderCreator(request)
+        oc = OrderCreator()
         order = oc.create_order(source)
         if random.random() < completion_probability:
             order.create_shipment_of_all_products()

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -20,7 +20,6 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.validators import validate_email, ValidationError
 from django.db.transaction import atomic
-from django.test import RequestFactory
 from django.utils.timezone import now
 from django_countries.data import COUNTRIES
 from factory.django import DjangoModelFactory
@@ -30,14 +29,15 @@ from six import BytesIO
 
 from shoop.core.defaults.order_statuses import create_default_order_statuses
 from shoop.core.models import (
-    Attribute, AttributeType, Category, CategoryStatus, CompanyContact,
-    Contact, ContactGroup, MutableAddress, Order, OrderLine, OrderLineTax,
-    OrderLineType, OrderStatus, PaymentMethod, PersonContact, Product,
-    ProductMedia, ProductMediaKind, ProductType, SalesUnit, ShippingMethod,
-    Shop, ShopProduct, ShopStatus, StockBehavior, Supplier, SupplierType, Tax,
-    TaxClass
+    AnonymousContact, Attribute, AttributeType, Category, CategoryStatus,
+    CompanyContact, Contact, ContactGroup, MutableAddress, Order, OrderLine,
+    OrderLineTax, OrderLineType, OrderStatus, PaymentMethod, PersonContact,
+    Product, ProductMedia, ProductMediaKind, ProductType, SalesUnit,
+    ShippingMethod, Shop, ShopProduct, ShopStatus, StockBehavior, Supplier,
+    SupplierType, Tax, TaxClass
 )
 from shoop.core.order_creator import OrderCreator, OrderSource
+from shoop.core.pricing import get_pricing_module
 from shoop.core.shortcuts import update_order_line_from_product
 from shoop.default_tax.models import TaxRule
 from shoop.testing.text_data import random_title
@@ -45,7 +45,6 @@ from shoop.utils.filer import filer_image_from_data
 from shoop.utils.money import Money
 
 from .image_generator import generate_image
-from .utils import apply_request_middleware
 
 DEFAULT_IDENTIFIER = "default"
 DEFAULT_NAME = "Default"
@@ -466,12 +465,11 @@ def create_order_with_product(
     order.full_clean()
     order.save()
 
-    request = apply_request_middleware(RequestFactory().get("/"))
-    request.shop = order.shop
+    pricing_context = _get_pricing_context(order.shop, order.customer)
 
     for x in range(n_lines):
         product_order_line = OrderLine(order=order)
-        update_order_line_from_product(pricing_context=request,
+        update_order_line_from_product(pricing_context,
                                        order_line=product_order_line,
                                        product=product, quantity=quantity,
                                        supplier=supplier)
@@ -610,8 +608,7 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
     if shop is None:
         shop = get_default_shop()
 
-    request = apply_request_middleware(RequestFactory().get("/"),
-                                       customer=customer)
+    pricing_context = _get_pricing_context(shop, customer)
 
     source = OrderSource(shop)
     source.customer = customer
@@ -634,7 +631,7 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
     for i in range(random.randint(3, 10)):
         product = random.choice(products)
         quantity = random.randint(1, 5)
-        price_info = product.get_price_info(request, quantity=quantity)
+        price_info = product.get_price_info(pricing_context, quantity=quantity)
         shop_product = product.get_shop_instance(source.shop)
         supplier = shop_product.suppliers.first()
         line = source.add_line(
@@ -657,3 +654,10 @@ def create_random_order(customer=None, products=(), completion_probability=0, sh
             order.status = OrderStatus.objects.get_default_complete()
             order.save(update_fields=("status",))
         return order
+
+
+def _get_pricing_context(shop, customer=None):
+    return get_pricing_module().get_context_from_data(
+        shop=shop,
+        customer=(customer or AnonymousContact()),
+    )

--- a/shoop_tests/campaigns/test_basket_campaigns.py
+++ b/shoop_tests/campaigns/test_basket_campaigns.py
@@ -23,7 +23,6 @@ from shoop.testing.factories import (
     create_product, get_default_supplier, get_default_tax_class,
     get_default_product
 )
-from shoop.testing.utils import apply_request_middleware
 from shoop_tests.campaigns import initialize_test
 from shoop_tests.core.test_order_creator import seed_source
 from shoop_tests.utils import printable_gibberish
@@ -259,8 +258,7 @@ def test_order_creation_adds_usage(rf, admin_user):
 
     source.add_code(coupon.code)
 
-    request = apply_request_middleware(rf.get("/"))
-    creator = OrderCreator(request)
+    creator = OrderCreator()
     creator.create_order(source)
 
     assert CouponUsage.objects.count() == 1

--- a/shoop_tests/core/test_order_creator.py
+++ b/shoop_tests/core/test_order_creator.py
@@ -15,7 +15,6 @@ from shoop.testing.factories import (
     get_default_shipping_method, get_default_shop, get_default_supplier,
     get_initial_order_status
 )
-from shoop.testing.utils import apply_request_middleware
 from shoop.utils.models import get_data_dict
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 
@@ -93,9 +92,7 @@ def test_order_creator(rf, admin_user):
         require_verification=True,
     )
 
-    request = apply_request_middleware(rf.get("/"))
-
-    creator = OrderCreator(request)
+    creator = OrderCreator()
     order = creator.create_order(source)
     assert get_data_dict(source.billing_address) == get_data_dict(order.billing_address)
     assert get_data_dict(source.shipping_address) == get_data_dict(order.shipping_address)
@@ -115,9 +112,7 @@ def test_order_creator_supplierless_product_line_conversion_should_fail(rf, admi
         base_unit_price=source.create_price(10),
     )
 
-    request = apply_request_middleware(rf.get("/"))
-
-    creator = OrderCreator(request)
+    creator = OrderCreator()
     with pytest.raises(ValueError):
         order = creator.create_order(source)
 
@@ -142,9 +137,8 @@ def test_order_source_parentage(rf, admin_user):
         base_unit_price=source.create_price(5),
         parent_line_id="parent"
     )
-    request = apply_request_middleware(rf.get("/"))
 
-    creator = OrderCreator(request)
+    creator = OrderCreator()
     order = Order.objects.get(pk=creator.create_order(source).pk)
     kid_line = order.lines.filter(sku="KIDKIDKID").first()
     assert kid_line

--- a/shoop_tests/core/test_product_packages.py
+++ b/shoop_tests/core/test_product_packages.py
@@ -7,7 +7,6 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 import six
-from django.test import RequestFactory
 
 from shoop.core.models import (
     AnonymousContact, OrderLineType, ProductMode, Shop
@@ -17,7 +16,6 @@ from shoop.testing.factories import (
     create_product, get_default_shop, get_default_supplier,
     get_initial_order_status
 )
-from shoop.testing.utils import apply_request_middleware
 from shoop_tests.utils.basketish_order_source import BasketishOrderSource
 
 
@@ -51,9 +49,7 @@ def test_package():
 
     source.status = get_initial_order_status()
 
-    request = apply_request_middleware(RequestFactory().get("/"))
-
-    creator = OrderCreator(request)
+    creator = OrderCreator()
     order = creator.create_order(source)
     pids_to_quantities = order.get_product_ids_and_quantities()
     for child, quantity in six.iteritems(package_def):


### PR DESCRIPTION
* Move order_creator_finished signal from front to
  core.order_creator.signals
* Admin: Make all enabled shipping and payment methods available in
  order creation
* OrderCreator: Make request argument optional
  *  Remove request from OrderCreator init calls
  * Admin: Order creating: Populate Order.ip_address
* factories: Depend less on request
* Ensure pricing context gets shop and customer

First two of those commits are from @tulimaki (I only fixed the Refs format and rephrased change log item from "Enable all methods for order creator" to "Make all enabled shipping and payment methods available in order creator". The rest commits are related clean-ups/refactoring that we should do while moving the signal, since they fix a long standing TODO item and improves OrderCreator by making it request independent.

Replaces PR #351