### PR TITLE
Admin: Add carts module for monitoring abandoned carts

### DIFF
--- a/doc/api/shoop.front.admin_module.carts.rst
+++ b/doc/api/shoop.front.admin_module.carts.rst
@@ -1,0 +1,17 @@
+shoop.front.admin_module.carts package
+======================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    shoop.front.admin_module.carts.views
+
+Module contents
+---------------
+
+.. automodule:: shoop.front.admin_module.carts
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.front.admin_module.carts.views.rst
+++ b/doc/api/shoop.front.admin_module.carts.views.rst
@@ -1,0 +1,10 @@
+shoop.front.admin_module.carts.views package
+============================================
+
+Module contents
+---------------
+
+.. automodule:: shoop.front.admin_module.carts.views
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.front.admin_module.rst
+++ b/doc/api/shoop.front.admin_module.rst
@@ -1,0 +1,17 @@
+shoop.front.admin_module package
+================================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    shoop.front.admin_module.carts
+
+Module contents
+---------------
+
+.. automodule:: shoop.front.admin_module
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/api/shoop.front.rst
+++ b/doc/api/shoop.front.rst
@@ -6,6 +6,7 @@ Subpackages
 
 .. toctree::
 
+    shoop.front.admin_module
     shoop.front.apps
     shoop.front.basket
     shoop.front.checkout
@@ -17,14 +18,6 @@ Subpackages
 
 Submodules
 ----------
-
-shoop.front.admin_module module
--------------------------------
-
-.. automodule:: shoop.front.admin_module
-    :members:
-    :undoc-members:
-    :show-inheritance:
 
 shoop.front.error_handling module
 ---------------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -65,6 +65,7 @@ Admin
 Front
 ~~~~~
 
+- Add admin view for monitoring customer carts
 - Remove ``get_method_validation_errors`` signal
 - Fix bug at ``get_visible_products`` filter when orderable_only is False
 - Set template price display options from the customer

--- a/shoop/admin/modules/orders/views/list.py
+++ b/shoop/admin/modules/orders/views/list.py
@@ -7,9 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
-from babel.dates import format_datetime
 from django.utils.html import escape
-from django.utils.timezone import localtime
 from django.utils.translation import ugettext as _
 
 from shoop.admin.utils.picotable import (
@@ -18,7 +16,7 @@ from shoop.admin.utils.picotable import (
 )
 from shoop.admin.utils.views import PicotableListView
 from shoop.core.models import Order, OrderStatus, PaymentStatus, ShippingStatus
-from shoop.utils.i18n import format_money, get_current_babel_locale
+from shoop.utils.i18n import format_money, get_locally_formatted_datetime
 
 
 class OrderListView(PicotableListView):
@@ -44,7 +42,7 @@ class OrderListView(PicotableListView):
         return super(OrderListView, self).get_queryset().exclude(deleted=True)
 
     def format_order_date(self, instance, *args, **kwargs):
-        return format_datetime(localtime(instance.order_date), locale=get_current_babel_locale())
+        return get_locally_formatted_datetime(instance.order_date)
 
     def format_taxful_total_price(self, instance, *args, **kwargs):
         return escape(format_money(instance.taxful_total_price))

--- a/shoop/admin/utils/picotable.py
+++ b/shoop/admin/utils/picotable.py
@@ -321,10 +321,11 @@ class Picotable(object):
         return out
 
     def process_item(self, object):
+        object_url = self.get_object_url(object) if callable(self.get_object_url) else None
         out = {
             "_id": object.id,
-            "_url": (self.get_object_url(object) if callable(self.get_object_url) else None),
-            "_linked_in_mobile": True
+            "_url": object_url,
+            "_linked_in_mobile": True if object_url else False
         }
         for column in self.columns:
             out[column.id] = column.get_display_value(context=self.context, object=object)

--- a/shoop/front/__init__.py
+++ b/shoop/front/__init__.py
@@ -18,7 +18,7 @@ class ShoopFrontAppConfig(AppConfig):
 
     provides = {
         "admin_module": [
-            "shoop.front.admin_module.BasketAdminModule",
+            "shoop.front.admin_module.CartAdminModule",
         ],
         "notify_event": [
             "shoop.front.notify_events:OrderReceived"

--- a/shoop/front/admin_module/carts/views/__init__.py
+++ b/shoop/front/admin_module/carts/views/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ._list import CartListView
+
+__all__ = ["CartListView"]

--- a/shoop/front/admin_module/carts/views/_list.py
+++ b/shoop/front/admin_module/carts/views/_list.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+import datetime
+
+from babel.dates import format_datetime
+from django.utils.html import escape
+from django.utils.timezone import localtime, now
+from django.utils.translation import ugettext as _
+
+from shoop.admin.utils.picotable import (
+    ChoicesFilter, Column, DateRangeFilter, MultiFieldTextFilter, RangeFilter
+)
+from shoop.admin.utils.views import PicotableListView
+from shoop.core.models import Shop
+from shoop.front.models import StoredBasket
+from shoop.utils.i18n import format_money, get_current_babel_locale
+
+
+class CartListView(PicotableListView):
+    model = StoredBasket
+    columns = [
+        Column("created_on", _(u"Created on"), display="format_created_date", filter_config=DateRangeFilter()),
+        Column("updated_on", _(u"Last updated on"), display="format_updated_date", filter_config=DateRangeFilter()),
+        Column(
+            "finished", _("Abandoned"),
+            display="format_abandoned_status",
+            filter_config=ChoicesFilter([(False, _("yes")), (True, _("no"))])
+        ),
+        Column("shop", _("Shop"), filter_config=ChoicesFilter(choices=Shop.objects.all())),
+        Column("product_count", _("Product count"), filter_config=RangeFilter()),
+        Column(
+            "customer", _(u"Customer"),
+            filter_config=MultiFieldTextFilter(filter_fields=("customer__email", "customer__name"))
+        ),
+        Column(
+            "orderer", _(u"Orderer"),
+            filter_config=MultiFieldTextFilter(filter_fields=("orderer__email", "orderer__name"))
+        ),
+        Column(
+            "taxful_total_price", _(u"Total"), sort_field="taxful_total_price_value",
+            display="format_taxful_total_price", class_name="text-right",
+            filter_config=RangeFilter(field_type="number", filter_field="taxful_total_price_value")
+        ),
+    ]
+
+    def get_queryset(self):
+        """
+        Ignore potentially active carts, displaying only those not updated for at least 2 hours.
+        """
+        cutoff = now() - datetime.timedelta(hours=2)
+        filters = {"updated_on__lt": cutoff, "product_count__gte": 0}
+        return super(CartListView, self).get_queryset().filter(**filters)
+
+    def format_abandoned_status(self, instance, *args, **kwargs):
+        return "yes" if not instance.finished else "no"
+
+    def format_created_date(self, instance, *args, **kwargs):
+        return format_datetime(localtime(instance.created_on), locale=get_current_babel_locale())
+
+    def format_updated_date(self, instance, *args, **kwargs):
+        return format_datetime(localtime(instance.updated_on), locale=get_current_babel_locale())
+
+    def format_taxful_total_price(self, instance, *args, **kwargs):
+        return escape(format_money(instance.taxful_total_price))
+
+    def get_context_data(self, **kwargs):
+        context = super(CartListView, self).get_context_data(**kwargs)
+        context["title"] = _("Carts")
+        return context
+
+    def get_object_abstract(self, instance, item):
+        return [
+            {"text": "%s" % instance, "class": "header"},
+            {"title": _(u"Created on"), "text": item["created_on"]},
+            {"title": _(u"Last updated on"), "text": item["updated_on"]},
+            {"title": _(u"Ordered"), "text": item["finished"]},
+            {"title": _(u"Total"), "text": item["taxful_total_price"]},
+        ]

--- a/shoop/front/admin_module/carts/views/_list.py
+++ b/shoop/front/admin_module/carts/views/_list.py
@@ -9,9 +9,8 @@ from __future__ import unicode_literals
 
 import datetime
 
-from babel.dates import format_datetime
 from django.utils.html import escape
-from django.utils.timezone import localtime, now
+from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
 from shoop.admin.utils.picotable import (
@@ -20,7 +19,7 @@ from shoop.admin.utils.picotable import (
 from shoop.admin.utils.views import PicotableListView
 from shoop.core.models import Shop
 from shoop.front.models import StoredBasket
-from shoop.utils.i18n import format_money, get_current_babel_locale
+from shoop.utils.i18n import format_money, get_locally_formatted_datetime
 
 
 class CartListView(PicotableListView):
@@ -62,10 +61,10 @@ class CartListView(PicotableListView):
         return "yes" if not instance.finished else "no"
 
     def format_created_date(self, instance, *args, **kwargs):
-        return format_datetime(localtime(instance.created_on), locale=get_current_babel_locale())
+        return get_locally_formatted_datetime(instance.created_on)
 
     def format_updated_date(self, instance, *args, **kwargs):
-        return format_datetime(localtime(instance.updated_on), locale=get_current_babel_locale())
+        return get_locally_formatted_datetime(instance.updated_on)
 
     def format_taxful_total_price(self, instance, *args, **kwargs):
         return escape(format_money(instance.taxful_total_price))

--- a/shoop/front/locale/en/LC_MESSAGES/django.po
+++ b/shoop/front/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-11 12:32+0000\n"
+"POT-Creation-Date: 2016-04-18 22:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -19,11 +19,50 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
-msgid "Abandoned Basket Value"
+msgid "Abandoned Cart Value"
 msgstr ""
 
 #, python-brace-format
-msgid "Based on {b} baskets over the last {d} days"
+msgid "Based on {b} carts over the last {d} days"
+msgstr ""
+
+msgid "Carts"
+msgstr ""
+
+msgid "Show carts"
+msgstr ""
+
+msgid "yes"
+msgstr ""
+
+msgid "no"
+msgstr ""
+
+msgid "Created on"
+msgstr ""
+
+msgid "Last updated on"
+msgstr ""
+
+msgid "Abandoned"
+msgstr ""
+
+msgid "Shop"
+msgstr ""
+
+msgid "Product count"
+msgstr ""
+
+msgid "Customer"
+msgstr ""
+
+msgid "Orderer"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "Ordered"
 msgstr ""
 
 #, python-format

--- a/shoop/utils/i18n.py
+++ b/shoop/utils/i18n.py
@@ -8,10 +8,12 @@
 
 import babel
 import babel.numbers
+from babel.dates import format_datetime
 from babel.numbers import format_currency
 from django.apps import apps
 from django.utils import translation
 from django.utils.lru_cache import lru_cache
+from django.utils.timezone import localtime
 from django.views.decorators.cache import cache_page
 from django.views.i18n import javascript_catalog
 
@@ -59,6 +61,13 @@ def format_percent(value, digits=0):
     pattern = locale.percent_formats.get(None).pattern
     new_pattern = pattern.replace("0", "0." + (digits * "0"))
     return babel.numbers.format_percent(value, new_pattern, locale)
+
+
+def get_locally_formatted_datetime(datetime):
+    """
+    Return a formatted, localized version of datetime based on the current context.
+    """
+    return format_datetime(localtime(datetime), locale=get_current_babel_locale())
 
 
 def format_money(amount, digits=None, widen=0, locale=None):

--- a/shoop_tests/admin/test_picotable.py
+++ b/shoop_tests/admin/test_picotable.py
@@ -120,3 +120,15 @@ def test_picotable_range_filter(rf, regular_user):
 def test_column_is_user_friendly():
     with pytest.raises(NameError):
         Column(id="foo", title="bar", asdf=True)
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("regular_user")
+def test_picotable_no_mobile_link_for_missing_object_url(rf, admin_user, regular_user):
+    pico = get_pico(rf)
+    pico.get_object_url = lambda object: "http://www.fakeurl.com"
+    data = pico.get_data({"perPage": 100, "page": 1})
+    assert data["items"][0]["_linked_in_mobile"]
+
+    pico.get_object_url = None
+    data = pico.get_data({"perPage": 100, "page": 1})
+    assert not data["items"][0]["_linked_in_mobile"]


### PR DESCRIPTION
Add an admin carts module that allows merchants to monitor abanded
user carts, total sales, date since last update, and other
useful information.

Refs SHOOP-2237