### PR TITLE
Admin: Fix contact detail page with many groups (SHOOP-2397)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -52,6 +52,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug: Detail page of contact with multiple groups fails on Python 3
 - Enable add/edit for weight based behavior component through service admin
 - Add ``admin_contact_group_form_part`` provider for ``ContactGroup`` admin
 - Redo shipping and payment method management

--- a/shoop/admin/modules/contacts/views/detail.py
+++ b/shoop/admin/modules/contacts/views/detail.py
@@ -83,6 +83,8 @@ class ContactDetailView(DetailView):
         user = getattr(self.object, "user", None)
         if user:
             order_q |= Q(creator=user)
+        context["contact_groups"] = sorted(
+            self.object.groups.all(), key=(lambda x: force_text(x)))
         context["orders"] = Order.objects.filter(order_q).order_by("-id")
         context["toolbar"] = ContactDetailToolbar(contact=self.object)
         context["title"] = "%s: %s" % (

--- a/shoop/admin/templates/shoop/admin/contacts/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/contacts/detail.jinja
@@ -9,7 +9,8 @@
                     {{ info_row(_("Full Name"), contact.full_name) }}
                     {{ info_row(_("Phone"), contact.phone, "tel:" ~ contact.phone) }}
                     {{ info_row(_("Email"), contact.email, "mailto:" ~ contact.email) }}
-                    {{ info_row(_("Groups"), contact.groups.all()|sort|join(", ")|default(_("No groups"), True)) }}
+                    {% set groups = render_objects(contact_groups) %}
+                    {{ info_row(_("Groups"), groups|default(_("No groups"), True)) }}
                     {{ info_row(_("Bound User"), contact.user, shoop_admin.model_url(contact.user) if contact.user else None) }}
                     {{ info_row(_("Merchant Notes"), contact.merchant_notes) }}
                     </tbody>
@@ -46,3 +47,16 @@
         </div>
     {% endcall %}
 {% endblock %}
+
+{%- macro render_objects(objs) -%}
+    {%- for obj in objs -%}
+        {{- render_object(obj) -}}
+        {%- if not loop.last %}, {% endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+
+{%- macro render_object(obj) -%}
+    <a href="{{ shoop_admin.model_url(obj) }}">
+        {{- obj -}}
+    </a>
+{%- endmacro -%}

--- a/shoop/core/models/_base.py
+++ b/shoop/core/models/_base.py
@@ -44,10 +44,15 @@ class TranslatableShoopModel(ShoopModel, parler.models.TranslatableModel):
 
     def __str__(self):
         name = self.safe_translation_getter(self.name_attr, any_language=True)
-        if name is None:
+        if name is not None:
+            # Ensure no lazy objects are returned
+            name = force_text(name)
+        if not name:
+            # Ensure no empty value is returned
             identifier = getattr(self, self.identifier_attr, None)
-            return '{}:{}'.format(type(self).__name__, identifier)
-        return force_text(name)  # ensure no lazy objects are returned
+            suffix = ' "{}"'.format(identifier) if identifier else ''
+            return self._meta.verbose_name + suffix
+        return name
 
     class Meta:
         abstract = True

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -12,6 +12,7 @@ from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from enumfields import Enum, EnumField
+from parler.managers import TranslatableQuerySet
 from parler.models import TranslatedFields
 from timezone_field.fields import TimeZoneField
 
@@ -32,7 +33,7 @@ PROTECTED_CONTACT_GROUP_IDENTIFIERS = [
 ]
 
 
-class ContactGroupQuerySet(models.QuerySet):
+class ContactGroupQuerySet(TranslatableQuerySet):
     def with_price_display_options(self):
         return self.filter(
             models.Q(show_prices_including_taxes__isnull=False) |

--- a/shoop_tests/admin/test_contact_page.py
+++ b/shoop_tests/admin/test_contact_page.py
@@ -5,13 +5,52 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+
+from __future__ import unicode_literals
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.core import mail
+from django.utils import translation
 
+from shoop.admin.modules.contacts.views.detail import ContactDetailView
 from shoop.admin.modules.contacts.views.reset import ContactResetPasswordView
+from shoop.core.models import ContactGroup
 from shoop.testing.factories import create_random_person, get_default_shop
 from shoop.testing.utils import apply_request_middleware
+
+
+@pytest.mark.django_db
+def test_contact_details_view_with_many_groups(rf, admin_user):
+    get_default_shop()
+    person = create_random_person()
+    person.groups.add(
+        ContactGroup.objects.create(name="Czz Group"),
+        ContactGroup.objects.create(name="Azz Group"),
+        ContactGroup.objects.create(name="Bzz Group"),
+        ContactGroup.objects.language('fi').create(name="Dzz ryhmä"),
+    )
+
+    # Group with name in two languages
+    grp_e = ContactGroup.objects.language('en').create(name="Ezz Group")
+    grp_e.set_current_language('fi')
+    grp_e.name = "Ezz ryhmä"
+    grp_e.save()
+    person.groups.add(grp_e)
+
+    request = apply_request_middleware(rf.get("/"), user=admin_user)
+    with translation.override('en'):
+        view_func = ContactDetailView.as_view()
+        response = view_func(request, pk=person.pk)
+    content = response.render().content.decode('utf-8')
+    assert "Azz Group" in content
+    assert "Bzz Group" in content
+    assert "Czz Group" in content
+    assert "Dzz ryhmä" in content, "no name in active language, still present"
+    assert "Ezz Group" in content, "rendered with active language"
+    positions = [content.index(x + "zz ") for x in 'ABCDE']
+    assert positions == sorted(positions), "Groups are sorted"
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -147,13 +147,13 @@ def test_person_name_gets_saved():
 def test_contact_group_repr_and_str_no_identifier_no_name():
     cg = ContactGroup()
     assert repr(cg) == '<ContactGroup:None>'
-    assert str(cg) == 'ContactGroup:None'
+    assert str(cg) == 'contact group'
 
 
 def test_contact_group_repr_and_str_has_identifier_no_name():
     cg = ContactGroup(identifier='hello')
     assert repr(cg) == '<ContactGroup:None-hello>'
-    assert str(cg) == 'ContactGroup:hello'
+    assert str(cg) == 'contact group "hello"'
 
 
 def test_contact_group_repr_and_str_no_identifier_has_name():


### PR DESCRIPTION
If contact belongs to multiple groups, the contact details views used to
fail on Python 3, since there was a call `contact.groups.all()|sort` in the
template, which tries to sort ContactGroup objects.  Fix this by adding
sorted contacts to the context and remove sorting from the template.

Also while at it:

  * Render the contact groups as links.
  * Add test case for this.
  * Fix ContactGroupQuerySet to derive from TranslatableQuerySet.

And since I got some problems rendering the details page in Finnish,
because my contact groups didn't have Finnish translations, add a fix
for that too in TranslatableShoopModel.