### PR TITLE
Simple Supplier: Fix product create view bug

### DIFF
--- a/shoop/simple_supplier/admin_module/forms.py
+++ b/shoop/simple_supplier/admin_module/forms.py
@@ -39,7 +39,7 @@ class SimpleSupplierForm(forms.Form):
         return Supplier.objects.filter(shop_products__product=product, module_identifier="simple_supplier").distinct()
 
     def can_manage_stock(self):
-        return Supplier.objects.filter(module_identifier="simple_supplier").exists()
+        return Supplier.objects.filter(module_identifier="simple_supplier", stock_managed=True).exists()
 
     def get_stock_information(self, supplier, product):
         return get_stock_information_html(supplier, product)
@@ -54,13 +54,14 @@ class SimpleSupplierFormPart(FormPart):
     form = SimpleSupplierForm
 
     def get_form_defs(self):
-        yield TemplatedFormDef(
-            name=self.name,
-            form_class=self.form,
-            template_name="shoop/simple_supplier/admin/product_form_part.jinja",
-            required=False,
-            kwargs={"product": self.object, "request": self.request}
-        )
+        if self.object.pk:  # Don't yield form if product is in new mode
+            yield TemplatedFormDef(
+                name=self.name,
+                form_class=self.form,
+                template_name="shoop/simple_supplier/admin/product_form_part.jinja",
+                required=False,
+                kwargs={"product": self.object, "request": self.request}
+            )
 
     def form_valid(self, form):
         return  # No need to save anything since all stock adjustments are made by AJAX

--- a/shoop_tests/simple_supplier/test_simple_supplier.py
+++ b/shoop_tests/simple_supplier/test_simple_supplier.py
@@ -9,6 +9,7 @@ import decimal
 import pytest
 import random
 
+from shoop.admin.modules.products.views.edit import ProductEditView
 from shoop.core.models import StockBehavior, Supplier
 from shoop.simple_supplier.admin_module.forms import SimpleSupplierForm
 from shoop.simple_supplier.admin_module.views import process_stock_adjustment
@@ -118,3 +119,28 @@ def test_admin_form(rf, admin_user):
     frm = SimpleSupplierForm(product=product, request=request)
     assert len(frm.products) == 1
     assert frm.products[0] == child_product
+
+
+@pytest.mark.django_db
+def test_new_product_admin_form_renders(rf, client, admin_user):
+    """
+    Make sure that no exceptions are raised when creating a new product
+    with simple supplier enabled
+    """
+    request = rf.get("/")
+    request.user = admin_user
+    request.session = client.session
+    view = ProductEditView.as_view()
+    shop = get_default_shop()
+    supplier = get_simple_supplier()
+    supplier.stock_managed = True
+    supplier.save()
+
+    # This should not raise an exception
+    view(request).render()
+
+    supplier.stock_managed = False
+    supplier.save()
+
+    # Nor should this
+    view(request).render()


### PR DESCRIPTION
Fix bug when creating new product with simple supplier set as
default by only rendering stock management form for saved products.

Refs SHOOP-2207