### PR TITLE
Add payment creation view to order admin (SHOOP-2399)

### DIFF
--- a/doc/api/shoop.admin.modules.orders.views.rst
+++ b/doc/api/shoop.admin.modules.orders.views.rst
@@ -28,6 +28,14 @@ shoop.admin.modules.orders.views.list module
     :undoc-members:
     :show-inheritance:
 
+shoop.admin.modules.orders.views.payment module
+-----------------------------------------------
+
+.. automodule:: shoop.admin.modules.orders.views.payment
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 shoop.admin.modules.orders.views.shipment module
 ------------------------------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -58,6 +58,7 @@ Localization
 Admin
 ~~~~~
 
+- Add payment creation view to ``Order`` admin
 - Enable order cancelation in Order edit view
 - Hide invalid choices for package products
 - Fix bug: Fix convert to parent menu items in ``EditProductToolbar``

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add payment methods to ``Order``
 - Add ``is_canceled`` and ``can_set_canceled`` to ``Order``
 - Fix bug: Convert ``Shipment`` weight to kilograms
 - Make ``create_shipment`` for order atomic

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-04 20:38+0000\n"
+"POT-Creation-Date: 2016-05-06 21:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -334,6 +334,12 @@ msgstr ""
 msgid "Could not create order:"
 msgstr ""
 
+msgid "Create Payment"
+msgstr ""
+
+msgid "This order cannot be paid at this point"
+msgstr ""
+
 msgid "Create Shipment"
 msgstr ""
 
@@ -375,6 +381,23 @@ msgid "Shipping Status"
 msgstr ""
 
 msgid "Total"
+msgstr ""
+
+#, python-format
+msgid "Create Payment -- %s"
+msgstr ""
+
+msgid "Payment amount"
+msgstr ""
+
+msgid "Payment amount cannot be 0"
+msgstr ""
+
+#, python-format
+msgid "Payment %s created."
+msgstr ""
+
+msgid "Order has already been paid"
 msgstr ""
 
 #, python-format
@@ -593,6 +616,7 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
+#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -963,6 +987,39 @@ msgstr ""
 msgid "Amount"
 msgstr ""
 
+msgid "Text"
+msgstr ""
+
+msgid "Taxless Unit Price"
+msgstr ""
+
+msgid "Quantity"
+msgstr ""
+
+msgid "Taxless Discount"
+msgstr ""
+
+msgid "Tax"
+msgstr ""
+
+msgid "Taxless Total"
+msgstr ""
+
+msgid "Total incl. Tax"
+msgstr ""
+
+msgid "Discount"
+msgstr ""
+
+msgid "Taxless"
+msgstr ""
+
+msgid "Paid"
+msgstr ""
+
+msgid "Remaining"
+msgstr ""
+
 msgid "To Ship"
 msgstr ""
 
@@ -1012,33 +1069,6 @@ msgid "Tracking codes"
 msgstr ""
 
 msgid "Order Contents"
-msgstr ""
-
-msgid "Text"
-msgstr ""
-
-msgid "Taxless Unit Price"
-msgstr ""
-
-msgid "Quantity"
-msgstr ""
-
-msgid "Taxless Discount"
-msgstr ""
-
-msgid "Tax"
-msgstr ""
-
-msgid "Taxless Total"
-msgstr ""
-
-msgid "Total incl. Tax"
-msgstr ""
-
-msgid "Discount"
-msgstr ""
-
-msgid "Taxless"
 msgstr ""
 
 msgid "Payments"
@@ -1218,8 +1248,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - (%"
-"(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-19 08:57+0000\n"
+"POT-Creation-Date: 2016-05-06 00:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -315,13 +315,13 @@ msgstr ""
 msgid "Add new variable"
 msgstr ""
 
+msgid "No results."
+msgstr ""
+
 msgid "No browser URL for kind:"
 msgstr ""
 
 msgid "Expand Editor"
-msgstr ""
-
-msgid "No results."
 msgstr ""
 
 msgid "From"

--- a/shoop/admin/modules/orders/__init__.py
+++ b/shoop/admin/modules/orders/__init__.py
@@ -30,6 +30,11 @@ class OrderModule(CurrencyBound, AdminModule):
                 name="order.create-shipment"
             ),
             admin_url(
+                "^orders/(?P<pk>\d+)/create-payment/$",
+                "shoop.admin.modules.orders.views.OrderCreatePaymentView",
+                name="order.create-payment"
+            ),
+            admin_url(
                 "^orders/(?P<pk>\d+)/set-status/$",
                 "shoop.admin.modules.orders.views.OrderSetStatusView",
                 name="order.set-status"

--- a/shoop/admin/modules/orders/views/__init__.py
+++ b/shoop/admin/modules/orders/views/__init__.py
@@ -9,6 +9,10 @@
 from .create import OrderCreateView
 from .detail import OrderDetailView, OrderSetStatusView
 from .list import OrderListView
+from .payment import OrderCreatePaymentView
 from .shipment import OrderCreateShipmentView
 
-__all__ = ["OrderDetailView", "OrderListView", "OrderCreateShipmentView", "OrderSetStatusView", "OrderCreateView"]
+__all__ = [
+    "OrderDetailView", "OrderListView", "OrderCreatePaymentView", "OrderCreateShipmentView",
+    "OrderSetStatusView", "OrderCreateView"
+]

--- a/shoop/admin/modules/orders/views/detail.py
+++ b/shoop/admin/modules/orders/views/detail.py
@@ -32,6 +32,14 @@ class OrderDetailView(DetailView):
             return
         toolbar = Toolbar()
         toolbar.append(URLActionButton(
+            text=_("Create Payment"),
+            icon="fa fa-money",
+            disable_reason=_("This order cannot be paid at this point") if order.is_paid() else None,
+            url=reverse("shoop_admin:order.create-payment", kwargs={"pk": order.pk}),
+            extra_css_class="btn-info"
+        ))
+
+        toolbar.append(URLActionButton(
             text=_("Create Shipment"),
             icon="fa fa-truck",
             disable_reason=_("There are no products to ship") if not order.get_unshipped_products() else None,

--- a/shoop/admin/modules/orders/views/payment.py
+++ b/shoop/admin/modules/orders/views/payment.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from __future__ import unicode_literals
+
+from django import forms
+from django.contrib import messages
+from django.http.response import HttpResponseRedirect
+from django.utils.translation import ugettext as _
+from django.views.generic import UpdateView
+
+from shoop.admin.toolbar import PostActionButton, Toolbar
+from shoop.admin.utils.forms import add_form_errors_as_messages
+from shoop.admin.utils.urls import get_model_url
+from shoop.core.excs import NoPaymentToCreateException
+from shoop.core.models import Order
+from shoop.utils.money import Money
+
+
+class OrderCreatePaymentView(UpdateView):
+    model = Order
+    template_name = "shoop/admin/orders/create_payment.jinja"
+    context_object_name = "order"
+    form_class = forms.Form  # Augmented manually
+
+    def get_context_data(self, **kwargs):
+        context = super(OrderCreatePaymentView, self).get_context_data(**kwargs)
+        context["title"] = _("Create Payment -- %s") % context["order"]
+        context["toolbar"] = Toolbar([
+            PostActionButton(
+                icon="fa fa-check-circle",
+                form_id="create_payment",
+                text=_("Create Payment"),
+                extra_css_class="btn-success",
+            ),
+        ])
+        return context
+
+    def get_form_kwargs(self):
+        kwargs = super(OrderCreatePaymentView, self).get_form_kwargs()
+        kwargs.pop("instance")
+        return kwargs
+
+    def get_form(self, form_class):
+        form = super(OrderCreatePaymentView, self).get_form(form_class)
+        order = self.object
+        form.fields["amount"] = forms.DecimalField(
+            required=True,
+            min_value=0,
+            max_value=order.get_total_unpaid_amount().value,
+            initial=0,
+            label=_("Payment amount"),
+        )
+        return form
+
+    def form_invalid(self, form):
+        add_form_errors_as_messages(self.request, form)
+        return super(OrderCreatePaymentView, self).form_invalid(form)
+
+    def form_valid(self, form):
+        order = self.object
+        amount = Money(form.cleaned_data["amount"], order.currency)
+        if amount.value == 0:
+            messages.error(self.request, _("Payment amount cannot be 0"))
+            return self.form_invalid(form)
+        try:
+            payment = order.create_payment(amount, description="Manual payment")
+            messages.success(self.request, _("Payment %s created.") % payment.payment_identifier)
+        except NoPaymentToCreateException:
+            messages.error(self.request, _("Order has already been paid"))
+            return self.form_invalid(form)
+        else:
+            return HttpResponseRedirect(get_model_url(order))

--- a/shoop/admin/templates/shoop/admin/orders/_order_contents.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/_order_contents.jinja
@@ -1,0 +1,73 @@
+<div class="hidden-xs">
+    <table class="table table-striped table-bordered">
+        <thead>
+            <tr>
+                <th>{% trans %}SKU{% endtrans %}</th>
+                <th>{% trans %}Text{% endtrans %}</th>
+                <th class="text-right">{% trans %}Taxless Unit Price{% endtrans %}</th>
+                <th class="text-right">{% trans %}Quantity{% endtrans %}</th>
+                <th class="text-right">{% trans %}Taxless Discount{% endtrans %}</th>
+                <th class="text-right">{% trans %}Tax{% endtrans %}</th>
+                <th class="text-right">{% trans %}Taxless Total{% endtrans %}</th>
+                <th class="text-right">{% trans %}Total incl. Tax{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tfoot>
+            <tr>
+                <th colspan="6"></th>
+                <th class="text-right">{{ order.taxless_total_price|money }}</th>
+                <th class="text-right">{{ order.taxful_total_price|money }}</th>
+            </tr>
+        </tfoot>
+        <tbody>
+            {% for line in order.lines.order_by("ordering") %}
+            <tr>
+                <td>{{ line.sku }}</td>
+                <td>{{ line.text }}</td>
+                <td class="text-right">{{ line.taxless_base_unit_price|money }}</td>
+                <td class="text-right">{{ line.quantity|number }}</td>
+                <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
+                <td class="text-right">{{ line.tax_rate|percent }}</td>
+                <td class="text-right">{{ line.taxless_price|money }}</td>
+                <td class="text-right">{{ line.taxful_price|money }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+<div class="visible-xs mobile-list-group">
+    <ul class="list-group">
+        {% for line in order.lines.order_by("ordering") %}
+            <li class="list-group-item">
+                <div class="row">
+                    <div class="col-xs-6">
+                        <strong>{{ line.sku }}</strong>
+                    </div>
+                    <div class="col-xs-6 text-right">
+                        {{ line.text }}
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-xs-6">
+                        {{ line.quantity|number }} &times; {{ line.taxless_base_unit_price|money }} {% if line.taxless_discount_amount %}<span class="text-muted">{% trans %}Discount{% endtrans %}{{ line.taxless_discount_amount|money }}</span>{% endif %}
+                    </div>
+                    <div class="col-xs-6 text-right">
+                        <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_price|money }}</strong>
+                    </div>
+                    <div class="col-xs-12 text-right text-muted">
+                        {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_price|money }} {% trans %}Taxless{% endtrans %})
+                    </div>
+                </div>
+            </li>
+        {% endfor %}
+    </ul>
+    <div class="clearfix">
+        <div class="col-xs-6"><strong>{% trans %}Taxless Total{% endtrans %}</strong></div>
+        <div class="col-xs-6 text-right"><strong>{{ order.taxless_total_price|money }}</strong></div>
+    </div>
+    <div class="clearfix">
+        <div class="col-xs-6"><strong>{% trans %}Total incl. Tax{% endtrans %}</strong></div>
+        <div class="col-xs-6 text-right"><strong>{{ order.taxful_total_price|money }}</strong></div>
+    </div>
+</div>
+

--- a/shoop/admin/templates/shoop/admin/orders/create_payment.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/create_payment.jinja
@@ -1,0 +1,28 @@
+{% extends "shoop/admin/base.jinja" %}
+{% from "shoop/admin/macros/general.jinja" import content_block %}
+{% block content %}
+    <div class="container-fluid">
+        <div class="content-block">
+            <form method="post" id="create_payment">
+                {% csrf_token %}
+                {% include "shoop/admin/orders/_order_contents.jinja" with context %}
+                <div class="text-right">
+                    <h3>{% trans %}Paid{% endtrans %}: {{ order.get_total_paid_amount()|money }}</h3>
+                    <h3>{% trans %}Remaining{% endtrans %}: {{ order.get_total_unpaid_amount()|money }}</h3>
+                    <div class="text-center"><button id="total-unpaid" class="btn btn-info" value="{{ order.get_total_unpaid_amount().value }}" type="button">Get Remaining Total</button></div>
+                </div>
+                <hr>
+                {{ bs3.field(form.amount) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}
+{% block extra_js %}
+    <script>
+        $("#total-unpaid").click(function(event) {
+            event.preventDefault();
+            var total = $(this).val();
+            $("#id_amount").val(total);
+        })
+    </script>
+{% endblock %}

--- a/shoop/admin/templates/shoop/admin/orders/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/detail.jinja
@@ -55,78 +55,7 @@
             {% endif %}
 
             {% call content_block(_("Order Contents"), "fa-file-text") %}
-                <div class="hidden-xs">
-                    <table class="table table-striped table-bordered">
-                        <thead>
-                            <tr>
-                                <th>{% trans %}SKU{% endtrans %}</th>
-                                <th>{% trans %}Text{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Taxless Unit Price{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Quantity{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Taxless Discount{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Tax{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Taxless Total{% endtrans %}</th>
-                                <th class="text-right">{% trans %}Total incl. Tax{% endtrans %}</th>
-                            </tr>
-                        </thead>
-                        <tfoot>
-                            <tr>
-                                <th colspan="6"></th>
-                                <th class="text-right">{{ order.taxless_total_price|money }}</th>
-                                <th class="text-right">{{ order.taxful_total_price|money }}</th>
-                            </tr>
-                        </tfoot>
-                        <tbody>
-                            {% for line in order.lines.order_by("ordering") %}
-                            <tr>
-                                <td>{{ line.sku }}</td>
-                                <td>{{ line.text }}</td>
-                                <td class="text-right">{{ line.taxless_base_unit_price|money }}</td>
-                                <td class="text-right">{{ line.quantity|number }}</td>
-                                <td class="text-right">{% if line.taxless_discount_amount %}{{ line.taxless_discount_amount|money }}{% else %}-{% endif %}</td>
-                                <td class="text-right">{{ line.tax_rate|percent }}</td>
-                                <td class="text-right">{{ line.taxless_price|money }}</td>
-                                <td class="text-right">{{ line.taxful_price|money }}</td>
-                            </tr>
-                            {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                <div class="visible-xs mobile-list-group">
-                    <ul class="list-group">
-                        {% for line in order.lines.order_by("ordering") %}
-                            <li class="list-group-item">
-                                <div class="row">
-                                    <div class="col-xs-6">
-                                        <strong>{{ line.sku }}</strong>
-                                    </div>
-                                    <div class="col-xs-6 text-right">
-                                        {{ line.text }}
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-xs-6">
-                                        {{ line.quantity|number }} &times; {{ line.taxless_base_unit_price|money }} {% if line.taxless_discount_amount %}<span class="text-muted">{% trans %}Discount{% endtrans %}{{ line.taxless_discount_amount|money }}</span>{% endif %}
-                                    </div>
-                                    <div class="col-xs-6 text-right">
-                                        <strong>{% trans %}Total{% endtrans %}: {{ line.taxful_price|money }}</strong>
-                                    </div>
-                                    <div class="col-xs-12 text-right text-muted">
-                                        {{ line.tax_rate|percent }} {% trans %}Tax{% endtrans %} ({{ line.taxless_price|money }} {% trans %}Taxless{% endtrans %})
-                                    </div>
-                                </div>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                    <div class="clearfix">
-                        <div class="col-xs-6"><strong>{% trans %}Taxless Total{% endtrans %}</strong></div>
-                        <div class="col-xs-6 text-right"><strong>{{ order.taxless_total_price|money }}</strong></div>
-                    </div>
-                    <div class="clearfix">
-                        <div class="col-xs-6"><strong>{% trans %}Total incl. Tax{% endtrans %}</strong></div>
-                        <div class="col-xs-6 text-right"><strong>{{ order.taxful_total_price|money }}</strong></div>
-                    </div>
-                </div>
+                {% include "shoop/admin/orders/_order_contents.jinja" with context %}
             {% endcall %}
 
             {% set payments=order.payments.all() %}


### PR DESCRIPTION
Add payment creation view to order admin.

![payment_creator](https://cloud.githubusercontent.com/assets/5107464/15061300/89fd0072-12e8-11e6-81a3-c5a0cbf95ac1.png)

Refs SHOOP-2399