### PR TITLE
Admin: Enable order cancelation in Order edit view (SHOOP-2401)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -57,6 +57,7 @@ Localization
 Admin
 ~~~~~
 
+- Enable order cancelation in Order edit view
 - Hide invalid choices for package products
 - Fix bug: Fix convert to parent menu items in ``EditProductToolbar``
 - Show tracking codes in order detail

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``is_canceled`` and ``can_set_canceled`` to ``Order``
 - Fix bug: Convert ``Shipment`` weight to kilograms
 - Make ``create_shipment`` for order atomic
 - Add ``shipment_created`` signal

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-28 18:05+0000\n"
+"POT-Creation-Date: 2016-05-04 20:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -346,6 +346,12 @@ msgstr ""
 msgid "This order can not be set as complete at this point"
 msgstr ""
 
+msgid "Cancel Order"
+msgstr ""
+
+msgid "Paid, shipped, or canceled orders cannot be canceled"
+msgstr ""
+
 msgid "Unable to set order as completed at this point"
 msgstr ""
 
@@ -609,6 +615,9 @@ msgid "Price"
 msgstr ""
 
 msgid "Waive limit"
+msgstr ""
+
+msgid "Service choice"
 msgstr ""
 
 msgid "Enabled"

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -554,6 +554,15 @@ class Order(MoneyPropped, models.Model):
         canceled = (self.status.role == OrderStatusRole.CANCELED)
         return (not self.is_complete()) and fully_shipped and (not canceled)
 
+    def is_canceled(self):
+        return (self.status.role == OrderStatusRole.CANCELED)
+
+    def can_set_canceled(self):
+        canceled = (self.status.role == OrderStatusRole.CANCELED)
+        paid = self.is_paid()
+        shipped = (self.shipping_status != ShippingStatus.NOT_SHIPPED)
+        return not (canceled or paid or shipped)
+
     def check_and_set_fully_shipped(self):
         if self.shipping_status != ShippingStatus.FULLY_SHIPPED:
             if not self.get_unshipped_products():


### PR DESCRIPTION
Enable cancelation in admin Order edit view for unpaid and unshipped
orders.

Refs SHOOP-2401