### PR TITLE
Xtheme: Add generic snippets plugin for simple integrations

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -56,6 +56,7 @@ Front
 Xtheme
 ~~~~~~
 
+- Add generic snippets plugin for doing simple integrations
 
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~

--- a/shoop/xtheme/__init__.py
+++ b/shoop/xtheme/__init__.py
@@ -31,7 +31,8 @@ class XThemeAppConfig(AppConfig):
     provides = {
         "front_urls_pre": [__name__ + ".urls:urlpatterns"],
         "xtheme_plugin": [
-            "shoop.xtheme.plugins.text:TextPlugin"
+            "shoop.xtheme.plugins.text:TextPlugin",
+            "shoop.xtheme.plugins.snippets:SnippetsPlugin",
         ],
         "admin_module": [
             "shoop.xtheme.admin_module:XthemeAdminModule"

--- a/shoop/xtheme/locale/en/LC_MESSAGES/django.po
+++ b/shoop/xtheme/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-28 00:12+0000\n"
+"POT-Creation-Date: 2016-03-22 17:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -63,6 +63,21 @@ msgid "Theme configuration for %s"
 msgstr ""
 
 msgid "Plugin"
+msgstr ""
+
+msgid "Snippets"
+msgstr ""
+
+msgid "In-Place Snippet"
+msgstr ""
+
+msgid "Resource snippet for end of head"
+msgstr ""
+
+msgid "Resource snippet for beginning of body"
+msgstr ""
+
+msgid "Resource for end of body"
 msgstr ""
 
 msgid "text"

--- a/shoop/xtheme/plugins/snippets.py
+++ b/shoop/xtheme/plugins/snippets.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2015, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django import forms
+from django.utils.translation import ugettext_lazy as _
+
+from shoop.xtheme import Plugin, resources
+from shoop.xtheme.resources import add_resource, InlineMarkupResource
+
+
+class SnippetsPlugin(Plugin):
+    """
+    Simple plugin class for including snippets and resources on the page, mostly for simple integrations.
+    """
+    identifier = "snippets"
+    name = _("Snippets")
+    fields = [
+        ("in_place", forms.CharField(label=_("In-Place Snippet"), widget=forms.Textarea, required=False)),
+        ("head_end", forms.CharField(label=_("Resource snippet for end of head"), widget=forms.Textarea,
+                                     required=False)),
+        ("body_start", forms.CharField(label=_("Resource snippet for beginning of body"), widget=forms.Textarea,
+                                       required=False)),
+        ("body_end", forms.CharField(label=_("Resource for end of body"), widget=forms.Textarea, required=False)),
+    ]
+
+    def render(self, context):
+        for location, __ in self.fields:
+            if location in resources.KNOWN_LOCATIONS:
+                resource = self.config.get(location, "")
+                add_resource(context, location, InlineMarkupResource(resource))
+        return self.config.get("in_place", "")

--- a/shoop_tests/xtheme/test_plugins.py
+++ b/shoop_tests/xtheme/test_plugins.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from shoop.xtheme import resources
+from shoop.xtheme.plugins.snippets import SnippetsPlugin
+
+
+def test_snippets_plugin():
+    resources_name = resources.RESOURCE_CONTAINER_VAR_NAME
+    context = {
+        resources_name: resources.ResourceContainer(),
+    }
+    config = {
+        "in_place": "This is in place",
+        "head_end": "This the head end",
+        "body_start": "This is the body start",
+        "body_end": "This is the body end",
+    }
+    plugin = SnippetsPlugin(config)
+    rendered = plugin.render(context)
+    # Make sure that plugin properly rendered in-place stuff
+    assert config.pop("in_place") == rendered
+
+    # Make sure all of the resources were added to context
+    resource_dict = context[resources_name].resources
+    for location, snippet in config.items():
+        assert snippet == resource_dict[location][0]


### PR DESCRIPTION
Add a generic simple snippets plugin for doing simple integrations that
primarily require adding JavaScript or CSS resources to the page.

This is related to the PR #379, which is a refactor of PR #375.

Refs SHOOP-1972