### PR TITLE
Fix choices of ProductCrossSellsPlugin type field (SHOOP-2305)

### DIFF
--- a/shoop/themes/classic_gray/plugins.py
+++ b/shoop/themes/classic_gray/plugins.py
@@ -8,7 +8,7 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.core.models import ProductCrossSellType
+from shoop.core.models import ProductCrossSell, ProductCrossSellType
 from shoop.front.template_helpers.general import (
     get_best_selling_products, get_newest_products, get_random_products
 )
@@ -60,11 +60,7 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
     required_context_variables = ["product"]
     fields = [
         ("title", TranslatableField(label=_("Title"), required=False, initial="")),
-        ("type", forms.ChoiceField(label=_("Type"), choices=[
-            (ProductCrossSellType.RELATED, "Related"),
-            (ProductCrossSellType.RECOMMENDED, "Recommended"),
-            (ProductCrossSellType.BOUGHT_WITH, "Bought With"),
-        ], initial=ProductCrossSellType.RELATED)),
+        ("type", ProductCrossSell.type.field.formfield()),
         ("count", forms.IntegerField(label=_("Count"), min_value=1, initial=4)),
         ("orderable_only", forms.BooleanField(label=_("Only show in-stock and orderable items"),
                                               initial=True,
@@ -75,7 +71,9 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
         count = self.config.get("count", 4)
         product = context.get("product", None)
         orderable_only = self.config.get("orderable_only", True)
-        type = self.config.get("type", ProductCrossSellType.RELATED)
+        type = self.config.get("type")
+        if not isinstance(type, ProductCrossSellType):
+            type = ProductCrossSellType.RELATED
         return {
             "request": context["request"],
             "title": self.get_translated_value("title"),

--- a/shoop_tests/themes/classic_gray/test_plugins.py
+++ b/shoop_tests/themes/classic_gray/test_plugins.py
@@ -21,7 +21,7 @@ def test_cross_sell_plugin_renders():
     shop = get_default_shop()
     product = create_product("test-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
     computed = create_product("test-computed-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
-    type ="computed"
+    type = ProductCrossSell.type.field.enum.COMPUTED
 
     ProductCrossSell.objects.create(product1=product, product2=computed, type=type)
     assert ProductCrossSell.objects.filter(product1=product, type=type).count() == 1


### PR DESCRIPTION
The type field of ProductCrossSellsPlugin used to use translated string as
field values as choices were given as (enum, string) pairs, where the
enum part was converted to translated string implicitly.  Fix this by
not defining the form field at all, but rather construct the form field
from the model field with `ProductCrossSell.type.field.formfield()`.
This will use the enum values as choice values.

Database may have old translated string values, use RELATED for those.

Also improve error handling of get_product_cross_sells (the second commit).