### PR TITLE
Core: Convert ``Shipment`` weights to kilograms (SHOOP-2494 / SHOOP-2511)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Convert ``Shipment`` weight to kilograms
 - Make ``create_shipment`` for order atomic
 - Add ``shipment_created`` signal
 - Add ``get_tracking_codes`` to ``shoop.core.models.Order``

--- a/shoop/core/models/_shipments.py
+++ b/shoop/core/models/_shipments.py
@@ -19,6 +19,7 @@ from shoop.core.fields import MeasurementField, QuantityField
 __all__ = ("Shipment", "ShipmentProduct")
 
 CUBIC_MM_TO_CUBIC_METERS_DIVISOR = Decimal("1000000000")
+GRAMS_TO_KILOGRAMS_DIVISOR = 1000
 
 
 class ShipmentStatus(Enum):
@@ -70,7 +71,7 @@ class Shipment(models.Model):
             total_volume += quantity * volume
             total_weight += quantity * weight
         self.volume = total_volume
-        self.weight = total_weight
+        self.weight = total_weight / GRAMS_TO_KILOGRAMS_DIVISOR
 
     @property
     def total_products(self):

--- a/shoop_tests/core/test_basic_order.py
+++ b/shoop_tests/core/test_basic_order.py
@@ -5,6 +5,7 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import decimal
 import pytest
 from django.utils.timezone import now
 
@@ -85,7 +86,7 @@ def create_order(request, creator, customer, product):
 
     shipment = order.create_shipment_of_all_products(supplier=supplier)
     assert shipment.total_products == 5, "All products were shipped"
-    assert shipment.weight == product.net_weight * 5, "Gravity works"
+    assert shipment.weight == product.gross_weight * 5 / 1000, "Gravity works"
     assert not order.get_unshipped_products(), "Nothing was left in the warehouse"
 
     order.create_payment(order.taxful_total_price)

--- a/shoop_tests/core/test_orders.py
+++ b/shoop_tests/core/test_orders.py
@@ -136,7 +136,7 @@ def test_basic_order():
     assert order.taxful_total_price == TaxfulPrice(PRODUCTS_TO_SEND * (10 + 5) - 30, currency)
     shipment = order.create_shipment_of_all_products(supplier=supplier)
     assert shipment.total_products == PRODUCTS_TO_SEND, "All products were shipped"
-    assert shipment.weight == product.net_weight * PRODUCTS_TO_SEND, "Gravity works"
+    assert shipment.weight == product.gross_weight * PRODUCTS_TO_SEND / 1000, "Gravity works"
     assert not order.get_unshipped_products(), "Nothing was left in the warehouse"
     order.shipping_status = ShippingStatus.FULLY_SHIPPED
     order.create_payment(order.taxful_total_price)

--- a/shoop_tests/core/test_shipment_weights.py
+++ b/shoop_tests/core/test_shipment_weights.py
@@ -22,7 +22,7 @@ def test_shipment_weights_separate_shipments():
     product_lines = order.lines.exclude(product_id=None)
     for line in product_lines:
         shipment = order.create_shipment(supplier, {line.product: line.quantity})
-        assert shipment.weight == (line.quantity * line.product.gross_weight)
+        assert shipment.weight == (line.quantity * line.product.gross_weight / 1000)
 
 
 @pytest.mark.django_db
@@ -32,8 +32,12 @@ def test_shipment_weights_ship_all():
     order = _get_order(shop, supplier)
     shipment = order.create_shipment_of_all_products(supplier=supplier)
     assert shipment.weight == sum(
-        [(product_data["quantity"] * product_data["gross_weight"]) for product_data in _get_product_data()]
+        [_get_weight_from_product_data(product_data) for product_data in _get_product_data()]
     )
+
+
+def _get_weight_from_product_data(product_data):
+    return (product_data["quantity"] * product_data["gross_weight"] / 1000)
 
 
 def _get_order(shop, supplier):


### PR DESCRIPTION
Instead of ``Product`` and ``ShipmentProduct`` ``Shipment`` weights  are
stored as a kilograms.

Add the missing grams to kilograms conversion in ``Shipment.cache_values``