### PR TITLE
Front: Make required fields of address configurable (SHOOP-2503)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -86,6 +86,7 @@ Addons
 Front
 ~~~~~
 
+- Add SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES setting
 - Support also django-registration-redux 1.4
 - Enable description and logo for methods in checkout
 - Add admin view for monitoring customer carts

--- a/shoop/front/checkout/addresses.py
+++ b/shoop/front/checkout/addresses.py
@@ -31,6 +31,11 @@ class AddressForm(forms.ModelForm):
             # Set default country
             self.fields["country"].initial = settings.SHOOP_ADDRESS_HOME_COUNTRY
 
+        field_properties = settings.SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES
+        for field, properties in field_properties.items():
+            for prop in properties:
+                setattr(self.fields[field], prop, properties[prop])
+
 
 class CompanyForm(TaxNumberCleanMixin, forms.ModelForm):
     company_name_field = "name"

--- a/shoop/front/checkout/single_page.py
+++ b/shoop/front/checkout/single_page.py
@@ -8,14 +8,13 @@
 from __future__ import unicode_literals
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import FormView
 
 from shoop.core.models import (
-    CompanyContact, MutableAddress, OrderStatus, PaymentMethod, ShippingMethod
+    CompanyContact, OrderStatus, PaymentMethod, ShippingMethod
 )
 from shoop.front.basket import get_basket_order_creator
 from shoop.front.basket.objects import BaseBasket
@@ -24,18 +23,7 @@ from shoop.utils.fields import RelaxedModelChoiceField
 from shoop.utils.form_group import FormGroup
 
 from ._mixins import TaxNumberCleanMixin
-
-
-class AddressForm(forms.ModelForm):
-    class Meta:
-        model = MutableAddress
-        fields = ("name", "phone", "email", "street", "street2", "postal_code", "city", "region", "country")
-
-    def __init__(self, **kwargs):
-        super(AddressForm, self).__init__(**kwargs)
-        if not kwargs.get("instance"):
-            # Set default country
-            self.fields["country"].initial = settings.SHOOP_ADDRESS_HOME_COUNTRY
+from .addresses import AddressForm
 
 
 def _to_choices(objects):

--- a/shoop/front/settings.py
+++ b/shoop/front/settings.py
@@ -63,3 +63,16 @@ SHOOP_CHECKOUT_VIEW_SPEC = (
 #:
 #: Handled error cases are: 400, 403, 404, and 500
 SHOOP_FRONT_INSTALL_ERROR_HANDLERS = True
+
+#: A dictionary defining properties to override the default field properties of the
+#: checkout address form. Should map the field name (as a string) to a dictionary
+#: containing the overridding Django form field properties, as in the following
+#: example which makes the postal code a required field:
+#:
+#: SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES = {
+#:    "postal_code": {"required": True}
+#: }
+#:
+#: It should be noted, however, that overriding some settings (such as making a
+#: required field non-required) could create other validation issues.
+SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES = {}

--- a/shoop_tests/front/test_checkout.py
+++ b/shoop_tests/front/test_checkout.py
@@ -32,3 +32,22 @@ def test_checkout_singlepage_addresses_has_no_default_country():
 def test_checkout_singlepage_addresses_has_default_country():
     form = SinglePageAddressForm()
     assert form.fields["country"].initial == "FI"
+
+
+def test_required_address_fields():
+    with override_settings(SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES={}):
+        form = SinglePageAddressForm()
+        assert form.fields["email"].required == False
+        assert form.fields["email"].help_text != "Enter email"
+        assert form.fields["phone"].help_text != "Enter phone"
+
+    with override_settings(
+        SHOOP_FRONT_ADDRESS_FIELD_PROPERTIES={
+            "email": {"required": True, "help_text": "Enter email"},
+            "phone": {"help_text": "Enter phone"}
+        }
+    ):
+        form = SinglePageAddressForm()
+        assert form.fields["email"].required == True
+        assert form.fields["email"].help_text == "Enter email"
+        assert form.fields["phone"].help_text == "Enter phone"


### PR DESCRIPTION
Add SHOOP_FRONT_REQUIRED_ADDRESS_FIELDS setting to define required
address settings in checkout address form in addition to those defined
at the model leve.

Refs SHOOP-2503