### PR TITLE
Extra shop form part and marketing permission (SHOOP-2172, SHOOP-2175)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -41,6 +41,7 @@ Localization
 Admin
 ~~~~~
 
+- Add option to add extra form parts to Shop edit view
 - Make all enabled shipping and payment methods available in order creator
 - Check product quantities in order creation
 - Add option to add action buttons to Order edit view

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Set customer marketing permission while creating order
 - Allow storing price display options to contact groups
 - Add template tags for rendering prices with context specific price
   display options (pretax or with taxes, or hide prices totally)

--- a/doc/provides.rst
+++ b/doc/provides.rst
@@ -65,6 +65,9 @@ Core
     Additional ``FormPart`` classes for Product editing.
     (This is used by pricing modules, for instance.)
 
+``admin_shop_form_part``
+    Additional ``FormPart`` classes for Shop editing.
+
 ``admin_module``
     Admin module classes. Practically all of the functionality in the admin is built
     via admin modules.

--- a/shoop/admin/modules/shops/views/edit.py
+++ b/shoop/admin/modules/shops/views/edit.py
@@ -92,6 +92,7 @@ class ShopEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView):
     template_name = "shoop/admin/shops/edit.jinja"
     context_object_name = "shop"
     base_form_part_classes = [ShopBaseFormPart, ContactAddressFormPart]
+    form_part_class_provide_key = "admin_shop_form_part"
 
     def get_object(self, queryset=None):
         obj = super(ShopEditView, self).get_object(queryset)

--- a/shoop/core/order_creator/_creator.py
+++ b/shoop/core/order_creator/_creator.py
@@ -214,6 +214,10 @@ class OrderCreator(object):
         order.cache_prices()
         order.save()
 
+        if order.customer and order.customer.marketing_permission != order.marketing_permission:
+            order.customer.marketing_permission = order.marketing_permission
+            order.customer.save(update_fields=["marketing_permission"])
+
         self._assign_code_usages(order_source, order)
 
         order_creator_finished.send(


### PR DESCRIPTION
Admin: Enable extra form parts for Shops
Core: Change customer marketing permission while creating order

Refs SHOOP-787 / SHOOP-2172 / SHOOP-2175