### PR TITLE
Improve shoop_setup_utils for addons (SHOOP-2507)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,12 +66,8 @@ EXCLUDED_PACKAGES = [
     'shoop_tests', 'shoop_tests.*',
 ]
 
-utils.set_exclude_patters([
-    '__pycache__', '*.py[cod]',
-    'node_modules', 'bower_components',
+utils.add_exclude_patters([
     'build', 'doc', 'var',
-    '.tox', '.cache', 'venv*',
-    '.git', '.gitignore',
     'LC_MESSAGES',
     'local_settings.py',
 ])

--- a/shoop_setup_utils/__init__.py
+++ b/shoop_setup_utils/__init__.py
@@ -5,7 +5,9 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from .commands import COMMANDS
-from .excludes import get_exclude_patterns, set_exclude_patters
+from .excludes import (
+    add_exclude_patters, get_exclude_patterns, set_exclude_patters
+)
 from .finding import find_packages
 from .parsing import get_long_description, get_test_requirements_from_tox_ini
 from .resource_building import build_resources
@@ -15,6 +17,7 @@ __all__ = [
     'COMMANDS',
     'build_resources',
     'find_packages',
+    'add_exclude_patters',
     'get_exclude_patterns',
     'get_long_description',
     'get_test_requirements_from_tox_ini',

--- a/shoop_setup_utils/excludes.py
+++ b/shoop_setup_utils/excludes.py
@@ -1,7 +1,19 @@
 import os
 from fnmatch import fnmatch
 
-_EXCLUDE_PATTERNS = []
+_EXCLUDE_PATTERNS = [
+    '__pycache__', '*.py[cod]',
+    'node_modules', 'bower_components',
+    '.tox', '.cache', 'venv*',
+    '.git', '.gitignore',
+]
+
+
+def add_exclude_patters(excludes):
+    global _EXCLUDE_PATTERNS
+    for exclude in excludes:
+        if exclude not in _EXCLUDE_PATTERNS:
+            _EXCLUDE_PATTERNS.append(exclude)
 
 
 def set_exclude_patters(excludes):

--- a/shoop_setup_utils/resource_building.py
+++ b/shoop_setup_utils/resource_building.py
@@ -70,7 +70,7 @@ class Builder(object):
         items = excludes.walk_excl(self.root_directory)
         for (dirpath, dirnames, filenames) in items:
             if 'package.json' in filenames:
-                if dirpath != '.':  # Ignore the root package json
+                if 'generated_resources.txt' in filenames:
                     yield dirpath
 
     def build_dirs(self, directories):


### PR DESCRIPTION
The shoop_setup_utils package provides a nice way to do resource
generating on "setup.py build" phase.  It is used here in Shoop, but it
is also useful for Shoop addons.

Improve it a bit so that is more useful for addons.  See the commit
messages for details.