### PR TITLE
Classic Gray: Add social media xtheme plugin

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,7 @@ Classic Gray Theme
 - Show error messages while adding products to basket
 - Add Coupon use possibility to basket page
 - Add option to only show orderable products to highlights plugin
+- Add Xtheme plugin to display social media links on shop front
 
 Simple Supplier
 ~~~~~~~~~~~~~~~

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/social-media-links.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/social-media-links.less
@@ -1,0 +1,12 @@
+.social-media-links ul {
+    padding-left: 0;
+
+    li {
+        display: inline;
+        list-style-type: none;
+    }
+
+    li + li {
+        margin-left: 10px;
+    }
+}

--- a/shoop/themes/classic_gray/static_src/less/style.less
+++ b/shoop/themes/classic_gray/static_src/less/style.less
@@ -77,3 +77,4 @@
 @import "classic-gray/loader.less";
 @import "classic-gray/user-account.less";
 @import "classic-gray/carousel.less";
+@import "classic-gray/social-media-links.less";

--- a/shoop/xtheme/__init__.py
+++ b/shoop/xtheme/__init__.py
@@ -33,6 +33,7 @@ class XThemeAppConfig(AppConfig):
         "xtheme_plugin": [
             "shoop.xtheme.plugins.text:TextPlugin",
             "shoop.xtheme.plugins.snippets:SnippetsPlugin",
+            "shoop.xtheme.plugins.social_media_links:SocialMediaLinksPlugin",
         ],
         "admin_module": [
             "shoop.xtheme.admin_module:XthemeAdminModule"

--- a/shoop/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shoop/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-03-22 17:46+0000\n"
+"POT-Creation-Date: 2016-03-22 22:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -78,6 +78,21 @@ msgid "Resource snippet for beginning of body"
 msgstr ""
 
 msgid "Resource for end of body"
+msgstr ""
+
+msgid "Social Media Links"
+msgstr ""
+
+msgid "Topic"
+msgstr ""
+
+msgid "Title"
+msgstr ""
+
+msgid "Icon Size"
+msgstr ""
+
+msgid "Alignment"
 msgstr ""
 
 msgid "text"

--- a/shoop/xtheme/plugins/social_media_links.py
+++ b/shoop/xtheme/plugins/social_media_links.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import re
+from collections import defaultdict
+
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.xtheme import TemplatedPlugin
+from shoop.xtheme.plugins.forms import GenericPluginForm, TranslatableField
+
+
+class SocialMediaLinksPluginForm(GenericPluginForm):
+    """
+    Form for the social media links xtheme plugin. One field is provided for each
+    entry in the plugin's icon_classes attribute, which maps social media site names
+    to font-awesome icon classes by default.
+    """
+    def populate(self):
+        """
+        Populates form with default plugin fields as well as any social media link type
+        included in the plugin's ``icon_classes`` attribute.
+
+        Also adds an ordering field for each link type to change display order.
+        """
+        icon_classes = self.plugin.icon_classes
+        links = self.plugin.config.get("links", {})
+        for name, icon_class in sorted(icon_classes.items()):
+            url = links[name]["url"] if name in links else ""
+            ordering = links[name]["ordering"] if name in links else None
+            self.fields[name] = forms.URLField(
+                label=name, required=False,
+                widget=forms.TextInput(attrs={"placeholder": "URL"}),
+                initial=url)
+            self.fields["%s-ordering" % name] = forms.IntegerField(
+                label="", required=False, min_value=0, max_value=len(icon_classes)*2,
+                initial=ordering, widget=forms.NumberInput(attrs={"placeholder": "Ordering"}))
+        super(SocialMediaLinksPluginForm, self).populate()
+
+    def clean(self):
+        """
+        Returns cleaned data from default plugin fields and any link fields.
+
+        Processed link configuration information is stored and returned as a dictionary
+        (``links``).
+        """
+        links_dict = defaultdict(dict)
+        cleaned_data = {}
+        precleaned_data = super(SocialMediaLinksPluginForm, self).clean()
+        plugin_fields = [field for (field, value) in self.plugin.fields]
+        for field in plugin_fields:
+            cleaned_data[field] = precleaned_data.pop(field)
+        for link_info in precleaned_data:
+            link_name = re.sub("-ordering", "", link_info)
+            if not link_info.endswith("-ordering"):
+                links_dict[link_name]["url"] = precleaned_data[link_info]
+            else:
+                links_dict[link_name]["ordering"] = precleaned_data[link_info]
+        cleaned_data["links"] = {k: v for (k, v) in links_dict.items() if v["url"]}
+        return cleaned_data
+
+
+class SocialMediaLinksPlugin(TemplatedPlugin):
+    """
+    An xtheme plugin for displaying site links to common social media sites.
+    """
+    identifier = "social_media_links"
+    name = _("Social Media Links")
+    template_name = "shoop/xtheme/plugins/social_media_links.jinja"
+    editor_form_class = SocialMediaLinksPluginForm
+    fields = [
+        ("topic", TranslatableField(label=_("Topic"), required=False, initial="")),
+        ("text", TranslatableField(label=_("Title"), required=False, initial="")),
+        ("icon_size", forms.ChoiceField(label=_("Icon Size"), required=False, choices=[
+            ("", "Default"),
+            ("lg", "Large"),
+            ("2x", "2x"),
+            ("3x", "3x"),
+            ("4x", "4x"),
+            ("5x", "5x"),
+        ], initial="")),
+        ("alignment", forms.ChoiceField(label=_("Alignment"), required=False, choices=[
+            ("", "Default"),
+            ("left", "Left"),
+            ("center", "Center"),
+            ("right", "Right"),
+        ], initial="")),
+    ]
+
+    icon_classes = {
+        "Facebook": "facebook-square",
+        "Flickr": "flickr",
+        "Google Plus": "google-plus-square",
+        "Instagram": "instagram",
+        "Linkedin": "linkedin-square",
+        "Pinterest": "pinterest",
+        "Tumbler": "tumblr",
+        "Twitter": "twitter",
+        "Vimeo": "vimeo",
+        "Vine": "vine",
+        "Yelp": "yelp",
+        "Youtube": "youtube",
+    }
+
+    def get_context_data(self, context):
+        """
+        Returns plugin settings and a sorted list of social media links
+
+        :return: Plugin context data
+        :rtype: dict
+        """
+        links = self.get_links()
+
+        return {
+            "links": links,
+            "request": context["request"],
+            "topic": self.get_translated_value("topic"),
+            "text": self.get_translated_value("text"),
+            "icon_size": self.config.get("icon_size", ""),
+            "alignment": self.config.get("alignment", ""),
+        }
+
+    def get_links(self):
+        """
+        Returns the list of social media links sorted according to ordering
+
+        :return: List of link tuples (ordering, icon class, url)
+        :rtype: [(int, str, str)]
+        """
+        links = self.config.get("links", {})
+
+        return sorted([
+            (v["ordering"] or 0, self.icon_classes[k], v["url"])
+            for (k, v)
+            in links.items()
+        ])

--- a/shoop/xtheme/templates/shoop/xtheme/plugins/social_media_links.jinja
+++ b/shoop/xtheme/templates/shoop/xtheme/plugins/social_media_links.jinja
@@ -1,0 +1,13 @@
+{% if links %}
+<section class="social-media-links">
+    <div class="row{% if alignment %} text-{{ alignment }}{% endif %}">
+        {% if topic %}<h2>{{ topic }}</h2>{% endif %}
+        {% if text %}<p>{{ text }}</p>{% endif %}
+        <ul>
+            {% for ordering, class, url in links %}
+                <li><a href="{{ url }}"><i class="fa fa-{{ class }}{% if icon_size %} fa-{{ icon_size }}{% endif %}"></i></a></li>
+            {% endfor %}
+        </ul>
+    </div>
+</section>
+{% endif %}

--- a/shoop_tests/xtheme/test_plugins.py
+++ b/shoop_tests/xtheme/test_plugins.py
@@ -5,8 +5,12 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import pytest
+
 from shoop.xtheme import resources
 from shoop.xtheme.plugins.snippets import SnippetsPlugin
+from shoop.xtheme.plugins.social_media_links import SocialMediaLinksPlugin
+from shoop_tests.front.fixtures import get_jinja_context
 
 
 def test_snippets_plugin():
@@ -29,3 +33,33 @@ def test_snippets_plugin():
     resource_dict = context[resources_name].resources
     for location, snippet in config.items():
         assert snippet == resource_dict[location][0]
+
+
+@pytest.mark.django_db
+def test_social_media_plugin_ordering():
+    """
+    Test that social media plugin ordering works as expected
+    """
+    context = get_jinja_context()
+    icon_classes = SocialMediaLinksPlugin.icon_classes
+    link_1_type = "Facebook"
+    link_1 = {
+        "url": "http://www.facebook.com",
+        "ordering": 2,
+    }
+
+    link_2_type = "Twitter"
+    link_2 = {
+        "url": "http://www.twitter.com",
+        "ordering": 1,
+    }
+
+    links = {
+        link_1_type: link_1,
+        link_2_type: link_2,
+    }
+    plugin = SocialMediaLinksPlugin({"links": links})
+    assert len(plugin.get_links()) == 2
+
+    # Make sure link 2 comes first
+    assert plugin.get_links()[0][2] == link_2["url"]


### PR DESCRIPTION
Add an xtheme plugin in classic_gray to display social media links on the
shop front.

This is a refactor of PR #375.

Refs SHOOP-1972