### PR TITLE
Front/Classic Gray: Fix cross sell plugin

### DIFF
--- a/shoop/front/template_helpers/product.py
+++ b/shoop/front/template_helpers/product.py
@@ -50,6 +50,7 @@ def is_visible(context, product):
 
 @contextfunction
 def get_product_cross_sells(context, product, relation_type=ProductCrossSellType.RELATED, count=4, orderable_only=True):
+    relation_type = _relation_type_str_to_enum(relation_type)
     related_product_ids = list((
         ProductCrossSell.objects
         .filter(product1=product, type=relation_type)
@@ -68,3 +69,15 @@ def get_product_cross_sells(context, product, relation_type=ProductCrossSellType
     related_products.sort(key=lambda prod: list(related_product_ids).index(prod.id))
 
     return related_products[:count]
+
+
+def _relation_type_str_to_enum(relation_type):
+    if relation_type == "related":
+        return ProductCrossSellType.RELATED
+    elif relation_type == "recommended":
+        return ProductCrossSellType.RECOMMENDED
+    elif relation_type == "computed":
+        return ProductCrossSellType.COMPUTED
+    elif relation_type == "bought_with":
+        return ProductCrossSellType.BOUGHT_WITH
+    return relation_type

--- a/shoop/themes/classic_gray/plugins.py
+++ b/shoop/themes/classic_gray/plugins.py
@@ -64,7 +64,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
             (ProductCrossSellType.RELATED, "Related"),
             (ProductCrossSellType.RECOMMENDED, "Recommended"),
             (ProductCrossSellType.BOUGHT_WITH, "Bought With"),
-        ], initial="related")),
+        ], initial=ProductCrossSellType.RELATED)),
         ("count", forms.IntegerField(label=_("Count"), min_value=1, initial=4)),
         ("orderable_only", forms.BooleanField(label=_("Only show in-stock and orderable items"),
                                               initial=True,
@@ -75,8 +75,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
         count = self.config.get("count", 4)
         product = context.get("product", None)
         orderable_only = self.config.get("orderable_only", True)
-        type = self.config.get("type", "related")
-
+        type = self.config.get("type", ProductCrossSellType.RELATED)
         return {
             "request": context["request"],
             "title": self.get_translated_value("title"),


### PR DESCRIPTION
* At plugin use ``ProductCrossSellType`` enum instead of strings
* At the product template helper ``get_product_cross_sells`` convert
strings to ``ProductCrossSellType`` if needed.

Refs SHOOP-2245