### PR TITLE
Core: Change max length for service method names in `Order` (SHOOP-2489)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Fix max length for service method names for ``Order``
 - Add payment methods to ``Order``
 - Add ``is_canceled`` and ``can_set_canceled`` to ``Order``
 - Fix bug: Convert ``Shipment`` weight to kilograms

--- a/shoop/core/migrations/0022_change_order_method_name_lengths.py
+++ b/shoop/core/migrations/0022_change_order_method_name_lengths.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0021_weight_based_pricing'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='order',
+            name='payment_method_name',
+            field=models.CharField(default='', max_length=100, verbose_name='payment method name', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='order',
+            name='shipping_method_name',
+            field=models.CharField(default='', max_length=100, verbose_name='shipping method name', blank=True),
+        ),
+    ]

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -214,7 +214,7 @@ class Order(MoneyPropped, models.Model):
         default=None, on_delete=models.PROTECT,
         verbose_name=_('payment method'))
     payment_method_name = models.CharField(
-        max_length=64, blank=True, default="",
+        max_length=100, blank=True, default="",
         verbose_name=_('payment method name'))
     payment_data = JSONField(blank=True, null=True, verbose_name=_('payment data'))
 
@@ -223,7 +223,7 @@ class Order(MoneyPropped, models.Model):
         default=None, on_delete=models.PROTECT,
         verbose_name=_('shipping method'))
     shipping_method_name = models.CharField(
-        max_length=64, blank=True, default="",
+        max_length=100, blank=True, default="",
         verbose_name=_('shipping method name'))
     shipping_data = JSONField(blank=True, null=True, verbose_name=_('shipping data'))
 


### PR DESCRIPTION
Make max length for shipping and payment method names in `Order` the
same as max length for model names.

Refs SHOOP-2489