### PR TITLE
Add attribute checks for user instance

### DIFF
--- a/shoop/admin/modules/users/views/detail.py
+++ b/shoop/admin/modules/users/views/detail.py
@@ -45,8 +45,8 @@ class BaseUserForm(forms.ModelForm):
             # Changing the password for an existing user requires more confirmation
             self.fields.pop("password")
             self.initial["permission_info"] = ", ".join(force_text(perm) for perm in [
-                _("staff") if self.instance.is_staff else "",
-                _("superuser") if self.instance.is_superuser else "",
+                _("staff") if getattr(self.instance, 'is_staff', None) else "",
+                _("superuser") if getattr(self.instance, 'is_superuser', None) else "",
             ] if perm) or _("No special permissions")
         else:
             self.fields.pop("permission_info")
@@ -81,7 +81,7 @@ class UserDetailToolbar(Toolbar):
         )
         reset_password_button = DropdownItem(
             url=reverse("shoop_admin:user.reset-password", kwargs={"pk": user.pk}),
-            disable_reason=(_("User has no email address") if not user.email else None),
+            disable_reason=(_("User has no email address") if not getattr(user, 'email', '') else None),
             text=_(u"Send Password Reset Email"), icon="fa fa-envelope"
         )
         permissions_button = DropdownItem(
@@ -189,7 +189,7 @@ class UserDetailView(CreateOrUpdateView):
     def _handle_set_is_active(self):
         state = bool(int(self.request.POST["set_is_active"]))
         if not state:
-            if (self.object.is_superuser and not self.request.user.is_superuser):
+            if (getattr(self.object, 'is_superuser', False) and not getattr(self.request.user, 'is_superuser', False)):
                 raise Problem(_("You can not deactivate a superuser."))
             if self.object == self.request.user:
                 raise Problem(_("You can not deactivate yourself."))

--- a/shoop/admin/modules/users/views/list.py
+++ b/shoop/admin/modules/users/views/list.py
@@ -43,14 +43,14 @@ class UserListView(PicotableListView):
 
     def get_object_abstract(self, instance, item):
         bits = filter(None, [
-            _("First Name: %s") % (instance.first_name or "\u2014"),
-            _("Last Name: %s") % (instance.last_name or "\u2014"),
+            _("First Name: %s") % (getattr(instance, 'first_name', None) or "\u2014"),
+            _("Last Name: %s") % (getattr(instance, 'last_name', None) or "\u2014"),
             _("Active") if instance.is_active else _(u"Inactive"),
-            _("Email: %s") % (instance.email or "\u2014"),
-            _("Staff") if instance.is_staff else None,
-            _("Superuser") if instance.is_superuser else None
+            _("Email: %s") % (getattr(instance, 'email', None) or "\u2014"),
+            _("Staff") if getattr(instance, 'is_staff', None) else None,
+            _("Superuser") if getattr(instance, 'is_superuser', None) else None
         ])
         return [
-            {"text": instance.username or _("User"), "class": "header"},
+            {"text": instance.get_username() or _("User"), "class": "header"},
             {"text": ", ".join(bits)}
         ]

--- a/shoop/admin/modules/users/views/password.py
+++ b/shoop/admin/modules/users/views/password.py
@@ -38,12 +38,12 @@ class PasswordChangeForm(forms.Form):
         super(PasswordChangeForm, self).__init__(*args, **kwargs)
         self.changing_user = changing_user
         self.target_user = target_user
-        if self.target_user.is_superuser and not self.changing_user.is_superuser:
+        if getattr(self.target_user, 'is_superuser', False) and not getattr(self.changing_user, 'is_superuser', False):
             raise Problem(_("You can not change the password of a superuser."))
 
         if not (
             self.changing_user == self.target_user or
-            self.target_user.is_superuser
+            getattr(self.target_user, 'is_superuser', False)
         ):
             # Only require old password when changing your own or a superuser's password.
             self.fields.pop("old_password")
@@ -131,7 +131,8 @@ class UserResetPasswordView(DetailView):
         r = RecoverPasswordForm()
         r.request = self.request
         if r.process_user(user):
-            messages.success(self.request, _(u"Password recovery email sent to %(email)s") % {"email": user.email})
+            messages.success(self.request, _(u"Password recovery email sent to %(email)s") %
+                             {"email": getattr(user, 'email', '')})
         else:
             raise Problem(_(u"Sending the password recovery email failed."))
 

--- a/shoop/admin/modules/users/views/permissions.py
+++ b/shoop/admin/modules/users/views/permissions.py
@@ -30,12 +30,12 @@ class PermissionChangeFormBase(forms.ModelForm):
     def __init__(self, changing_user, *args, **kwargs):
         super(PermissionChangeFormBase, self).__init__(*args, **kwargs)
         self.changing_user = changing_user
-        if self.instance.is_superuser and not self.changing_user.is_superuser:
+        if getattr(self.instance, 'is_superuser', False) and not getattr(self.changing_user, 'is_superuser', False):
             self.fields.pop("is_superuser")
 
         if not (
             self.changing_user == self.instance or
-            self.instance.is_superuser
+            getattr(self.instance, 'is_superuser', False)
         ):
             # Only require old password when editing
             self.fields.pop("old_password")

--- a/shoop/core/api/products.py
+++ b/shoop/core/api/products.py
@@ -39,7 +39,7 @@ class ProductViewSet(ModelViewSet):
     serializer_class = ProductSerializer
 
     def get_queryset(self):
-        if self.request.user.is_superuser:
+        if getattr(self.request.user, 'is_superuser', False):
             return Product.objects.all_except_deleted()
         return Product.objects.list_visible(
             customer=self.request.customer,
@@ -52,7 +52,7 @@ class ShopProductViewSet(ModelViewSet):
     serializer_class = ShopProductSerializer
 
     def get_queryset(self):
-        if self.request.user.is_superuser:
+        if getattr(self.request.user, 'is_superuser', False):
             products = Product.objects.all_except_deleted()
         else:
             products = Product.objects.list_visible(

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -262,17 +262,17 @@ class PersonContact(Contact):
             if not self.name:
                 self.name = user.get_full_name()
             if not self.email:
-                self.email = user.email
+                self.email = getattr(user, 'email', '')
             if not self.first_name and not self.last_name:
-                self.first_name = user.first_name
-                self.last_name = user.last_name
+                self.first_name = getattr(user, 'first_name', '')
+                self.last_name = getattr(user, 'last_name', '')
 
         return super(PersonContact, self).save(*args, **kwargs)
 
     @property
     def is_all_seeing(self):
         if self.user_id:
-            return self.user.is_superuser
+            return getattr(self.user, 'is_superuser', False)
 
 
 class AnonymousContact(Contact):
@@ -349,8 +349,8 @@ def get_person_contact(user):
         return AnonymousContact()
     defaults = {
         'is_active': user.is_active,
-        'first_name': user.first_name,
-        'last_name': user.last_name,
-        'email': user.email,
+        'first_name': getattr(user, 'first_name', ''),
+        'last_name': getattr(user, 'last_name', ''),
+        'email': getattr(user, 'email', ''),
     }
     return PersonContact.objects.get_or_create(user=user, defaults=defaults)[0]

--- a/shoop/front/apps/auth/forms.py
+++ b/shoop/front/apps/auth/forms.py
@@ -90,7 +90,7 @@ class RecoverPasswordForm(forms.Form):
             self.process_user(user)
 
     def process_user(self, user_to_recover):
-        if not user_to_recover.has_usable_password():
+        if not user_to_recover.has_usable_password() or not hasattr(user_to_recover, 'email'):
             return False
 
         context = {

--- a/shoop/front/middleware.py
+++ b/shoop/front/middleware.py
@@ -143,7 +143,7 @@ class ShoopFrontMiddleware(object):
         if resolver_match and resolver_match.app_name == "shoop_admin":
             return None
 
-        if request.shop.maintenance_mode and not request.user.is_superuser:
+        if request.shop.maintenance_mode and not getattr(request.user, 'is_superuser', False):
             return HttpResponse(loader.render_to_string("shoop/front/maintenance.jinja", request=request), status=503)
 
 if (

--- a/shoop/notify/models/notification.py
+++ b/shoop/notify/models/notification.py
@@ -30,7 +30,7 @@ class NotificationManager(models.Manager):
 
         q = (Q(recipient_type=RecipientType.SPECIFIC_USER) & Q(recipient=user))
 
-        if user.is_superuser:
+        if getattr(user, 'is_superuser', False):
             q |= Q(recipient_type=RecipientType.ADMINS)
 
         return self.filter(q)

--- a/shoop/simple_cms/views.py
+++ b/shoop/simple_cms/views.py
@@ -47,7 +47,7 @@ class PageView(DetailView):
         return self.render_to_response(context)
 
     def get_queryset(self):
-        if self.request.user.is_superuser:
+        if getattr(self.request.user, 'is_superuser', False):
             # Superusers may see all pages despite their visibility status
             return self.model.objects.all()
         return self.model.objects.visible()

--- a/shoop/xtheme/editing.py
+++ b/shoop/xtheme/editing.py
@@ -26,7 +26,7 @@ def could_edit(request):
     """
     # TODO: Possibly other conditions?
     user = getattr(request, "user", AnonymousUser())
-    return (user.is_superuser or user.is_staff)
+    return (getattr(user, 'is_superuser', False) or getattr(user, 'is_staff', False))
 
 
 def is_edit_mode(request):


### PR DESCRIPTION
One can set a different `AUTH_USER_MODEL` in settings which has not same
attributes of the default Django's User class, throwing exceptions.
Several `hasattr` and `getattr` calls were added to check and get attributes values.