### PR TITLE
admin: Fix generated_resources.txt

### DIFF
--- a/shoop/admin/generated_resources.txt
+++ b/shoop/admin/generated_resources.txt
@@ -6,6 +6,8 @@ static/shoop_admin/css/media-browser.css
 static/shoop_admin/css/media-browser.css.map
 static/shoop_admin/js/base.js
 static/shoop_admin/js/base.js.map
+static/shoop_admin/js/contact-group.js
+static/shoop_admin/js/contact-group.js.map
 static/shoop_admin/js/dashboard.js
 static/shoop_admin/js/dashboard.js.map
 static/shoop_admin/js/media-browser.js
@@ -14,10 +16,10 @@ static/shoop_admin/js/order-creator.js
 static/shoop_admin/js/order-creator.js.map
 static/shoop_admin/js/picotable.js
 static/shoop_admin/js/picotable.js.map
-static/shoop_admin/js/product-variation-variable-editor.js
-static/shoop_admin/js/product-variation-variable-editor.js.map
 static/shoop_admin/js/product.js
 static/shoop_admin/js/product.js.map
+static/shoop_admin/js/product-variation-variable-editor.js
+static/shoop_admin/js/product-variation-variable-editor.js.map
 static/shoop_admin/js/remarkable.js
 static/shoop_admin/js/remarkable.js.map
 static/shoop_admin/js/vendor.js


### PR DESCRIPTION
In commit e657ce669 some new resources were added for
gulp (i.e. `contact-group.js*`), but they were not added to
generated_resources.txt. This causes the build cache to not function
properly, since it does not know which of the files are source files and
which are generated.  Add the missing resources to the
`generated_resources.txt` file (and sort it).

Refs SHOOP-1981