### PR TITLE
Admin: Improve configuring price display mode (SHOOP-2269)

### DIFF
--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-29 18:45+0000\n"
+"POT-Creation-Date: 2016-03-24 10:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -26,6 +26,9 @@ msgid "Browse"
 msgstr ""
 
 msgid "Clear"
+msgstr ""
+
+msgid "Select"
 msgstr ""
 
 msgid "Attributes"
@@ -75,6 +78,39 @@ msgstr ""
 
 msgid "Contacts"
 msgstr ""
+
+msgid "Price display mode"
+msgstr ""
+
+msgid "unspecified"
+msgstr ""
+
+msgid "show prices with taxes included"
+msgstr ""
+
+msgid "show pre-tax prices"
+msgstr ""
+
+msgid "hide prices"
+msgstr ""
+
+msgid "member"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
+
+#, python-format
+msgid "%(count)s member added"
+msgid_plural "%(count)s members added"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "%(count)s member removed"
+msgid_plural "%(count)s members removed"
+msgstr[0] ""
+msgstr[1] ""
 
 msgid "Number of Members"
 msgstr ""
@@ -794,7 +830,7 @@ msgstr ""
 msgid "Members"
 msgstr ""
 
-msgid "No members."
+msgid "Add more"
 msgstr ""
 
 msgid "Addresses"
@@ -1049,6 +1085,9 @@ msgid "Shop Logo"
 msgstr ""
 
 msgid "Maintenance Mode"
+msgstr ""
+
+msgid "Contact Address"
 msgstr ""
 
 msgid "About Shoop Telemetry"

--- a/shoop/admin/locale/fi_FI/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/fi_FI/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Shoop\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-01-21 07:22+0000\n"
+"POT-Creation-Date: 2016-03-24 10:45+0000\n"
 "PO-Revision-Date: 2016-01-05 06:44+0000\n"
 "Last-Translator: Shoop Admin <admin@shoop.io>\n"
 "Language-Team: Finnish (Finland) (http://www.transifex.com/shoop/shoop/"
@@ -39,6 +39,9 @@ msgstr "Selaa"
 
 msgid "Clear"
 msgstr "Tyhjennä"
+
+msgid "Select"
+msgstr ""
 
 msgid "Attributes"
 msgstr "Attribuutit"
@@ -88,6 +91,43 @@ msgstr "Kontaktiryhmät"
 msgid "Contacts"
 msgstr "Kontaktit"
 
+msgid "Price display mode"
+msgstr "Hintojen näyttämistapa"
+
+msgid "unspecified"
+msgstr "määrittelemätön"
+
+msgid "show prices with taxes included"
+msgstr "näytä verolliset hinnat"
+
+msgid "show pre-tax prices"
+msgstr "näytä verottomat hinnat"
+
+msgid "hide prices"
+msgstr "piilota hinnat"
+
+#, fuzzy
+#| msgid "Members"
+msgid "member"
+msgstr "Jäsenet"
+
+#, fuzzy
+#| msgid "Removed: %d"
+msgid "Remove"
+msgstr "Poistettu: %d"
+
+#, python-format
+msgid "%(count)s member added"
+msgid_plural "%(count)s members added"
+msgstr[0] ""
+msgstr[1] ""
+
+#, python-format
+msgid "%(count)s member removed"
+msgid_plural "%(count)s members removed"
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Number of Members"
 msgstr "Jäsenien määrä"
 
@@ -131,6 +171,10 @@ msgstr "Henkilö"
 
 msgid "Company"
 msgstr "Yritys"
+
+#, python-format
+msgid "User %(bind_user)s already has a contact"
+msgstr ""
 
 msgid "Email"
 msgstr "Sähköposti"
@@ -234,6 +278,10 @@ msgstr "Muokkaa %(model)s"
 #, python-format
 msgid "Default %s module"
 msgstr "Oletus%smoduuli"
+
+#, python-format
+msgid "Module %(name)s has no admin detail view"
+msgstr ""
 
 msgid "Orders"
 msgstr "Tilaukset"
@@ -573,9 +621,6 @@ msgid ""
 msgstr ""
 "Tätä kenttää ei voi muuttaa, koska tälle kaupalle on olemassa tilauksia."
 
-msgid "Only one shop permitted."
-msgstr "Vain yksi kauppa sallittu"
-
 msgid "Domain"
 msgstr "Verkkotunnus"
 
@@ -795,6 +840,9 @@ msgstr "Kojelauta"
 msgid "Search for"
 msgstr "Etsi"
 
+msgid "Settings"
+msgstr ""
+
 msgid "Hello"
 msgstr "Hei"
 
@@ -813,8 +861,8 @@ msgstr "Yleiset tiedot"
 msgid "Members"
 msgstr "Jäsenet"
 
-msgid "No members."
-msgstr "Ei jäseniä."
+msgid "Add more"
+msgstr ""
 
 msgid "Addresses"
 msgstr "Osoitteet"
@@ -973,14 +1021,11 @@ msgstr "Veroton"
 msgid "Payments"
 msgstr "Maksut"
 
+msgid "Error!"
+msgstr ""
+
 msgid "Additional Details"
 msgstr "Lisätietoja"
-
-msgid "Stock"
-msgstr "Varasto"
-
-msgid "Unstocked"
-msgstr "Varastoimaton"
 
 msgid "Accounting"
 msgstr "Kirjanpito"
@@ -1075,15 +1120,25 @@ msgstr "Kaupan logo"
 msgid "Maintenance Mode"
 msgstr "Huoltotila"
 
+#, fuzzy
+#| msgid "Contacts"
+msgid "Contact Address"
+msgstr "Kontaktit"
+
 msgid "About Shoop Telemetry"
 msgstr "Tietoja Shoopin telemetriasta"
 
 msgid "Shoop will occasionally send telemetry data to a Shoop.io server."
 msgstr "Shoop lähettää aina välillä telemetriadataa shoop.io palvelimelle."
 
+#, fuzzy, python-format
+#| msgid ""
+#| "The data contains an unique installation key, as well as the hostname of "
+#| "the installation (as sent by the visiting browser; currently"
 msgid ""
 "The data contains an unique installation key, as well as the hostname of the "
-"installation (as sent by the visiting browser; currently"
+"installation (as sent by the visiting browser; currently <code>%(host)s</"
+"code>)."
 msgstr ""
 "Tiedot sisältävät uniikin asennusavaimen sekä asennuksen osoitteen (selaimen "
 "lähettämänä; nyt "
@@ -1100,14 +1155,10 @@ msgstr ""
 msgid "Opt-in / opt-out"
 msgstr "Mukanaolo"
 
-msgid "You are currently"
-msgstr "Olet tällä hetkellä"
-
-msgid "opted in"
-msgstr "olet mukana"
-
-msgid "to send telemetry data to Shoop.io."
-msgstr "lähettämässä telemetriadataa Shoop.io-palvelimelle."
+msgid ""
+"You are currently <span class=\"lead label label-success\">opted in</span> "
+"to send telemetry data to Shoop.io."
+msgstr ""
 
 msgid "Thank you for your valuable contribution."
 msgstr "Kiitos arvokkaasta panostuksestasi."
@@ -1115,11 +1166,10 @@ msgstr "Kiitos arvokkaasta panostuksestasi."
 msgid "Opt out"
 msgstr "Jättäydy syrjään"
 
-msgid "opted out"
-msgstr "Jättäydytty syrjään"
-
-msgid "of Shoop telemetry."
-msgstr "Shoopin telemetriasta."
+msgid ""
+"You are currently <span class=\"label label-warning\">opted out</span> of "
+"Shoop telemetry."
+msgstr ""
 
 msgid "Opt in"
 msgstr "Tule mukaan"
@@ -1135,11 +1185,11 @@ msgstr ""
 "vasta 24 tunnin kuluessa asennuksesta jollei lähetystä ole siihen mennessä "
 "kytketty pois päältä."
 
-msgid "Telemetry data was last submitted at"
-msgstr "Telemetriadata on viimeksi toimitettu"
-
-msgid "ago"
-msgstr "sitten"
+#, python-format
+msgid ""
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
+msgstr ""
 
 msgid "See the data that was submitted."
 msgstr "Katso data, joka toimitettiin."
@@ -1228,3 +1278,8 @@ msgstr "Uusi %s"
 #, python-format
 msgid "Unnamed %s"
 msgstr "Nimeämätön %s"
+
+#, fuzzy, python-format
+#| msgid "Only one shop permitted."
+msgid "Only one %(model)s permitted."
+msgstr "Vain yksi kauppa sallittu"

--- a/shoop/admin/modules/contact_groups/views/forms.py
+++ b/shoop/admin/modules/contact_groups/views/forms.py
@@ -26,7 +26,55 @@ from shoop.utils.multilanguage_model_form import MultiLanguageModelForm
 class ContactGroupBaseForm(MultiLanguageModelForm):
     class Meta:
         model = ContactGroup
-        fields = ("name", "show_prices_including_taxes", "hide_prices")
+        fields = ("name",)
+
+    def __init__(self, *args, **kwargs):
+        super(ContactGroupBaseForm, self).__init__(*args, **kwargs)
+        self.fields['price_display_mode'] = forms.ChoiceField(
+            choices=_PRICE_DISPLAY_MODE_CHOICES,
+            label=_("Price display mode"),
+            initial=_get_price_display_mode(self.instance))
+
+    def save(self, commit=True):
+        price_display_mode = self.cleaned_data['price_display_mode']
+        _set_price_display_mode(self.instance, price_display_mode)
+        super(ContactGroupBaseForm, self).save(commit=commit)
+
+
+_PRICE_DISPLAY_MODE_CHOICES = [
+    ('none', _("unspecified")),
+    ('with_taxes', _("show prices with taxes included")),
+    ('without_taxes', _("show pre-tax prices")),
+    ('hide', _("hide prices")),
+]
+
+
+def _get_price_display_mode(contact_group):
+    taxes = contact_group.show_prices_including_taxes
+    hide = contact_group.hide_prices
+    if hide is None and taxes is None:
+        return 'none'
+    elif hide:
+        return 'hide'
+    elif taxes:
+        return 'with_taxes'
+    else:
+        return 'without_taxes'
+
+
+def _set_price_display_mode(contact_group, price_display_mode):
+    if price_display_mode == 'none':
+        contact_group.show_prices_including_taxes = None
+        contact_group.hide_prices = None
+    elif price_display_mode == 'hide':
+        contact_group.show_prices_including_taxes = None
+        contact_group.hide_prices = True
+    elif price_display_mode == 'with_taxes':
+        contact_group.show_prices_including_taxes = True
+        contact_group.hide_prices = None
+    elif price_display_mode == 'without_taxes':
+        contact_group.show_prices_including_taxes = False
+        contact_group.hide_prices = None
 
 
 class ContactGroupBaseFormPart(FormPart):


### PR DESCRIPTION
Since there is currently only four different modes of showing prices,
make the contact group editing form show those as a dropdown rather than
as two dropdowns.  This should be easier for the merchant.

Also update related translation fiels and translate added messages to
Finnish.
