### PR TITLE
Campaigns: Add automatic update for sales range groups (SHOOP-2439)

### DIFF
--- a/doc/api/shoop.admin.modules.services.rst
+++ b/doc/api/shoop.admin.modules.services.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
 
     shoop.admin.modules.services.views
+    shoop.admin.modules.services.weight_based_pricing
 
 Submodules
 ----------

--- a/doc/api/shoop.admin.modules.services.weight_based_pricing.rst
+++ b/doc/api/shoop.admin.modules.services.weight_based_pricing.rst
@@ -1,4 +1,4 @@
-gitshoop.admin.modules.services.weight_based_pricing package
+shoop.admin.modules.services.weight_based_pricing package
 =========================================================
 
 Module contents

--- a/doc/api/shoop.campaigns.rst
+++ b/doc/api/shoop.campaigns.rst
@@ -45,6 +45,14 @@ shoop.campaigns.signal_handlers module
     :undoc-members:
     :show-inheritance:
 
+shoop.campaigns.utils module
+----------------------------
+
+.. automodule:: shoop.campaigns.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 Module contents
 ---------------

--- a/shoop/campaigns/models/contact_group_sales_ranges.py
+++ b/shoop/campaigns/models/contact_group_sales_ranges.py
@@ -11,8 +11,9 @@ from django.db import models
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 
+from shoop.campaigns.utils import assign_to_group_based_on_sales
 from shoop.core.fields import MoneyValueField
-from shoop.core.models import ContactGroup, Shop
+from shoop.core.models import Contact, ContactGroup, Shop
 from shoop.core.models._contacts import PROTECTED_CONTACT_GROUP_IDENTIFIERS
 
 
@@ -40,6 +41,8 @@ class ContactGroupSalesRange(models.Model):
     def save(self, *args, **kwargs):
         self.clean()
         super(ContactGroupSalesRange, self).save(*args, **kwargs)
+        for customer in Contact.objects.all():
+            assign_to_group_based_on_sales(ContactGroupSalesRange, self.shop, customer, sales_range=self)
 
     def clean(self):
         super(ContactGroupSalesRange, self).clean()

--- a/shoop/campaigns/signal_handlers.py
+++ b/shoop/campaigns/signal_handlers.py
@@ -6,37 +6,13 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from django.db.models import Q, Sum
+from shoop.campaigns.models.contact_group_sales_ranges import \
+    ContactGroupSalesRange
 
-from shoop.campaigns.models import ContactGroupSalesRange
-from shoop.core.models import Payment
-
-
-def _get_total_sales(shop, customer):
-    aggregated_sales = Payment.objects.filter(
-        order__customer=customer,
-        order__shop=shop,
-    ).aggregate(total_sales=Sum("amount_value"))
-    return aggregated_sales["total_sales"] or 0
-
-
-def _assign_to_group_based_on_sales(shop, customer):
-    total_sales = _get_total_sales(shop, customer)
-
-    # Only ranges with sales bigger than min_value
-    query = Q(min_value__lte=total_sales)
-    # Ranges with max lower than sales or None
-    query &= Q(Q(max_value__gt=total_sales) | Q(max_value__isnull=True))
-
-    matching_pks = set(ContactGroupSalesRange.objects.active(shop).filter(query).values_list("pk", flat=True))
-    for sales_range in ContactGroupSalesRange.objects.filter(pk__in=matching_pks):
-        sales_range.group.members.add(customer)
-
-    for sales_range in ContactGroupSalesRange.objects.active(shop).exclude(pk__in=matching_pks):
-        sales_range.group.members.remove(customer)
+from .utils import assign_to_group_based_on_sales
 
 
 def update_customers_groups(sender, instance, **kwargs):
     if not instance.order.customer:
         return
-    _assign_to_group_based_on_sales(instance.order.shop, instance.order.customer)
+    assign_to_group_based_on_sales(ContactGroupSalesRange, instance.order.shop, instance.order.customer)

--- a/shoop/campaigns/utils.py
+++ b/shoop/campaigns/utils.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from django.db.models import Q, Sum
+
+from shoop.core.models import Payment
+
+
+def get_total_sales(shop, customer):
+    aggregated_sales = Payment.objects.filter(
+        order__customer=customer,
+        order__shop=shop,
+    ).aggregate(total_sales=Sum("amount_value"))
+    return aggregated_sales["total_sales"] or 0
+
+
+def assign_to_group_based_on_sales(cls, shop, customer, sales_range=None):
+    total_sales = get_total_sales(shop, customer)
+
+    # Only ranges with sales bigger than min_value
+    query = Q(min_value__lte=total_sales)
+    # Ranges with max lower than sales or None
+    query &= Q(Q(max_value__gt=total_sales) | Q(max_value__isnull=True))
+
+    qs = cls.objects.active(shop)
+    if sales_range:
+        qs = qs.filter(pk=sales_range.pk)
+
+    matching_pks = set(qs.filter(query).values_list("pk", flat=True))
+    for sales_range in cls.objects.filter(pk__in=matching_pks):
+        sales_range.group.members.add(customer)
+
+    for sales_range in cls.objects.active(shop).exclude(pk__in=matching_pks):
+        sales_range.group.members.remove(customer)


### PR DESCRIPTION
Add automatic update to customer groups based on sales range when
sales ranges are created or edited.

Refs SHOOP-2439