### PR TITLE
Core: Change ``Shipment`` weight to grams

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Change ``Shipment`` weight measurement field to grams
 - Make ``create_shipment`` for order atomic
 - Add ``shipment_created`` signal
 - Add ``get_tracking_codes`` to ``shoop.core.models.Order``

--- a/shoop/core/migrations/0022_shipment_weight_to_grams.py
+++ b/shoop/core/migrations/0022_shipment_weight_to_grams.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import shoop.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0021_weight_based_pricing'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='shipment',
+            name='weight',
+            field=shoop.core.fields.MeasurementField(default=0, unit='g', verbose_name='weight', max_digits=36, decimal_places=9),
+        ),
+    ]

--- a/shoop/core/models/_shipments.py
+++ b/shoop/core/models/_shipments.py
@@ -43,7 +43,7 @@ class Shipment(models.Model):
     tracking_code = models.CharField(max_length=64, blank=True, verbose_name=_("tracking code"))
     description = models.CharField(max_length=255, blank=True, verbose_name=_("description"))
     volume = MeasurementField(unit="m3", verbose_name=_("volume"))
-    weight = MeasurementField(unit="kg", verbose_name=_("weight"))
+    weight = MeasurementField(unit="g", verbose_name=_("weight"))
     # TODO: documents = models.ManyToManyField(FilerFile)
 
     class Meta:

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -85,7 +85,7 @@ def create_order(request, creator, customer, product):
 
     shipment = order.create_shipment_of_all_products(supplier=supplier)
     assert shipment.total_products == 5, "All products were shipped"
-    assert shipment.weight == product.net_weight * 5, "Gravity works"
+    assert shipment.weight == product.gross_weight * 5, "Gravity works"
     assert not order.get_unshipped_products(), "Nothing was left in the warehouse"
 
     order.create_payment(order.taxful_total_price)


### PR DESCRIPTION
Allow merchant use different measurement units for products. In case
merchant decides to use pounds we can't do any grams to kilograms
conversion in backend.

Unify Shoop weight based ``MeasurementField``s to use grams so we don't
need to do unit conversions.

Refs SHOOP-2494 / SHOOP-2511