### PR TITLE
Core: Fix for updating order line from product in shortcuts (SHOOP-2443)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Order line text is not set for package products
 - Add new Service API and implement shipping and payments with it
 - Remove BaseMethodModule based API (``shoop.core.methods``)
 - Add management command to generate bought with relations

--- a/shoop/core/shortcuts/__init__.py
+++ b/shoop/core/shortcuts/__init__.py
@@ -36,7 +36,7 @@ def update_order_line_from_product(
     order_line.product = product
     order_line.quantity = quantity
     order_line.sku = product.sku
-    order_line.name = product.safe_translation_getter("name") or product.sku
+    order_line.text = product.safe_translation_getter("name") or product.sku
     order_line.accounting_identifier = product.accounting_identifier
     order_line.require_verification = bool(getattr(product, "require_verification", False))
     order_line.verified = False

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -49,6 +49,8 @@ def create_order(request, creator, customer, product):
         product=product,
         quantity=5,
         supplier=supplier)
+
+    assert product_order_line.text == product.safe_translation_getter("name")
     product_order_line.base_unit_price = shop.create_price(100)
     assert product_order_line.price.value > 0
     product_order_line.save()


### PR DESCRIPTION
Assing product name into order line text instead of name