### PR TITLE
Classic gray: Fix initial config for cross sells plugin

### DIFF
--- a/shoop/front/template_helpers/product.py
+++ b/shoop/front/template_helpers/product.py
@@ -53,7 +53,7 @@ def is_visible(context, product):
 def get_product_cross_sells(
         context, product, relation_type=ProductCrossSellType.RELATED,
         count=4, orderable_only=True):
-    rtype = _map_relation_type(relation_type)
+    rtype = map_relation_type(relation_type)
     related_product_ids = list((
         ProductCrossSell.objects
         .filter(product1=product, type=rtype)
@@ -74,7 +74,7 @@ def get_product_cross_sells(
     return related_products[:count]
 
 
-def _map_relation_type(relation_type):
+def map_relation_type(relation_type):
     """
     Map relation type to enum value.
 

--- a/shoop/themes/classic_gray/plugins.py
+++ b/shoop/themes/classic_gray/plugins.py
@@ -12,6 +12,7 @@ from shoop.core.models import ProductCrossSell, ProductCrossSellType
 from shoop.front.template_helpers.general import (
     get_best_selling_products, get_newest_products, get_random_products
 )
+from shoop.front.template_helpers.product import map_relation_type
 from shoop.xtheme import TemplatedPlugin
 from shoop.xtheme.plugins.forms import TranslatableField
 
@@ -67,12 +68,25 @@ class ProductCrossSellsPlugin(TemplatedPlugin):
                                               required=False))
     ]
 
+    def __init__(self, config):
+        relation_type = config.get("type", None)
+        if relation_type:
+            # Map initial config string to enum type
+            try:
+                type = map_relation_type(relation_type)
+            except AttributeError:
+                type = ProductCrossSellType.RELATED
+            config["type"] = type
+        super(ProductCrossSellsPlugin, self).__init__(config)
+
     def get_context_data(self, context):
         count = self.config.get("count", 4)
         product = context.get("product", None)
         orderable_only = self.config.get("orderable_only", True)
-        type = self.config.get("type")
-        if not isinstance(type, ProductCrossSellType):
+        relation_type = self.config.get("type")
+        try:
+            type = map_relation_type(relation_type)
+        except AttributeError:
             type = ProductCrossSellType.RELATED
         return {
             "request": context["request"],

--- a/shoop_tests/themes/classic_gray/test_plugins.py
+++ b/shoop_tests/themes/classic_gray/test_plugins.py
@@ -7,7 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 import pytest
 
-from shoop.core.models import Product, ProductCrossSell, StockBehavior
+from shoop.core.models import (
+    Product, ProductCrossSell, ProductCrossSellType, StockBehavior
+)
 from shoop.testing.factories import create_product, get_default_shop
 from shoop.themes.classic_gray.plugins import ProductCrossSellsPlugin
 from shoop_tests.front.fixtures import get_jinja_context
@@ -21,7 +23,7 @@ def test_cross_sell_plugin_renders():
     shop = get_default_shop()
     product = create_product("test-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
     computed = create_product("test-computed-sku", shop=shop, stock_behavior=StockBehavior.UNSTOCKED)
-    type = ProductCrossSell.type.field.enum.COMPUTED
+    type = ProductCrossSellType.COMPUTED
 
     ProductCrossSell.objects.create(product1=product, product2=computed, type=type)
     assert ProductCrossSell.objects.filter(product1=product, type=type).count() == 1
@@ -29,3 +31,11 @@ def test_cross_sell_plugin_renders():
     context = get_jinja_context(product=product)
     rendered  = ProductCrossSellsPlugin({"type": type}).render(context)
     assert computed.sku in rendered
+
+
+def test_cross_sell_plugin_accepts_initial_config_as_string_or_enum():
+    plugin = ProductCrossSellsPlugin({"type": "computed"})
+    assert plugin.config["type"] == ProductCrossSellType.COMPUTED
+
+    plugin = ProductCrossSellsPlugin({"type": ProductCrossSellType.RECOMMENDED})
+    assert plugin.config["type"] == ProductCrossSellType.RECOMMENDED


### PR DESCRIPTION
Fix the inital configuriaton for the cross sells plugin.

Currently, configuration is stored as an enum, but initial settings
are received as a string. These are now mapped to the correct enum
type on initialization.

Refs SHOOP-2409