### PR TITLE
Admin: Hide invalid package product choices (SHOOP-2389)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -55,6 +55,7 @@ Localization
 Admin
 ~~~~~
 
+- Hide invalid choices for package products
 - Fix bug: Fix convert to parent menu items in ``EditProductToolbar``
 - Show tracking codes in order detail
 - Fix bug: Show package siblings for variation children

--- a/shoop/admin/forms/widgets.py
+++ b/shoop/admin/forms/widgets.py
@@ -7,6 +7,8 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+import json
+
 from django.forms import HiddenInput, Widget
 from django.utils.encoding import force_text
 from django.utils.html import escape
@@ -16,7 +18,7 @@ from filer.models import File
 
 from shoop.admin.utils.forms import flatatt_filter
 from shoop.admin.utils.urls import get_model_url, NoModelUrl
-from shoop.core.models import Contact, Product
+from shoop.core.models import Contact, Product, ProductMode
 
 
 class BasePopupChoiceWidget(Widget):
@@ -117,3 +119,7 @@ class ContactChoiceWidget(BasePopupChoiceWidget):
             "icon": icon,
             "text": _("Select")
         }
+
+
+class PackageProductChoiceWidget(ProductChoiceWidget):
+    filter = json.dumps({"modes": [ProductMode.NORMAL.value, ProductMode.VARIATION_CHILD.value]})

--- a/shoop/admin/modules/products/forms/package_forms.py
+++ b/shoop/admin/modules/products/forms/package_forms.py
@@ -13,7 +13,7 @@ from django.contrib import messages
 from django.db.transaction import atomic
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.admin.forms.widgets import ProductChoiceWidget
+from shoop.admin.forms.widgets import PackageProductChoiceWidget
 from shoop.admin.modules.products.utils import clear_existing_package
 from shoop.core.excs import ImpossibleProductModeException, Problem
 from shoop.core.models import Product
@@ -24,7 +24,7 @@ from .parent_forms import ProductChildBaseFormSet
 class PackageChildForm(forms.Form):
     child = forms.ModelChoiceField(
         queryset=Product.objects.all(),
-        widget=ProductChoiceWidget(),
+        widget=PackageProductChoiceWidget(),
         label="",
         required=True,
     )

--- a/shoop/admin/modules/products/views/list.py
+++ b/shoop/admin/modules/products/views/list.py
@@ -7,6 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 from __future__ import unicode_literals
 
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
 from shoop.admin.utils.picotable import ChoicesFilter, Column, TextFilter
@@ -28,8 +29,13 @@ class ProductListView(PicotableListView):
     ]
 
     def get_queryset(self):
-        shop_id = self.get_filter().get("shop")
+        filter = self.get_filter()
+        shop_id = filter.get("shop")
         qs = Product.objects.all_except_deleted()
+        q = Q()
+        for mode in filter.get("modes", []):
+            q = q | Q(mode=mode)
+        qs = qs.filter(q)
         if shop_id:
             qs = qs.filter(shop_products__shop_id=int(shop_id))
         return qs


### PR DESCRIPTION
When adding products to a package product, hide invalid choices,
including variation parents and package products.

Refs SHOOP-2389

Notes: There might be a better way to do this. The browse widget has a built-in "filter" parameter, however since we need to use Q objects to filter multiple valid modes, I had to implement a workaround by just indicating the "mode" in the filter setting.