### PR TITLE
Make checkout templates easier to extend (SHOOP-2537)

### DIFF
--- a/shoop/testing/templates/shoop_testing/simple_checkout_phase.jinja
+++ b/shoop/testing/templates/shoop_testing/simple_checkout_phase.jinja
@@ -1,14 +1,10 @@
 {% extends "shoop/front/checkout/_base.jinja" %}
+{% from "shoop/front/checkout/_buttons.jinja" import default_buttons %}
 
-{% block content %}
+{% block checkout_phase_content %}
 <form role="form" method="post" action="">
     {% csrf_token %}
     {{ bs3.field(form.will_pay) }}
-
-    <div class="clearfix">
-        <button type="submit" class="btn btn-primary btn-lg pull-right">
-            <i class="fa fa-check"></i>Continue
-        </button>
-    </div>
+    {{ default_buttons() }}
 </form>
 {% endblock %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_base.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_base.jinja
@@ -16,3 +16,8 @@
         {% endif %}
     {% endblock %}
 {% endblock %}
+
+{% block content %}
+    {% block checkout_phase_content %}
+    {% endblock %}
+{% endblock %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_buttons.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/_buttons.jinja
@@ -1,0 +1,17 @@
+{% macro buttons_container() %}
+    <div class="clearfix">
+        {{ caller() }}
+    </div>
+{% endmacro %}
+
+{% macro next_button() %}
+    <button type="submit" class="btn btn-primary btn-lg pull-right">
+        <i class="fa fa-check"></i> {% trans %}Continue{% endtrans %}
+    </button>
+{% endmacro %}
+
+{% macro default_buttons() %}
+    {% call buttons_container() %}
+        {{ next_button() }}
+    {% endcall %}
+{% endmacro %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/addresses.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/addresses.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/front/checkout/_base.jinja" %}
+{% from "shoop/front/checkout/_buttons.jinja" import default_buttons %}
 
-{% block content %}
+{% block checkout_phase_content %}
 <form role="form" method="post" action="" id="addresses">
     {% set forms = form.forms %}
     {% csrf_token %}
@@ -50,11 +51,7 @@
             </div>
         </fieldset>
     </div>
-    <div class="clearfix">
-        <button type="submit" class="btn btn-primary btn-lg pull-right">
-            <i class="fa fa-check"></i> {% trans %}Continue{% endtrans %}
-        </button>
-    </div>
+    {{ default_buttons() }}
 </form>
 {% endblock %}
 

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/confirm.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/confirm.jinja
@@ -31,7 +31,7 @@
     </div>
 {% endmacro %}
 
-{% block content %}
+{% block checkout_phase_content %}
     <div class="well">
         {% include "shoop/front/checkout/_confirm_table.jinja" %}
     </div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/empty.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/empty.jinja
@@ -1,6 +1,6 @@
 {% extends "shoop/front/checkout/_base.jinja" %}
 {% block checkout_phase_bar %}{% endblock %}
-{% block content %}
+{% block checkout_phase_content %}
     <div class="alert alert-danger">
         {% trans %}Your shopping cart is empty.{% endtrans %}
     </div>

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/methods.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/methods.jinja
@@ -1,6 +1,7 @@
 {% extends "shoop/front/checkout/_base.jinja" %}
+{% from "shoop/front/checkout/_buttons.jinja" import default_buttons %}
 
-{% block content %}
+{% block checkout_phase_content %}
 <form role="form" method="post" action="">
     {% csrf_token %}
     <div class="panel panel-default">
@@ -23,10 +24,6 @@
             {{ form.payment_method }}
         </div>
     </div>
-    <div class="clearfix">
-        <button type="submit" class="btn btn-primary btn-lg pull-right">
-            <i class="fa fa-check"></i> {% trans %}Continue{% endtrans %}
-        </button>
-    </div>
+    {{ default_buttons() }}
 </form>
 {% endblock %}

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/single_phase.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/single_phase.jinja
@@ -9,7 +9,7 @@
             {% trans %}Your shopping cart is empty.{% endtrans %}
         </div>
     {% else %}
-        {% include "shoop/front/basket/partials/table.jinja" %}
+        {% include "shoop/front/basket/partials/_basket_content.jinja" %}
 
         {% if errors %}
             <div class="alert alert-danger">

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/single_phase.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/checkout/single_phase.jinja
@@ -1,9 +1,9 @@
-{% extends "shoop/front/base.jinja" %}
+{% extends "shoop/front/checkout/_base.jinja" %}
 
 {% block title %}{% trans %}Shopping cart{% endtrans %}{% endblock %}
 {% block content_title %}{% trans %}Shopping cart{% endtrans %}{% endblock %}
 
-{% block content %}
+{% block checkout_phase_content %}
     {% if basket.is_empty %}
         <div class="alert alert-danger">
             {% trans %}Your shopping cart is empty.{% endtrans %}


### PR DESCRIPTION
* Add block checkout_phase_content which can be wrapped with appropriate
  container elements in themes by overriding the content block in
  `checkout/_base.jinja`.
* Also add macros for rendering the buttons.
* Use new template API for the test checkout phase