### PR TITLE
Front: Enable description and logo for methods in checkout (SHOOP-2406)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -65,6 +65,7 @@ Admin
 Front
 ~~~~~
 
+- Enable description and logo for methods in checkout
 - Add admin view for monitoring customer carts
 - Remove ``get_method_validation_errors`` signal
 - Fix bug at ``get_visible_products`` filter when orderable_only is False

--- a/shoop/themes/classic_gray/static_src/less/classic-gray/methods.less
+++ b/shoop/themes/classic_gray/static_src/less/classic-gray/methods.less
@@ -1,0 +1,35 @@
+div.service-provider {
+    margin: 10px 0 10px 0;
+    img {
+        height: 50px;
+    }
+}
+
+div.method-radio {
+    margin: 0 0 0 30px;
+    label {
+        display: inline-flex;
+        margin: 10px 0 10px 0;
+        width: 100%;
+        img {
+            height: 50px;
+        }
+        input {
+            margin: 20px 0 0 0;
+        }
+        span.label-text {
+            display: block;
+            list-style: none;
+            padding: 0 0 0 10px;
+            span.title {
+                display: list-item;
+                span.price {
+                    font-weight: bold;
+                }
+            }
+            span.description {
+                display: list-item;
+            }
+        }
+    }
+}

--- a/shoop/themes/classic_gray/static_src/less/style.less
+++ b/shoop/themes/classic_gray/static_src/less/style.less
@@ -81,3 +81,4 @@
 @import "classic-gray/user-account.less";
 @import "classic-gray/carousel.less";
 @import "classic-gray/social-media-links.less";
+@import "classic-gray/methods.less";

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/method_choice.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/method_choice.jinja
@@ -1,0 +1,40 @@
+<div id="id_{{ field_name }}">
+{% for service_provider, services in grouped_methods.items() %}
+    <div class="service-provider">
+        {% if service_provider.logo %}
+            {% set service_provider_logo = service_provider.logo|thumbnail(size=(0,100)) %}
+            <img class="image" src="{{ service_provider_logo }}" alt="{{ service_provider.name }}">
+        {% else %}
+            <h3>{{ service_provider.name }}</h3>
+        {% endif %}
+    </div>
+    <div class="radio method-radio">
+    {% for service in services %}
+        <label for="id_{{ field_name }}_{{ service.id }}">
+            <input
+                {% if current_value == service.id %}checked=checked{% endif %}
+                name="{{ field_name }}"
+                id="id_{{ field_name }}_{{ service.id }}"
+                type="radio" value="{{ service.id }}">
+            {% if service.logo %}
+                {% set service_logo = service.logo|thumbnail(size=(0,100)) %}
+                <img class="image" src="{{ service_logo }}" alt="{{ service.name }}">
+            {% endif %}
+            <span class="label-text">
+                <span class="title">
+                    <span class="name">{{ service.name }}</span>
+                    {% if show_prices() %}
+                        {% set price_info = service.get_total_cost(basket) %}
+                        <span class="price">{{ price_info.price|money }}</span>
+                    {% endif %}
+                </span>
+                <small class="description">
+                    {{ service.description }}
+                </small>
+            </span>
+        </label>
+    {% endfor %}
+    </div>
+    <hr>
+{% endfor %}
+</div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/methods.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/methods.jinja
@@ -12,7 +12,7 @@
                     </h2>
                 </div>
                 <div class="panel-body">
-                    {{ bs3.field(form.shipping_method) }}
+                    {{ form.shipping_method }}
                 </div>
             </div>
         </div>
@@ -24,7 +24,7 @@
                     </h2>
                 </div>
                 <div class="panel-body">
-                    {{ bs3.field(form.payment_method) }}
+                    {{ form.payment_method }}
                 </div>
             </div>
             </div>

--- a/shoop_tests/front/test_methods_phase.py
+++ b/shoop_tests/front/test_methods_phase.py
@@ -1,0 +1,51 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+
+from bs4 import BeautifulSoup
+from django.utils.translation import activate
+
+from shoop.front.checkout.methods import MethodsPhase
+from shoop.testing.factories import get_payment_method, get_shipping_method, get_default_shop
+from shoop.testing.utils import apply_request_middleware
+
+SHIPPING_DATA = {
+    "name": "Home delivery",
+    "description": "Delivery takes 3 years, sorry.",
+}
+
+PAYMENT_DATA = {
+    "name": "Cash",
+    "description": "No coins!",
+}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("get_method,data,method_id,", [
+    (get_shipping_method, SHIPPING_DATA, "id_shipping_method"),
+    (get_payment_method, PAYMENT_DATA, "id_payment_method")
+])
+def test_method_phase_basic(rf, get_method, data, method_id):
+    activate("en")
+    shop = get_default_shop()
+    method = get_method(shop, price=0, name=data["name"])
+    method.description = data["description"]
+    method.save()
+    assert method.enabled
+
+    view = MethodsPhase.as_view()
+    request = apply_request_middleware(rf.get("/"))
+    response = view(request=request)
+    if hasattr(response, "render"):
+        response.render()
+    assert response.status_code in [200, 302]
+    soup = BeautifulSoup(response.content)
+    method_soup = soup.find("div", {"id": method_id})
+    assert data["name"] in method_soup.text
+    assert data["description"] in method_soup.text
+    assert soup.find("input", {"id": "%s_%s" % (method_id, method.pk)})


### PR DESCRIPTION
* Create custom method widget to render method logo and description in
checkout.
* Group methods by service provider and also show service provider
logo or name at the methods phase in checkout