### PR TITLE
Define price display options in ContactGroup admin (SHOOP-2143)

### DIFF
--- a/shoop/admin/modules/contact_groups/views/edit.py
+++ b/shoop/admin/modules/contact_groups/views/edit.py
@@ -13,15 +13,8 @@ from django.db.transaction import atomic
 from shoop.admin.form_part import FormPartsViewMixin, SaveFormPartsMixin
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.core.models import ContactGroup
-from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
 
 from .forms import ContactGroupBaseFormPart, ContactGroupMembersFormPart
-
-
-class ContactGroupForm(MultiLanguageModelForm):
-    class Meta:
-        model = ContactGroup
-        fields = ("name",)
 
 
 class ContactGroupEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView):

--- a/shoop/admin/modules/contact_groups/views/forms.py
+++ b/shoop/admin/modules/contact_groups/views/forms.py
@@ -26,7 +26,7 @@ from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
 class ContactGroupBaseForm(MultiLanguageModelForm):
     class Meta:
         model = ContactGroup
-        fields = ("name",)
+        fields = ("name", "show_prices_including_taxes", "hide_prices")
 
 
 class ContactGroupBaseFormPart(FormPart):

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -136,7 +136,7 @@ class Contact(NameMixin, PolymorphicModel):
         groups_with_options = self.groups.with_price_display_options()
         if groups_with_options:
             default_group = self.get_default_group()
-            if groups_with_options.filter(pk=default_group).exists():
+            if groups_with_options.filter(pk=default_group.pk).exists():
                 group_with_options = default_group
             else:
                 # Contact was removed from the default group.

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -186,3 +186,23 @@ def test_contact_group_price_display_options_defined(taxes, hide_prices):
     assert options.include_taxes is taxes
     assert options.hide_prices is bool(hide_prices)
     assert options.show_prices is bool(not hide_prices)
+
+
+@pytest.mark.django_db
+def test_contact_group_price_display_for_contact(regular_user):
+    group = ContactGroup.objects.create(hide_prices=True)
+    person = get_person_contact(regular_user)
+    person.groups.add(group)
+
+    options = person.get_price_display_options()
+    assert options.hide_prices
+    assert options.include_taxes is None
+
+    default_group_for_person = person.get_default_group()
+    default_group_for_person.show_prices_including_taxes = True
+    default_group_for_person.save()
+
+    # Now since default group has pricing options set these should be returned
+    default_options = person.get_price_display_options()
+    assert default_options.include_taxes
+    assert not default_options.hide_prices


### PR DESCRIPTION
Core: Fix ``get_price_display_options`` for ``Contact``
Admin: Define price display options for ``ContactGroup``

Refs SHOOP-1981 / SHOOP-2143