### PR TITLE
shoop_setup_utils: Speed-up for setuptools 18.2 or newer

### DIFF
--- a/shoop_setup_utils/finding.py
+++ b/shoop_setup_utils/finding.py
@@ -15,9 +15,11 @@ if hasattr(setuptools, "PackageFinder"):
     # https://bitbucket.org/pypa/setuptools/commits/09e0ab6bb31c3055a19c856e328ba99e225ab8d7
     class FastFindPackages(setuptools.PackageFinder):
         @staticmethod
-        def _all_dirs(base_path):
+        def _candidate_dirs(base_path):
             """
-            Return all dirs in base_path, relative to base_path, but filtering
+            Return all dirs in base_path that might be packages.
+
+            This overrides the base class method to add filtering
             subdirectories matching excludes out _during_ the search.
 
             This makes a significant difference on some file systems
@@ -25,8 +27,14 @@ if hasattr(setuptools, "PackageFinder"):
             """
             items = excludes.walk_excl(base_path, followlinks=True)
             for (root, dirs, files) in items:
+                dirs[:] = [x for x in dirs if '.' not in x]
                 for dir in dirs:
                     yield os.path.relpath(os.path.join(root, dir), base_path)
+
+        @staticmethod
+        def _all_dirs(base_path):
+            # For setuptools < 18.2
+            return FastFindPackages._candidate_dirs(base_path)
 
     def find_packages(*args, **kwargs):
         kwargs.setdefault('exclude', excludes.get_exclude_patterns())


### PR DESCRIPTION
Port our FastFindPackages speed-up to work with newer setuptools.  Since
version 18.2 of setuptools, there is no longer `_all_dirs` function, but
rather `_candidate_dirs` which does more or less the same thing.

This makes all "setup.py" commands, with a fresh setuptools, much faster
when ran from a checkout which has node_modules and bower_components.