### PR TITLE
Admin: Show package siblings for variation children

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -52,6 +52,7 @@ Localization
 Admin
 ~~~~~
 
+- Fix bug: Show package siblings for variation children
 - Fix bug: Detail page of contact with multiple groups fails on Python 3
 - Enable add/edit for weight based behavior component through service admin
 - Add ``admin_contact_group_form_part`` provider for ``ContactGroup`` admin

--- a/shoop/admin/modules/products/views/toolbars.py
+++ b/shoop/admin/modules/products/views/toolbars.py
@@ -121,7 +121,7 @@ class EditProductToolbar(Toolbar):
         if (product.is_variation_parent() or product.is_variation_child()):
             for item in self._get_variation_menu_items(product):
                 yield item
-        elif (product.is_package_parent() or product.is_package_child()):
+        if (product.is_package_parent() or product.is_package_child()):
             for item in self._get_package_menu_items(product):
                 yield item
         else:


### PR DESCRIPTION
In case variation children included in some package. ``EditProductToolbar``
show only variation siblings. This makes also package siblings visible for
variation child that is in product package.

Refs SHOOP-2387