### PR TITLE
Update requirements more (SHOOP-2150)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,11 +92,7 @@ REQUIRES = [
     # our custom get_success_url
     'django-registration-redux>=1.2,<1.4',
     'django-timezone-field>=1.2,<2',
-
-    # djangorestframework>=3.3.0 does not work with
-    # django-parler-rest 1.3a1 because compat.OrderedDict was dropped
-    'djangorestframework>=3.1,<3.3.0',
-
+    'djangorestframework>=3.1,<4',
     'factory-boy>=2.5,<3',
     'fake-factory>=0.5.0,<0.5.4',
     'Jinja2>=2.8,<3',

--- a/setup.py
+++ b/setup.py
@@ -107,18 +107,18 @@ REQUIRES = [
 REQUIRES_FOR_PYTHON2_ONLY = [
     # enum34 1.1 or newer does not currently work. See
     # https://github.com/hzdg/django-enumfields/pull/44
-    'enum34~=1.0,<1.1',
+    'enum34>=1.0,<1.1',
 ]
 
 EXTRAS_REQUIRE = {
     ':python_version=="2.7"': REQUIRES_FOR_PYTHON2_ONLY,
     'docs': [
-        'Sphinx~=1.3',
+        'Sphinx>=1.3,<2',
     ],
     'testing': utils.get_test_requirements_from_tox_ini(TOPDIR),
     'coding-style': [
-        'flake8~=2.4',
-        'pep8-naming~=0.2',
+        'flake8>=2.4,<3',
+        'pep8-naming>=0.2,<1',
     ],
 }
 EXTRAS_REQUIRE['everything'] = list(


### PR DESCRIPTION
Remove couple more usages of "~=" version specifiers which were
forgotten in commit b1508010.

Allow newer djangorestframework, since it now works, as long as also
django-parler-rest is updated to 1.3.