### PR TITLE
Always return non-None for OrderSource contacts (SHOOP-2246)

### DIFF
--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -9,6 +9,7 @@ from __future__ import unicode_literals
 
 from collections import Counter
 
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from django.utils.encoding import force_text
 from django.utils.timezone import now
@@ -17,8 +18,8 @@ from six import iteritems
 
 from shoop.core import taxing
 from shoop.core.models import (
-    OrderStatus, PaymentMethod, Product, ShippingMethod, Shop, Supplier,
-    TaxClass
+    AnonymousContact, OrderStatus, PaymentMethod, Product, ShippingMethod,
+    Shop, Supplier, TaxClass
 )
 from shoop.core.pricing import Price, Priceful, TaxfulPrice, TaxlessPrice
 from shoop.core.taxing import should_calculate_taxes_automatically, TaxableItem
@@ -109,9 +110,9 @@ class OrderSource(object):
         self.display_currency_rate = 1
         self.shipping_address = None
         self.billing_address = None
-        self.customer = None
-        self.orderer = None
-        self.creator = None
+        self._customer = None
+        self._orderer = None
+        self._creator = None
         self.shipping_method_id = None
         self.payment_method_id = None
         self.customer_comment = u""
@@ -180,6 +181,30 @@ class OrderSource(object):
     taxless_total_discount_or_none = taxless_total_discount.or_none
 
     total_price_of_products = _PriceSum("price", "get_product_lines")
+
+    @property
+    def customer(self):
+        return (self._customer or AnonymousContact())
+
+    @customer.setter
+    def customer(self, value):
+        self._customer = value
+
+    @property
+    def orderer(self):
+        return (self._orderer or AnonymousContact())
+
+    @orderer.setter
+    def orderer(self, value):
+        self._orderer = value
+
+    @property
+    def creator(self):
+        return (self._creator or AnonymousUser())
+
+    @creator.setter
+    def creator(self, value):
+        self._creator = value
 
     @property
     def shipping_method(self):

--- a/shoop_tests/campaigns/test_basket_contact_conditions.py
+++ b/shoop_tests/campaigns/test_basket_contact_conditions.py
@@ -12,7 +12,7 @@ from shoop.campaigns.models.campaigns import BasketCampaign
 from shoop.campaigns.models.basket_conditions import (
     ContactBasketCondition, ContactGroupBasketCondition
 )
-from shoop.core.models import AnonymousContact
+from shoop.core.models import AnonymousContact, Shop
 from shoop.front.basket import get_basket
 from shoop.testing.factories import (
     create_product, create_random_person, get_default_customer_group,
@@ -99,6 +99,16 @@ def test_group_basket_condition_with_anonymous_contact(rf):
 
     assert isinstance(basket.customer, AnonymousContact)
     assert_discounted_basket(basket, original_line_count, original_price, campaign_discount_value)
+
+
+@pytest.mark.django_db
+def test_contact_group_basket_condition_with_none(rf):
+    request = rf.get("/")
+    request.shop = Shop()
+    basket = get_basket(request)
+    condition = ContactGroupBasketCondition.objects.create()
+    result = condition.matches(basket)  # Should not raise any errors
+    assert result is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The customer, orderer and creator properties of OrderSource (or its
subclass BaseBasket) are used quite carelessly in some places, e.g. in
ContactGroupBasketCondition.matches.  Previously these properties could
have been None and then code like `basket.customer.groups.all()` would
fail to AttributeError.

Make OrderSource always return non-None objects for those three
attributes to fix ContactGroupBasketCondition.matches and possibly other
similar issues.

Add a test case for the issue in ContactGroupBasketCondition.matches.

Refs SHOOP-1981/SHOOP-2246