### PR TITLE
Admin: In service admin set delete url to None in new mode

### DIFF
--- a/shoop/admin/modules/services/views/_edit.py
+++ b/shoop/admin/modules/services/views/_edit.py
@@ -47,7 +47,7 @@ class ServiceEditView(SaveFormPartsMixin, FormPartsViewMixin, CreateOrUpdateView
     def get_toolbar(self):
         save_form_id = self.get_save_form_id()
         object = self.get_object()
-        delete_url = get_model_url(object, "delete")
+        delete_url = get_model_url(object, "delete") if object.pk else None
         return get_default_edit_toolbar(self, save_form_id, delete_url=(delete_url if object.can_delete() else None))
 
 


### PR DESCRIPTION
New services couldn't be created since the delete url is not available
in new mode.

Refs SHOOP-2051 / SHOOP-2418