### PR TITLE
Couple tiny improvements for default ContactGroups (SHOOP-2141)

### DIFF
--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -22,8 +22,8 @@ class ShoopModel(models.Model):
     identifier_attr = 'identifier'
 
     def __repr__(self):
-        if hasattr(self, self.identifier_attr):
-            identifier = getattr(self, self.identifier_attr) or ''
+        identifier = getattr(self, self.identifier_attr, None)
+        if identifier:
             identifier_suf = '-{}'.format(text.force_ascii(identifier))
         else:
             identifier_suf = ''

--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -40,7 +40,8 @@ class TranslatableShoopModel(ShoopModel, parler.models.TranslatableModel):
     def __str__(self):
         name = self.safe_translation_getter(self.name_attr, any_language=True)
         if name is None:
-            return '{}:{}'.format(type(self).__name__, self.pk)
+            identifier = getattr(self, self.identifier_attr, None)
+            return '{}:{}'.format(type(self).__name__, identifier)
         return force_text(name)  # ensure no lazy objects are returned
 
     class Meta:

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -100,22 +100,25 @@ class Contact(NameMixin, PolymorphicModel):
         add_to_default_group = bool(self.pk is None and self.default_contact_group_identifier)
         super(Contact, self).save(*args, **kwargs)
         if add_to_default_group:
-            self.groups.add(self.get_default_contact_group())
+            self.groups.add(self.get_default_group())
 
-    def get_default_contact_group(self):
+    @classmethod
+    def get_default_group(cls):
         """
-        Get or create default ``ContactGroup`` based on
-        `self.default_contact_group_identifier`.
+        Get or create default contact group for the class.
 
-        Name for new groups is set based on
-        `self.default_contact_group_name`.
+        Identifier of the group is specified by the class property
+        `default_contact_group_identifier`.
+
+        If new group is created, its name is set to value of
+        `default_contact_group_name` class property.
 
         :rtype: core.models.ContactGroup
         """
         obj, created = ContactGroup.objects.get_or_create(
-            identifier=self.default_contact_group_identifier,
+            identifier=cls.default_contact_group_identifier,
             defaults={
-                "name": self.default_contact_group_name
+                "name": cls.default_contact_group_name
             }
         )
         return obj
@@ -223,7 +226,7 @@ class AnonymousContact(Contact):
 
         :rtype: django.db.QuerySet
         """
-        self.get_default_contact_group()  # Make sure default anonymous contact group is created
+        self.get_default_group()  # Make sure group exists
         return ContactGroup.objects.filter(identifier=self.default_contact_group_identifier)
 
 

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -18,13 +18,11 @@ from timezone_field.fields import TimeZoneField
 
 from shoop.core.fields import InternalIdentifierField, LanguageField
 from shoop.core.utils.name_mixin import NameMixin
-from shoop.utils.text import force_text
 
 from ._base import TranslatableShoopModel
 from ._taxes import CustomerTaxGroup
 
 
-@python_2_unicode_compatible
 class ContactGroup(TranslatableShoopModel):
     identifier = InternalIdentifierField(unique=True)
     members = models.ManyToManyField("Contact", related_name="groups", verbose_name=_('members'), blank=True)
@@ -37,9 +35,6 @@ class ContactGroup(TranslatableShoopModel):
     class Meta:
         verbose_name = _('contact group')
         verbose_name_plural = _('contact groups')
-
-    def __str__(self):
-        return force_text(self.safe_translation_getter("name", default="Group<%s>" % (self.identifier or self.id)))
 
 
 @python_2_unicode_compatible

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -107,7 +107,7 @@ def test_person_contact_creating_from_user(regular_user):
 
 def test_contact_group_repr_and_str_no_identifier_no_name():
     cg = ContactGroup()
-    assert repr(cg) == '<ContactGroup:None->'
+    assert repr(cg) == '<ContactGroup:None>'
     assert str(cg) == 'Group<None>'
 
 
@@ -119,7 +119,7 @@ def test_contact_group_repr_and_str_has_identifier_no_name():
 
 def test_contact_group_repr_and_str_no_identifier_has_name():
     cg = ContactGroup(name='world')
-    assert repr(cg) == '<ContactGroup:None->'
+    assert repr(cg) == '<ContactGroup:None>'
     assert str(cg) == 'world'
 
 

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -108,13 +108,13 @@ def test_person_contact_creating_from_user(regular_user):
 def test_contact_group_repr_and_str_no_identifier_no_name():
     cg = ContactGroup()
     assert repr(cg) == '<ContactGroup:None>'
-    assert str(cg) == 'Group<None>'
+    assert str(cg) == 'ContactGroup:None'
 
 
 def test_contact_group_repr_and_str_has_identifier_no_name():
     cg = ContactGroup(identifier='hello')
     assert repr(cg) == '<ContactGroup:None-hello>'
-    assert str(cg) == 'Group<hello>'
+    assert str(cg) == 'ContactGroup:hello'
 
 
 def test_contact_group_repr_and_str_no_identifier_has_name():

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -12,7 +12,8 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import QuerySet
 
 from shoop.core.models import (
-    AnonymousContact, get_person_contact, PersonContact
+    AnonymousContact, CompanyContact, ContactGroup, get_person_contact,
+    PersonContact
 )
 from shoop_tests.utils.fixtures import regular_user
 
@@ -102,3 +103,48 @@ def test_person_contact_creating_from_user(regular_user):
     assert person.is_active == user.is_active
     assert person.name == user.get_full_name()
     assert person.email == user.email
+
+
+def test_contact_group_repr_and_str_no_identifier_no_name():
+    cg = ContactGroup()
+    assert repr(cg) == '<ContactGroup:None->'
+    assert str(cg) == 'Group<None>'
+
+
+def test_contact_group_repr_and_str_has_identifier_no_name():
+    cg = ContactGroup(identifier='hello')
+    assert repr(cg) == '<ContactGroup:None-hello>'
+    assert str(cg) == 'Group<hello>'
+
+
+def test_contact_group_repr_and_str_no_identifier_has_name():
+    cg = ContactGroup(name='world')
+    assert repr(cg) == '<ContactGroup:None->'
+    assert str(cg) == 'world'
+
+
+def test_contact_group_repr_and_str_has_identifier_has_name():
+    cg = ContactGroup(identifier='hello', name='world')
+    assert repr(cg) == '<ContactGroup:None-hello>'
+    assert str(cg) == 'world'
+
+
+@pytest.mark.django_db
+def test_default_anonymous_contact_group_repr_and_str():
+    adg = AnonymousContact.get_default_group()
+    assert repr(adg) == '<ContactGroup:%d-default_anonymous_group>' % adg.pk
+    assert str(adg) == 'Anonymous Contacts'
+
+
+@pytest.mark.django_db
+def test_default_company_contact_group_repr_and_str():
+    cdg = CompanyContact.get_default_group()
+    assert repr(cdg) == '<ContactGroup:%d-default_company_group>' % cdg.pk
+    assert str(cdg) == 'Company Contacts'
+
+
+@pytest.mark.django_db
+def test_default_person_contact_group_repr_and_str():
+    pdg = PersonContact.get_default_group()
+    assert repr(pdg) == '<ContactGroup:%d-default_person_group>' % pdg.pk
+    assert str(pdg) == 'Person Contacts'

--- a/shoop_tests/core/test_customers.py
+++ b/shoop_tests/core/test_customers.py
@@ -73,7 +73,7 @@ def test_default_groups(contact_cls, create_contact):
     assert new_contact.groups.count() == 1
     default_group = new_contact.groups.first()
     assert type(CustomerTaxGroup.get_default_company_group().__str__()) == str
-    assert default_group == new_contact.get_default_contact_group()
+    assert default_group == new_contact.get_default_group()
     assert default_group.identifier == contact_cls.default_contact_group_identifier
 
     some_other_contact = create_contact()


### PR DESCRIPTION
Fix couple things that popped into my mind while reviewing PR #358:

 * We shouldn't really define `__str__` for any of our models unless
   there is a very good reason, but rather make the version in
   TranslatableShoopModel work for most of the cases.
 * Rename `Contact.get_default_contact_group` to
   `Contact.get_default_group` and make it classmethod.
 * Add tests for ContactGroup str and repr.