### PR TITLE
Add first and last name for PersonContact (SHOOP-832)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``first_name`` and ``last_name`` fields to ``PersonContact``
 - Add bought with relation to ``ProductCrossSellType``
 - Set customer marketing permission while creating order
 - Disable delete for default contact groups

--- a/shoop/admin/modules/contacts/views/edit.py
+++ b/shoop/admin/modules/contacts/views/edit.py
@@ -47,11 +47,14 @@ class ContactBaseForm(BaseModelForm):
     FIELDS_BY_MODEL_NAME = {
         "Contact": (
             "is_active", "language", "marketing_permission", "phone", "www",
-            "timezone", "prefix", "name", "suffix", "name_ext", "email",
-            "tax_group",
+            "timezone", "prefix", "suffix", "name_ext", "email", "tax_group",
         ),
-        "PersonContact": ("gender", "birth_date"),
-        "CompanyContact": ("tax_number",)
+        "PersonContact": (
+            "gender", "birth_date", "first_name", "last_name"
+        ),
+        "CompanyContact": (
+            "name", "tax_number",
+        )
     }
 
     def __init__(self, bind_user=None, *args, **kwargs):
@@ -125,9 +128,9 @@ class ContactBaseForm(BaseModelForm):
         obj = super(ContactBaseForm, self).save(commit)
         if self.bind_user and not getattr(obj, "user", None):  # Allow binding only once
             obj.user = self.bind_user
-        obj.groups = self.cleaned_data["groups"]
-        obj.save()
+            obj.save()
 
+        obj.groups = self.cleaned_data["groups"]
         return obj
 
 

--- a/shoop/admin/templates/shoop/admin/contacts/_edit_base_form.jinja
+++ b/shoop/admin/templates/shoop/admin/contacts/_edit_base_form.jinja
@@ -6,6 +6,8 @@
     {{ bs3.field(contact_form.is_active) }}
     {{ bs3.field(contact_form.groups) }}
     {{ bs3.field(contact_form.name) }}
+    {{ bs3.field(contact_form.first_name) }}
+    {{ bs3.field(contact_form.last_name) }}
     {{ bs3.field(contact_form.name_ext) }}
     {{ bs3.field(contact_form.email) }}
     {{ bs3.field(contact_form.phone) }}

--- a/shoop/core/migrations/0001_initial.py
+++ b/shoop/core/migrations/0001_initial.py
@@ -182,7 +182,6 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'contacts',
                 'verbose_name': 'contact',
             },
-            bases=(shoop.core.utils.name_mixin.NameMixin, models.Model),
         ),
         migrations.CreateModel(
             name='ContactGroup',

--- a/shoop/core/migrations/0018_add_first_and_last_name.py
+++ b/shoop/core/migrations/0018_add_first_and_last_name.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def populate_first_and_last_names(apps, schema_editor):
+    person_contact_cls = apps.get_model("shoop", "PersonContact")
+
+    for person in person_contact_cls.objects.all():
+        if person.first_name or person.last_name:
+            continue  # Safety check
+        names = person.name.rsplit(" ", 1)
+        if len(names) < 2:
+            person.first_name = person.name
+            person.last_name = ""
+        else:
+            person.first_name = names[0]
+            person.last_name = names[1]
+        person.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0017_contact_group_price_display_options'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='personcontact',
+            name='first_name',
+            field=models.CharField(max_length=30, verbose_name='first name', blank=True),
+        ),
+        migrations.AddField(
+            model_name='personcontact',
+            name='last_name',
+            field=models.CharField(max_length=50, verbose_name='last name', blank=True),
+        ),
+        migrations.RunPython(populate_first_and_last_names),
+    ]

--- a/shoop/front/apps/customer_information/views.py
+++ b/shoop/front/apps/customer_information/views.py
@@ -17,11 +17,11 @@ from shoop.utils.form_group import FormGroup
 class PersonContactForm(forms.ModelForm):
     class Meta:
         model = PersonContact
-        fields = ("name", "phone", "email", "gender", "marketing_permission")
+        fields = ("first_name", "last_name", "phone", "email", "gender", "marketing_permission")
 
     def __init__(self, *args, **kwargs):
         super(PersonContactForm, self).__init__(*args, **kwargs)
-        for field in ("name", "email"):
+        for field in ("first_name", "last_name", "email"):
             self.fields[field].required = True
 
 

--- a/shoop/testing/factories.py
+++ b/shoop/testing/factories.py
@@ -577,6 +577,8 @@ def create_random_person(locale=None, minimum_name_comp_len=0):
         email=email,
         phone=phone,
         name=name,
+        first_name=first_name,
+        last_name=last_name,
         prefix=prefix,
         suffix=suffix,
         default_shipping_address=address,

--- a/shoop_tests/admin/test_contact_edit.py
+++ b/shoop_tests/admin/test_contact_edit.py
@@ -20,8 +20,11 @@ def test_contact_edit_form():
         first_name=printable_gibberish(),
         last_name=printable_gibberish(),
     )
+    test_first_name = printable_gibberish()
+    test_last_name = printable_gibberish()
     contact_base_form = ContactBaseForm(bind_user=user, data={
-        "name": "herf durr",
+        "first_name": test_first_name,
+        "last_name": test_last_name,
         "gender": Gender.UNDISCLOSED.value
     })
     assert contact_base_form.bind_user == user
@@ -31,3 +34,4 @@ def test_contact_edit_form():
     assert isinstance(contact, PersonContact)
     assert contact.user == user
     assert get_person_contact(user) == contact
+    assert contact.name == "%s %s" % (test_first_name, test_last_name)

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -106,6 +106,44 @@ def test_person_contact_creating_from_user(regular_user):
     assert person.email == user.email
 
 
+@pytest.mark.django_db
+def test_person_name_init_by_name():
+    john = PersonContact(name="John Smith")
+    assert john.name == "John Smith"
+    assert john.first_name == "John"
+    assert john.last_name == "Smith"
+
+
+@pytest.mark.django_db
+def test_person_name_create_with_name():
+    john = PersonContact.objects.create(name="John Smith")
+    assert PersonContact.objects.get(pk=john.pk).name == "John Smith"
+    assert john.name == "John Smith"
+    assert john.first_name == "John"
+    assert john.last_name == "Smith"
+
+
+@pytest.mark.django_db
+def test_person_name_init_by_first_and_last_name():
+    john = PersonContact(first_name="John", last_name="Smith")
+    assert john.name == "John Smith"
+    assert john.first_name == "John"
+    assert john.last_name == "Smith"
+
+
+@pytest.mark.django_db
+def test_person_name_gets_saved():
+    john = PersonContact.objects.create(first_name="John", last_name="Smith")
+    assert john.name == "John Smith"
+    assert john in set(PersonContact.objects.filter(name="John Smith"))
+    john.last_name = "Doe"
+    assert john.name == "John Doe"
+    john.save()
+    assert john.name == "John Doe"
+    assert john in set(PersonContact.objects.filter(name="John Doe"))
+    assert john not in set(PersonContact.objects.filter(name="John Smith"))
+
+
 def test_contact_group_repr_and_str_no_identifier_no_name():
     cg = ContactGroup()
     assert repr(cg) == '<ContactGroup:None>'

--- a/shoop_tests/front/test_customer_information.py
+++ b/shoop_tests/front/test_customer_information.py
@@ -37,8 +37,10 @@ def test_new_user_information_edit():
     # make sure all information matches in form
     customer_edit_url = reverse("shoop:customer_edit")
     soup = client.soup(customer_edit_url)
+
     assert soup.find(attrs={"name": "contact-email"})["value"] == user.email
-    assert soup.find(attrs={"name": "contact-name"})["value"] == user.get_full_name()
+    assert soup.find(attrs={"name": "contact-first_name"})["value"] == user.first_name
+    assert soup.find(attrs={"name": "contact-last_name"})["value"] == user.last_name
 
     # Test POSTing
     form = extract_form_fields(soup)


### PR DESCRIPTION
* Add first and last name for PersonContact
* Admin: Enable edit for PersonContact first and last name
* Add first and last name for customer information edit

This replaces PR #395.

The differences to PR #395 are:
 * Data migration for filling first_name and last_name
 * PersonContact.name property getter and setter
 * New tests
 * get_person_contact: Use user.first_name and user.last_name
 * Change Log entry

For full diff see `git diff 37fb7e4`.