### PR TITLE
Admin: Enable deleting unused shipping and payment methods (SHOOP-2051)

### DIFF
--- a/shoop/admin/modules/services/__init__.py
+++ b/shoop/admin/modules/services/__init__.py
@@ -11,7 +11,9 @@ from __future__ import unicode_literals
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.admin.base import AdminModule, MenuEntry
-from shoop.admin.utils.urls import derive_model_url, get_edit_and_list_urls
+from shoop.admin.utils.urls import (
+    admin_url, derive_model_url, get_edit_and_list_urls
+)
 from shoop.core.models import PaymentMethod, ShippingMethod
 
 
@@ -26,7 +28,13 @@ class ServiceModule(AdminModule):
     url_name_prefix = None
 
     def get_urls(self):
-        return get_edit_and_list_urls(
+        return [
+            admin_url(
+                "%s/(?P<pk>\d+)/delete/$" % self.url_prefix,
+                self.view_template % "Delete",
+                name=self.name_template % "delete"
+            )
+        ] + get_edit_and_list_urls(
             url_prefix=self.url_prefix,
             view_template=self.view_template,
             name_template=self.name_template

--- a/shoop/admin/modules/services/views/__init__.py
+++ b/shoop/admin/modules/services/views/__init__.py
@@ -6,12 +6,15 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+from ._delete import PaymentMethodDeleteView, ShippingMethodDeleteView
 from ._edit import PaymentMethodEditView, ShippingMethodEditView
 from ._list import PaymentMethodListView, ShippingMethodListView
 
 __all__ = [
+    "PaymentMethodDeleteView",
     "PaymentMethodEditView",
     "PaymentMethodListView",
+    "ShippingMethodDeleteView",
     "ShippingMethodEditView",
     "ShippingMethodListView"
 ]

--- a/shoop/admin/modules/services/views/_delete.py
+++ b/shoop/admin/modules/services/views/_delete.py
@@ -1,0 +1,21 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.core.urlresolvers import reverse_lazy
+from django.views.generic import DeleteView
+
+from shoop.core.models import PaymentMethod, ShippingMethod
+
+
+class PaymentMethodDeleteView(DeleteView):
+    model = PaymentMethod
+    success_url = reverse_lazy("shoop_admin:payment_methods.list")
+
+
+class ShippingMethodDeleteView(DeleteView):
+    model = ShippingMethod
+    success_url = reverse_lazy("shoop_admin:shipping_methods.list")

--- a/shoop/admin/modules/services/views/_edit.py
+++ b/shoop/admin/modules/services/views/_edit.py
@@ -15,6 +15,8 @@ from shoop.admin.modules.services.base_form_part import (
 )
 from shoop.admin.modules.services.behavior_form_part import \
     BehaviorComponentFormPart
+from shoop.admin.toolbar import get_default_edit_toolbar
+from shoop.admin.utils.urls import get_model_url
 from shoop.admin.utils.views import CreateOrUpdateView
 from shoop.apps.provides import get_provide_objects
 from shoop.core.models import PaymentMethod, ShippingMethod
@@ -41,6 +43,12 @@ class ServiceEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
 
     def _get_behavior_form_part(self, form, object):
         return BehaviorComponentFormPart(self.request, form, form._meta.model.__name__.lower(), object)
+
+    def get_toolbar(self):
+        save_form_id = self.get_save_form_id()
+        object = self.get_object()
+        delete_url = get_model_url(object, "delete")
+        return get_default_edit_toolbar(self, save_form_id, delete_url=(delete_url if object.can_delete() else None))
 
 
 class ShippingMethodEditView(ServiceEditView):

--- a/shoop/core/models/_service_payment.py
+++ b/shoop/core/models/_service_payment.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext_lazy as _
 from parler.models import TranslatedFields
 
 from ._order_lines import OrderLineType
-from ._orders import PaymentStatus
+from ._orders import Order, PaymentStatus
 from ._service_base import Service, ServiceChoice, ServiceProvider
 
 
@@ -35,6 +35,9 @@ class PaymentMethod(Service):
     class Meta:
         verbose_name = _("payment method")
         verbose_name_plural = _("payment methods")
+
+    def can_delete(self):
+        return not Order.objects.filter(payment_method=self).exists()
 
     def get_payment_process_response(self, order, urls):
         self._make_sure_is_usable()

--- a/shoop/core/models/_service_shipping.py
+++ b/shoop/core/models/_service_shipping.py
@@ -14,6 +14,7 @@ from parler.models import TranslatedFields
 from shoop.utils.dates import DurationRange
 
 from ._order_lines import OrderLineType
+from ._orders import Order
 from ._service_base import Service, ServiceChoice, ServiceProvider
 
 
@@ -35,6 +36,9 @@ class ShippingMethod(Service):
     class Meta:
         verbose_name = _("shipping method")
         verbose_name_plural = _("shipping methods")
+
+    def can_delete(self):
+        return not Order.objects.filter(shipping_method=self).exists()
 
     def get_shipping_time(self, source):
         """


### PR DESCRIPTION
Do not allow delete if shipping or payment method is linked to order
