### PR TITLE
Xtheme: Enable global placeholder type (SHOOP-2219)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,7 @@ Xtheme
 ~~~~~~
 
 - Enhance default text plugin editor to remarkable markdown editor
+- Add support for global/multi-view placeholders
 - Add generic snippets plugin for doing simple integrations
 - Add a plugin for displaying category links on shop front
 - Add a linkable image plugin

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_footer.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/includes/_footer.jinja
@@ -1,6 +1,6 @@
 <footer>
     <div class="container">
-        {% placeholder "footer" %}
+        {% placeholder "footer" global %}
             {% column {"sm": 4} %}
                 {% plugin "simple_cms.page_links" %}
                     title = "Pages"

--- a/shoop/xtheme/__init__.py
+++ b/shoop/xtheme/__init__.py
@@ -22,6 +22,8 @@ __all__ = [
     "templated_plugin_factory"
 ]
 
+XTHEME_GLOBAL_VIEW_NAME = "_XthemeGlobalView"
+
 
 class XThemeAppConfig(AppConfig):
     name = "shoop.xtheme"

--- a/shoop/xtheme/parsing.py
+++ b/shoop/xtheme/parsing.py
@@ -31,7 +31,8 @@ class NonConstant(ValueError):
 
 class NestingError(ValueError):
     """
-    Exception raised when a template's placeholder/column/row/plugin hierarchy is out of whack.
+    Exception raised when a template's placeholder/column/row/plugin
+    hierarchy is out of whack.
     """
 
 
@@ -45,7 +46,8 @@ def flatten_const_node_list(environment, node_list):
     :type node_list: list[jinja2.nodes.Node]
     :return: String of content
     :rtype: str
-    :raise Unflattenable: Raised when the node list can't be flattened into a constant
+    :raise Unflattenable: Raised when the node list can't be flattened into
+                          a constant
     """
     output = []
     eval_ctx = EvalContext(environment)
@@ -90,8 +92,8 @@ def parse_constantlike(environment, parser):
 
 class _PlaceholderManagingExtension(Extension):
     """
-    Superclass (could be mixin) with helpers for getting the currently active layout object
-    from a parser.
+    Superclass (could be mixin) with helpers for getting the currently
+    active layout object from a parser.
     """
     def _get_layout(self, parser, accept_none=False):
         """
@@ -99,12 +101,14 @@ class _PlaceholderManagingExtension(Extension):
 
         :param parser: Template parser
         :type parser: jinja2.parser.Parser
-        :param accept_none: Whether or not to accept the eventuality that there's no current layout.
-                            If False (the default), a `NestingError` is raised.
+        :param accept_none: Whether or not to accept the eventuality that
+                            there's no current layout. If False (the
+                            default), a `NestingError` is raised.
         :type accept_none: bool
         :return: The current layout
         :rtype: shoop.xtheme.view_config.Layout
-        :raises NestingError: Raised if there's no current layout and that's not okay.
+        :raises NestingError: Raised if there's no current layout and
+                              that's not okay.
         """
         cfg = getattr(parser, "_xtheme_placeholder_layout", None)
         if not accept_none and cfg is None:
@@ -163,14 +167,24 @@ def noop_node(lineno):
 
 class PlaceholderExtension(_PlaceholderManagingExtension):
     """
-    `PlaceholderExtension` manages `{% placeholder <NAME> %}` ... `{% endplaceholder %}`.
+    `PlaceholderExtension` manages `{% placeholder <NAME> [global] %}` ...
+      `{% endplaceholder %}`.
 
-    * The `name` can be any Jinja2 expression that can be folded into a constant, with the addition
-      of bare variable names such as `name` meaning the same as `"name"`. This makes it slightly
-      easier to write templates.
-    * The body of this block is actually discarded; only the inner `column`, `row` and `plugin`
-      directives have any meaning.  (A parser-time `Layout` object is created and populated during parsing
+    * The `name` can be any Jinja2 expression that can be folded into a
+      constant, with the addition of bare variable names such as `name`
+      meaning the same as `"name"`. This makes it slightly easier to write
+      templates.
+    * The body of this block is actually discarded; only the inner
+      `column`, `row` and `plugin` directives have any meaning.  (A
+      parser-time `Layout` object is created and populated during parsing
       of this block.)
+    * An optional ``global`` parameter can be used to specify that the
+      configuration for this placeholder should be "global" across
+      different views (although currently that only applies to placeholders
+      within the same template, i.e, if you defined the same global
+      placeholder in different templates they will not share configuration,
+      but an included or base template that is rendered by different views
+      will).
     """
     tags = set(['placeholder'])
 

--- a/shoop/xtheme/rendering.py
+++ b/shoop/xtheme/rendering.py
@@ -18,12 +18,14 @@ from shoop.xtheme.utils import get_html_attrs
 from shoop.xtheme.view_config import ViewConfig
 
 
-def get_view_config(context):
+def get_view_config(context, global_type=False):
     """
     Get a view configuration object for a Jinja2 rendering context.
 
     :param context: Rendering context
     :type context: jinja2.runtime.Context
+    :param global_type: Boolean indicating whether this is a global type
+    :type global_type: bool|False
     :return: View config
     :rtype: shoop.xtheme.view_config.ViewConfig
     """
@@ -31,7 +33,7 @@ def get_view_config(context):
     # to cache the view configuration. This is fine in our case, I'd say.
     request = context.get("request")
     config = context.vars.get("_xtheme_view_config")
-    if config is None:
+    if (config is None):
         view_object = context.get("view")
         if view_object:
             view_class = view_object.__class__
@@ -41,13 +43,15 @@ def get_view_config(context):
         config = ViewConfig(
             theme=get_current_theme(request),
             view_name=view_name,
-            draft=is_edit_mode(request)
+            draft=is_edit_mode(request),
+            global_type=global_type,
         )
         context.vars["_xtheme_view_config"] = config
     return config
 
 
-def render_placeholder(context, placeholder_name, default_layout=None, template_name=None):  # doccov: noargs
+def render_placeholder(context, placeholder_name, default_layout=None, template_name=None,
+                       global_type=False):  # doccov: noargs
     """
     Render a placeholder in a given context.
 
@@ -60,7 +64,8 @@ def render_placeholder(context, placeholder_name, default_layout=None, template_
         context,
         placeholder_name,
         default_layout=default_layout,
-        template_name=template_name
+        template_name=template_name,
+        global_type=global_type,
     )
     return renderer.render()
 
@@ -71,7 +76,7 @@ class PlaceholderRenderer(object):
     """
     # TODO: Maybe make this pluggable per-theme?
 
-    def __init__(self, context, placeholder_name, default_layout=None, template_name=None):
+    def __init__(self, context, placeholder_name, default_layout=None, template_name=None, global_type=False):
         """
         :param context: Rendering context
         :type context: jinja2.runtime.Context
@@ -82,18 +87,24 @@ class PlaceholderRenderer(object):
         :param template_name: The actual template this node was in. Used to figure out whether the placeholder
                               lives in an `extends` parent, or in a child.
         :type template_name: str|None
+        :param global_type: Boolean indicating whether this is a global placeholder
+        :type global_type: bool|False
         """
         self.context = context
-        self.view_config = get_view_config(context)
+        self.view_config = get_view_config(context, global_type=global_type)
         self.placeholder_name = placeholder_name
-        self.template_name = template_name
+        self.template_name = ("_xtheme_global_template_name" if global_type else template_name)
         self.default_layout = default_layout
         self.layout = self.view_config.get_placeholder_layout(placeholder_name, self.default_layout)
-        # Editing is only available for placeholders in the "base" template, i.e.
+        self.global_type = global_type
+        # For non-global placeholders, editing is only available for placeholders in the "base" template, i.e.
         # one that is not an `extend` parent.  Declaring placeholders in `include`d templates is fine,
         # but their configuration will not be shared among different uses of the same include.
-        is_base = (self.template_name == self.context.name)
-        self.edit = (is_base and is_edit_mode(context["request"]))
+        if global_type:
+            self.edit = is_edit_mode(context["request"])
+        else:
+            is_base = (self.template_name == self.context.name)
+            self.edit = (is_base and is_edit_mode(context["request"]))
 
     def render(self):
         """
@@ -115,11 +126,12 @@ class PlaceholderRenderer(object):
 
     def _get_wrapper_attrs(self):
         attrs = {
-            "class": ["xt-ph", "xt-ph-edit" if self.edit else None],
+            "class": ["xt-ph", "xt-ph-edit" if self.edit else None, "xt-global-ph" if self.global_type else None],
             "id": "xt-ph-%s" % self.placeholder_name
         }
         if self.edit:
             attrs["data-xt-placeholder-name"] = self.placeholder_name
+            attrs["data-xt-global-type"] = "global" if self.global_type else None
             attrs["title"] = _("Click to edit placeholder: %s") % self.placeholder_name.title()
         return attrs
 

--- a/shoop/xtheme/static_src/injection/index.js
+++ b/shoop/xtheme/static_src/injection/index.js
@@ -48,6 +48,7 @@ function setSidebarVisibility(visible) {
 
 function openPlaceholderEditor(domElement) {
     const placeholderName = domElement.dataset.xtPlaceholderName;
+    const globalType = domElement.dataset.xtGlobalType;
     if (!placeholderName) {
         return;
     }
@@ -58,6 +59,7 @@ function openPlaceholderEditor(domElement) {
         view: viewName,
         theme: window.XthemeEditorConfig.themeIdentifier,
         ph: placeholderName,
+        "global_type": globalType,
 
         // TODO: Hopefully we won't get any problems with too-long query strings (2048 is the maximum for IE):
         "default_config": defaultConfigJSON

--- a/shoop/xtheme/view_config.py
+++ b/shoop/xtheme/view_config.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from django.utils.encoding import force_text
 
+from shoop.xtheme import XTHEME_GLOBAL_VIEW_NAME
 from shoop.xtheme.layout import Layout
 from shoop.xtheme.models import SavedViewConfig
 
@@ -21,7 +22,7 @@ class ViewConfig(object):
     container for `SavedViewConfig` objects, and wraps the `SavedViewConfig` API.
     """
 
-    def __init__(self, theme, view_name, draft):
+    def __init__(self, theme, view_name, draft, global_type=False):
         """
         Initialize a view configuration.
 
@@ -31,9 +32,11 @@ class ViewConfig(object):
         :type view_name: str
         :param draft: Load in draft mode?
         :type draft: bool
+        :param global_type: Boolean indicating whether this is a global config
+        :type global_type: bool|False
         """
         self.theme = theme
-        self.view_name = force_text(view_name)
+        self.view_name = (XTHEME_GLOBAL_VIEW_NAME if global_type else force_text(view_name))
         self.draft = bool(draft)
         self._saved_view_config = None
 

--- a/shoop_tests/xtheme/templates/global_complex.jinja
+++ b/shoop_tests/xtheme/templates/global_complex.jinja
@@ -1,0 +1,81 @@
+<html>
+<head></head>
+<body>
+{% placeholder "foo1" "global" %}
+    {% row %}
+        {% column {"md": 7} %}
+            {% plugin "text" %}text = "wider column"{% endplugin %}
+        {% endcolumn %}
+        {% column {"md": 5} %}
+            {% plugin "text" %}text = "less wide column"{% endplugin %}
+        {% endcolumn %}
+    {% endrow %}
+{% endplaceholder %}
+{% placeholder "bar" %}
+    {% column {"xs": 0} %}
+        {% plugin "text" %}{% endplugin %}
+    {% endcolumn %}
+{% endplaceholder %}
+{% placeholder "quux" %}
+    {% plugin "text" %}{% endplugin %}
+{% endplaceholder %}
+
+{% placeholder "foo2" global %}
+    {% row %}
+        {% column {"md": 7} %}
+            {% plugin "text" %}text = "wider column"{% endplugin %}
+        {% endcolumn %}
+        {% column {"md": 5} %}
+            {% plugin "text" %}text = "less wide column"{% endplugin %}
+        {% endcolumn %}
+    {% endrow %}
+{% endplaceholder %}
+{% placeholder "bar" %}
+    {% column {"xs": 0} %}
+        {% plugin "text" %}{% endplugin %}
+    {% endcolumn %}
+{% endplaceholder %}
+{% placeholder "quux" %}
+    {% plugin "text" %}{% endplugin %}
+{% endplaceholder %}
+
+
+{% placeholder foo3 "global" %}
+    {% row %}
+        {% column {"md": 7} %}
+            {% plugin "text" %}text = "wider column"{% endplugin %}
+        {% endcolumn %}
+        {% column {"md": 5} %}
+            {% plugin "text" %}text = "less wide column"{% endplugin %}
+        {% endcolumn %}
+    {% endrow %}
+{% endplaceholder %}
+{% placeholder "bar" %}
+    {% column {"xs": 0} %}
+        {% plugin "text" %}{% endplugin %}
+    {% endcolumn %}
+{% endplaceholder %}
+{% placeholder "quux" %}
+    {% plugin "text" %}{% endplugin %}
+{% endplaceholder %}
+
+{% placeholder foo4 global %}
+    {% row %}
+        {% column {"md": 7} %}
+            {% plugin "text" %}text = "wider column"{% endplugin %}
+        {% endcolumn %}
+        {% column {"md": 5} %}
+            {% plugin "text" %}text = "less wide column"{% endplugin %}
+        {% endcolumn %}
+    {% endrow %}
+{% endplaceholder %}
+{% placeholder "bar" %}
+    {% column {"xs": 0} %}
+        {% plugin "text" %}{% endplugin %}
+    {% endcolumn %}
+{% endplaceholder %}
+{% placeholder "quux" %}
+    {% plugin "text" %}{% endplugin %}
+{% endplaceholder %}
+</body>
+</html>

--- a/shoop_tests/xtheme/test_editor_view.py
+++ b/shoop_tests/xtheme/test_editor_view.py
@@ -7,6 +7,7 @@ from django.test.client import RequestFactory
 
 from shoop.apps.provides import override_provides
 from shoop.utils.excs import Problem
+from shoop.xtheme import XTHEME_GLOBAL_VIEW_NAME
 from shoop.xtheme.layout import Layout
 from shoop.xtheme.models import SavedViewConfig, SavedViewConfigStatus
 from shoop.xtheme.plugins.consts import FALLBACK_LANGUAGE_CODE
@@ -151,3 +152,15 @@ def test_editor_cell_limits():
 
         with pytest.raises(ValueError):
             view_obj.dispatch_add_cell(y=0)
+
+
+@pytest.mark.django_db
+def test_get_global_placeholder():
+    request = RequestFactory().get("/")
+    layout, svc = get_test_layout_and_svc()
+    with initialize_editor_view(svc.view_name, layout.placeholder_name, request=request) as view_obj:
+        view_name_1 = view_obj.dispatch(view_obj.request).context_data["view"].view_config.view_name
+        view_obj.request.GET.update({"x": 0, "y": 0, "global_type": True})
+        view_name_2 = view_obj.dispatch(view_obj.request).context_data["view"].view_config.view_name
+        assert view_name_1 != view_name_2
+        assert view_name_2 == XTHEME_GLOBAL_VIEW_NAME

--- a/shoop_tests/xtheme/test_layout.py
+++ b/shoop_tests/xtheme/test_layout.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 import six
 
+from shoop.xtheme import XTHEME_GLOBAL_VIEW_NAME
 from shoop.xtheme.layout import Layout, LayoutCell
 from shoop.xtheme.plugins.text import TextPlugin
 from shoop.xtheme.rendering import get_view_config, render_placeholder
 from shoop.xtheme.testing import override_current_theme_class
 from shoop_tests.utils import printable_gibberish
 from shoop_tests.xtheme.utils import (
-    close_enough, get_request, get_test_template_bits, plugin_override
+    close_enough, FauxView, get_jinja2_engine, get_request,
+    get_test_template_bits, plugin_override
 )
 
 
@@ -46,6 +48,23 @@ def test_layout_rendering(rf):
             </div>
             """ % gibberish
             assert close_enough(result, expect)
+
+
+def test_layout_rendering_with_global_type(rf):
+    request = get_request(edit=False)
+    with override_current_theme_class(None):
+        with plugin_override():
+            jeng = get_jinja2_engine()
+            template = jeng.from_string("")
+
+            (template, layout, gibberish, ctx) = get_test_template_bits(request)
+
+            global_class = "xt-global-ph"
+            result = six.text_type(render_placeholder(ctx, "test", layout, template.template.name, global_type=True))
+            assert global_class in result
+
+            result = six.text_type(render_placeholder(ctx, "test", layout, template.template.name, global_type=False))
+            assert global_class not in result
 
 
 def test_layout_edit_render():

--- a/shoop_tests/xtheme/test_load_save.py
+++ b/shoop_tests/xtheme/test_load_save.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from shoop.xtheme import Theme
+from shoop.xtheme import Theme, XTHEME_GLOBAL_VIEW_NAME
 from shoop.xtheme.view_config import ViewConfig
 from shoop_tests.utils import printable_gibberish
 

--- a/shoop_tests/xtheme/test_plugin_forms.py
+++ b/shoop_tests/xtheme/test_plugin_forms.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.forms.fields import IntegerField
 
-from shoop.xtheme.plugins.forms import TranslatableField
 from shoop.xtheme import Plugin
+from shoop.xtheme.plugins.forms import TranslatableField
 
 
 class SomewhatConfigurablePlugin(Plugin):

--- a/shoop_tests/xtheme/test_rendering.py
+++ b/shoop_tests/xtheme/test_rendering.py
@@ -11,12 +11,16 @@ from shoop_tests.xtheme.utils import (
 @pytest.mark.parametrize("edit", (False, True))
 @pytest.mark.parametrize("injectable", (False, True))
 @pytest.mark.parametrize("theme_class", (None, FauxTheme))
-def test_rendering(edit, injectable, theme_class):
+@pytest.mark.parametrize("global_type", (False, True))
+def test_rendering(edit, injectable, theme_class, global_type):
     request = get_request(edit)
     with override_current_theme_class(theme_class):
         with plugin_override():
             jeng = get_jinja2_engine()
-            template = jeng.get_template("complex.jinja")
+            if global_type:
+                template = jeng.get_template("global_complex.jinja")
+            else:
+                template = jeng.get_template("complex.jinja")
             view = FauxView()
             view.xtheme_injection = bool(injectable)
             output = template.render(context={


### PR DESCRIPTION
Enable a ``global`` parameter for Xtheme placeholders which would store
a site-wite placeholder configuration.

This is done by overriding the placeholder's view name as
``_XthemeGlobalView`` and should work as expected when editing,
rendering, etc.

Currently, this only applies to global placeholders that are within the
same template (but might be included in other templates), so if two
placeholders are marked as ``global`` but are not in the same template
they will not share the same settings.

Refs SHOOP-2219