### PR TITLE
Admin: Add delete for service providers admin module (SHOOP-2297)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -49,6 +49,7 @@ Localization
 Admin
 ~~~~~
 
+- Add delete for service providers admin module
 - Remove shipping and payment method management
 - Add package mode for products
 - Enable ```merchant_notes`` editing for ``Contact``

--- a/shoop/admin/modules/service_providers/__init__.py
+++ b/shoop/admin/modules/service_providers/__init__.py
@@ -11,7 +11,9 @@ from __future__ import unicode_literals
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.admin.base import AdminModule, MenuEntry
-from shoop.admin.utils.urls import derive_model_url, get_edit_and_list_urls
+from shoop.admin.utils.urls import (
+    admin_url, derive_model_url, get_edit_and_list_urls
+)
 from shoop.core.models import ServiceProvider
 
 
@@ -20,7 +22,13 @@ class ServiceProviderModule(AdminModule):
     category = _("Payment and Shipping")
 
     def get_urls(self):
-        return get_edit_and_list_urls(
+        return [
+            admin_url(
+                "^service_provider/(?P<pk>\d+)/delete/$",
+                "shoop.admin.modules.service_providers.views.ServiceProviderDeleteView",
+                name="service_provider.delete"
+            )
+        ] + get_edit_and_list_urls(
             url_prefix="^service_provider",
             view_template="shoop.admin.modules.service_providers.views.ServiceProvider%sView",
             name_template="service_provider.%s"

--- a/shoop/admin/modules/service_providers/views/__init__.py
+++ b/shoop/admin/modules/service_providers/views/__init__.py
@@ -6,10 +6,12 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+from ._delete import ServiceProviderDeleteView
 from ._edit import ServiceProviderEditView
 from ._list import ServiceProviderListView
 
 __all__ = [
+    "ServiceProviderDeleteView",
     "ServiceProviderEditView",
     "ServiceProviderListView",
 ]

--- a/shoop/admin/modules/service_providers/views/_delete.py
+++ b/shoop/admin/modules/service_providers/views/_delete.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.core.urlresolvers import reverse_lazy
+from django.views.generic import DeleteView
+
+from shoop.core.models import ServiceProvider
+
+
+class ServiceProviderDeleteView(DeleteView):
+    model = ServiceProvider
+    success_url = reverse_lazy("shoop_admin:service_provider.list")

--- a/shoop/admin/modules/service_providers/views/_edit.py
+++ b/shoop/admin/modules/service_providers/views/_edit.py
@@ -10,11 +10,12 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 
 from django import forms
-from django.core.urlresolvers import reverse
+from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.admin.base import MenuEntry
+from shoop.admin.toolbar import get_default_edit_toolbar
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.apps.provides import get_provide_objects
 from shoop.core.models import ServiceProvider
@@ -78,6 +79,12 @@ class ServiceProviderEditView(CreateOrUpdateView):
 
     def get_success_url(self):
         return reverse("shoop_admin:service_provider.edit", kwargs={"pk": self.object.pk})
+
+    def get_toolbar(self):
+        save_form_id = self.get_save_form_id()
+        object = self.get_object()
+        delete_url = reverse_lazy("shoop_admin:service_provider.delete", kwargs={"pk": object.pk})
+        return get_default_edit_toolbar(self, save_form_id, delete_url=delete_url)
 
 
 class _FormInfoMap(OrderedDict):

--- a/shoop/core/models/_service_payment.py
+++ b/shoop/core/models/_service_payment.py
@@ -63,6 +63,10 @@ class PaymentProcessor(ServiceProvider):
     Note: `PaymentProcessor` objects should never be created on their
     own but rather through a concrete subclass.
     """
+    def delete(self, *args, **kwargs):
+        PaymentMethod.objects.filter(payment_processor=self).update(**{"enabled": False})
+        super(PaymentProcessor, self).delete(*args, **kwargs)
+
     def get_payment_process_response(self, service, order, urls):
         """
         Get payment process response for given order.

--- a/shoop/core/models/_service_shipping.py
+++ b/shoop/core/models/_service_shipping.py
@@ -70,6 +70,10 @@ class Carrier(ServiceProvider):
     Note: `Carrier` objects should never be created on their own but
     rather through a concrete subclass.
     """
+    def delete(self, *args, **kwargs):
+        ShippingMethod.objects.filter(carrier=self).update(**{"enabled": False})
+        super(Carrier, self).delete(*args, **kwargs)
+
     def _create_service(self, choice_identifier, **kwargs):
         return ShippingMethod.objects.create(
             carrier=self, choice_identifier=choice_identifier, **kwargs)


### PR DESCRIPTION
Services linked to service provider is not removed, but the
service provider foreign key is set to null and service is disabled.

Refs SHOOP-2297