### PR TITLE
Simple CMS plugin fixes (SHOOP-2179)

### DIFF
--- a/shoop/simple_cms/plugins.py
+++ b/shoop/simple_cms/plugins.py
@@ -32,7 +32,7 @@ class PageLinksConfigForm(GenericPluginForm):
         self.fields["pages"] = forms.ModelMultipleChoiceField(
             queryset=Page.objects.filter(visible_in_menu=True),
             required=False,
-            initial=self.plugin.config.get("categories", None),
+            initial=self.plugin.config.get("pages", None),
         )
 
     def clean(self):

--- a/shoop/simple_cms/plugins.py
+++ b/shoop/simple_cms/plugins.py
@@ -77,14 +77,14 @@ class PageLinksPlugin(TemplatedPlugin):
         selected_pages = self.config.get("pages", [])
         show_all_pages = self.config.get("show_all_pages", True)
         hide_expired = self.config.get("hide_expired", False)
+
         pages_qs = Page.objects.filter(visible_in_menu=True)
-        if not show_all_pages:
-            if selected_pages:
-                pages_qs = pages_qs.filter(id__in=selected_pages),
-            else:
-                pages_qs = pages_qs.none()
         if hide_expired:
             pages_qs = pages_qs.visible()
+
+        if not show_all_pages:
+            pages_qs = pages_qs.filter(id__in=selected_pages)
+
         return {
             "title": self.get_translated_value("title"),
             "pages": pages_qs,

--- a/shoop_tests/simple_cms/test_plugins.py
+++ b/shoop_tests/simple_cms/test_plugins.py
@@ -29,14 +29,16 @@ def test_page_links_plugin_visible_in_menu():
 
 
 @pytest.mark.django_db
-def test_page_links_plugin_hide_expired():
+@pytest.mark.parametrize("show_all_pages", [True, False])
+def test_page_links_plugin_hide_expired(show_all_pages):
     """
     Make sure plugin correctly filters out expired pages based on plugin
     configuration
     """
     context = get_jinja_context()
     page = create_page(eternal=True, visible_in_menu=True)
-    plugin = PageLinksPlugin({"pages": [page.pk]})
+    another_page = create_page(eternal=True, visible_in_menu=True)
+    plugin = PageLinksPlugin({"pages": [page.pk, another_page.pk], "show_all_pages": show_all_pages})
     assert page in plugin.get_context_data(context)["pages"]
 
     page.available_from = None
@@ -45,7 +47,9 @@ def test_page_links_plugin_hide_expired():
     assert page in plugin.get_context_data(context)["pages"]
 
     plugin.config["hide_expired"] = True
-    assert page not in plugin.get_context_data(context)["pages"]
+    pages_in_context = plugin.get_context_data(context)["pages"]
+    assert page not in pages_in_context
+    assert another_page in pages_in_context
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Simple CMS: Make plugin hide expired pages correctly
Simple CMS: Initalize pages-field in plugin correctly

Refs SHOOP-2179 / SHOOP-2315, SHOOP-2316