### PR TITLE
Order creator: Hide initial method prices (SHOOP-2319)

### DIFF
--- a/shoop/admin/modules/orders/static_src/create/reducers/order.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/order.js
@@ -9,10 +9,6 @@
 import {handleActions} from "redux-actions";
 import _ from "lodash";
 
-function getMethodPrice(method) {
-    return  method && method.price ? method.price : 0;
-}
-
 function updateTotals(state, {payload}) {
     const updates = {};
     const {lines, methods} = payload();
@@ -20,8 +16,6 @@ function updateTotals(state, {payload}) {
     _.map(lines, (line) => {
         total += line.total;
     });
-    total += getMethodPrice(methods.shippingMethod);
-    total += getMethodPrice(methods.paymentMethod);
     updates.total = +total.toFixed(2);
     return _.assign({}, state, updates);
 }

--- a/shoop/admin/modules/orders/static_src/create/view/methods.js
+++ b/shoop/admin/modules/orders/static_src/create/view/methods.js
@@ -20,10 +20,7 @@ function renderMethod(store, mode, title, selectedMethod, choices, emptyChoice) 
                     store.dispatch(updateTotals(store.getState));
                 }, [].concat({id: 0, name: emptyChoice}, choices || []))
             ]
-        ),
-        m("div", [
-            (selectedMethod ? m("p.text-center", gettext("Price") + ": " + parseFloat(selectedMethod.price).toFixed(2)) : null)
-        ])
+        )
     ];
 }
 

--- a/shoop/admin/modules/orders/views/create.py
+++ b/shoop/admin/modules/orders/views/create.py
@@ -64,17 +64,8 @@ def encode_shop(shop):
     }
 
 
-def encode_method_extras(method):
-    module_data = method.module_data or {}
-
-    return {
-        "price": module_data.get("price", "0"),
-    }
-
-
 def encode_method(method):
     basic_data = {"id": method.pk, "name": force_text(method)}
-    basic_data.update(encode_method_extras(method))
     return basic_data
 
 


### PR DESCRIPTION
Hide method prices for order creator until user reaches confirmation
view where they can be more easily calculated.