### PR TITLE
Make tracking codes visible ( SHOOP-2281)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -101,6 +101,7 @@ Xtheme
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 
+- Show tracking codes in order detail
 - Remove ``ProductCrossSellType.COMPUTED`` from cross-sells plugin
 - Update cross-sells plugin to use ``ProductCrossSellType.BOUGHT_WITH``
 - Render prices with the new price rendering template tags

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -53,6 +53,7 @@ Localization
 Admin
 ~~~~~
 
+- Show tracking codes in order detail
 - Fix bug: Show package siblings for variation children
 - Fix bug: Detail page of contact with multiple groups fails on Python 3
 - Enable add/edit for weight based behavior component through service admin

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``get_tracking_codes`` to ``shoop.core.models.Order``
 - Add weight based pricing behavior component
 - Add ``total_gross_weight`` property for ``Source``
 - Fix bug: Order line text is not set for package products

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-25 17:21+0000\n"
+"POT-Creation-Date: 2016-04-28 18:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -997,6 +997,9 @@ msgid "Total Price (taxless)"
 msgstr ""
 
 msgid "Total Price"
+msgstr ""
+
+msgid "Tracking codes"
 msgstr ""
 
 msgid "Order Contents"

--- a/shoop/admin/templates/shoop/admin/orders/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/detail.jinja
@@ -24,6 +24,10 @@
                     {{ info_row(_("Order Status"), order.get_status_display()) }}
                     {{ info_row(_("Payment Status"), order.get_payment_status_display()) }}
                     {{ info_row(_("Shipping Status"), order.get_shipping_status_display()) }}
+                    {% set tracking_codes = order.get_tracking_codes() %}
+                    {% if tracking_codes %}
+                        {{ info_row(_("Tracking codes"), render_objects(tracking_codes)) }}
+                    {% endif %}
                 </dl>
             {% endcall %}
 
@@ -134,3 +138,10 @@
         </div>
     {% endcall %}
 {% endblock %}
+
+{%- macro render_objects(objs) -%}
+    {%- for obj in objs -%}
+        {{- obj -}}
+        {%- if not loop.last %}, {% endif -%}
+    {%- endfor -%}
+{%- endmacro -%}

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -610,6 +610,9 @@ class Order(MoneyPropped, models.Model):
     def get_status_display(self):
         return force_text(self.status)
 
+    def get_tracking_codes(self):
+        return [shipment.tracking_code for shipment in self.shipments.all() if shipment.tracking_code]
+
 
 OrderLogEntry = define_log_model(Order)
 

--- a/shoop/themes/classic_gray/locale/en/LC_MESSAGES/django.po
+++ b/shoop/themes/classic_gray/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-11 12:32+0000\n"
+"POT-Creation-Date: 2016-04-28 18:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
-"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -195,10 +195,10 @@ msgstr ""
 msgid "There are errors"
 msgstr ""
 
-msgid "Shipping"
+msgid "Choose Shipping Method"
 msgstr ""
 
-msgid "Payment"
+msgid "Choose Payment Method"
 msgstr ""
 
 msgid "Errors"
@@ -292,6 +292,9 @@ msgid "Products ordered"
 msgstr ""
 
 msgid "Tax breakdown"
+msgstr ""
+
+msgid "Payment"
 msgstr ""
 
 msgid "Company"
@@ -462,6 +465,9 @@ msgid "Total Price"
 msgstr ""
 
 msgid "Total Price (taxless)"
+msgstr ""
+
+msgid "Tracking codes"
 msgstr ""
 
 msgid "Status"

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/personal_order_history/order_detail.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/personal_order_history/order_detail.jinja
@@ -55,6 +55,10 @@
             {{ info_row(_("Tax Number"), order.tax_number) }}
             {{ price_row(_("Total Price"), order.taxful_total_price) }}
             {{ price_row(_("Total Price (taxless)"), order.taxless_total_price) }}
+            {% set tracking_codes = order.get_tracking_codes() %}
+            {% if tracking_codes %}
+                {{ info_row(_("Tracking codes"), render_objects(tracking_codes)) }}
+            {% endif %}
         </table>
     {% endcall %}
 {% endmacro %}
@@ -176,3 +180,11 @@
         {{ number_cell("", elem) }}
     {%- endif -%}
 {% endmacro %}
+
+{%- macro render_objects(objs) -%}
+    {%- for obj in objs -%}
+        {{- obj -}}
+        {%- if not loop.last %}, {% endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+

--- a/shoop_tests/core/test_tracking_codes.py
+++ b/shoop_tests/core/test_tracking_codes.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+import decimal
+import pytest
+
+from shoop.testing.factories import (
+    add_product_to_order, create_order_with_product, create_product,
+    get_default_product, get_default_supplier,
+)
+
+
+@pytest.mark.django_db
+def test_tracking_codes():
+    product = get_default_product()
+    supplier = get_default_supplier()
+    order = create_order_with_product(
+        product,
+        supplier=supplier,
+        quantity=1,
+        taxless_base_unit_price=10,
+        tax_rate=decimal.Decimal("0.5")
+    )
+    _add_product_to_order(order, "duck-tape-1", 3, order.shop, supplier)
+    _add_product_to_order(order, "water-1", 2, order.shop, supplier)
+
+    order.cache_prices()
+    order.check_all_verified()
+    order.save()
+
+    # Create shipment with tracking code for every product line.
+    product_lines = order.lines.exclude(product_id=None)
+    assert len(product_lines) == 3
+    for line in product_lines:
+        shipment = order.create_shipment(supplier, {line.product: line.quantity})
+        if line.quantity != 3:
+            shipment.tracking_code = "123FI"
+            shipment.save()
+
+    tracking_codes = order.get_tracking_codes()
+    code_count = (len(product_lines)-1)  # We skipped that one
+    assert len(tracking_codes) == code_count
+    assert len([tracking_code for tracking_code in tracking_codes if tracking_code == "123FI"]) == code_count
+
+
+def _add_product_to_order(order, sku, quantity, shop, supplier):
+    product = create_product(
+        sku=sku,
+        shop=shop,
+        supplier=supplier,
+        default_price=3.33,
+    )
+    add_product_to_order(order, supplier, product, quantity=quantity, taxless_base_unit_price=1)


### PR DESCRIPTION
Core: Add ``get_tracking_codes`` to ``shoop.core.models.Order``
Admin: Show tracking codes in order detail
Classic Gray Theme: Show tracking codes in order detail