### PR TITLE
Order printouts: Fix tax rate percent display

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -124,6 +124,7 @@ Simple Supplier
 Order Printouts
 ~~~~~~~~~~~~~~~
 
+- Output tax rates as percentages
 - Add basic support to create PDF printouts
 - Add admin module to print order shipments and confirmation
 

--- a/shoop/order_printouts/templates/shoop/order_printouts/admin/macros.jinja
+++ b/shoop/order_printouts/templates/shoop/order_printouts/admin/macros.jinja
@@ -92,7 +92,7 @@
                     <td width="60">{{ ol.text }}</td>
                     {% if ol.quantity != 0 %}
                         <td width="10" class="align-right">{{ ol.quantity|floatformat(2) }}</td>
-                        <td width="10" class="align-right">{{ ol.tax_rate }}%</td>
+                        <td width="10" class="align-right">{{ ol.tax_rate|percent(ndigits=3) }}</td>
                         <td width="10" class="align-right">{{ ol.taxful_price|money }}</td>
                     {% else %}
                         <td width="30"></td>


### PR DESCRIPTION
Display tax rates in order printouts as percentages.

Refs SHOOP-2490