### PR TITLE
Enable editing orders (SHOOP-2338, SHOOP-2534)

### DIFF
--- a/doc/api/shoop.admin.modules.orders.views.rst
+++ b/doc/api/shoop.admin.modules.orders.views.rst
@@ -4,18 +4,18 @@ shoop.admin.modules.orders.views package
 Submodules
 ----------
 
-shoop.admin.modules.orders.views.create module
-----------------------------------------------
-
-.. automodule:: shoop.admin.modules.orders.views.create
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 shoop.admin.modules.orders.views.detail module
 ----------------------------------------------
 
 .. automodule:: shoop.admin.modules.orders.views.detail
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+shoop.admin.modules.orders.views.edit module
+--------------------------------------------
+
+.. automodule:: shoop.admin.modules.orders.views.edit
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``Order.can_edit``
 - Update shipping status correctly in ``Order.create_shipment``
 - Add ``OrderModifier`` for basic ``Order`` modifying from ``OrderSource``
 - Add option use ``Order.create_shipment`` with unsaved ``Shipment``

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``OrderModifier`` for basic ``Order`` modifying from ``OrderSource``
 - Add option use ``Order.create_shipment`` with unsaved ``Shipment``
 - Add identifier for ``Shipment``
 - Fix bug: Fix max length for service method names for ``Order``

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -64,6 +64,7 @@ Localization
 Admin
 ~~~~~
 
+- Enable order editing
 - Allow shipment creation form extensions
 - Add payment creation view to ``Order`` admin
 - Enable order cancelation in Order edit view

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Update shipping status correctly in ``Order.create_shipment``
 - Add ``OrderModifier`` for basic ``Order`` modifying from ``OrderSource``
 - Add option use ``Order.create_shipment`` with unsaved ``Shipment``
 - Add identifier for ``Shipment``

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-06 21:24+0000\n"
+"POT-Creation-Date: 2016-05-13 01:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
-"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -317,23 +317,6 @@ msgstr ""
 msgid "Please select payment method."
 msgstr ""
 
-msgid "Create Order"
-msgstr ""
-
-#, python-format
-msgid "Contact %s does not exist."
-msgstr ""
-
-#, python-format
-msgid "Order %(identifier)s created."
-msgstr ""
-
-msgid "Could not proceed with order:"
-msgstr ""
-
-msgid "Could not create order:"
-msgstr ""
-
 msgid "Create Payment"
 msgstr ""
 
@@ -358,11 +341,38 @@ msgstr ""
 msgid "Paid, shipped, or canceled orders cannot be canceled"
 msgstr ""
 
+msgid "Edit order"
+msgstr ""
+
+msgid "This order cannot modified at this point"
+msgstr ""
+
 msgid "Unable to set order as completed at this point"
 msgstr ""
 
 #, python-format
 msgid "Order status changed: %s to %s"
+msgstr ""
+
+msgid "Create Order"
+msgstr ""
+
+#, python-format
+msgid "Contact %s does not exist."
+msgstr ""
+
+#, python-format
+msgid "Order %(identifier)s updated."
+msgstr ""
+
+#, python-format
+msgid "Order %(identifier)s created."
+msgstr ""
+
+msgid "Could not proceed with order:"
+msgstr ""
+
+msgid "Could not finalize order:"
 msgstr ""
 
 msgid "Order"
@@ -616,7 +626,6 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
-#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -1248,8 +1257,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - "
-"(%(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - (%"
+"(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-06 00:02+0000\n"
+"POT-Creation-Date: 2016-05-13 01:21+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
-"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -31,21 +31,20 @@ msgstr ""
 msgid "New file name?"
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "Are you sure you want to delete the file %s?"
 msgid "Are you sure you want to delete the file %s?"
 msgstr ""
 
 msgid "New folder name?"
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "Are you sure you want to delete the %s folder?"
 msgid "Are you sure you want to delete the %s folder?"
 msgstr ""
 
 msgid "New folder"
-msgstr ""
-
-msgid "current"
 msgstr ""
 
 msgid "Oldest first"
@@ -95,7 +94,8 @@ msgstr ""
 msgid "Delete folder"
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "Order %s created."
 msgid "Order %s created."
 msgstr ""
 
@@ -165,6 +165,9 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
+msgid "Discard Changes"
+msgstr ""
+
 msgid "Select Shop"
 msgstr ""
 
@@ -223,7 +226,8 @@ msgid ""
 "customer first."
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "All prices are in %s currency."
 msgid "All prices are in %s currency."
 msgstr ""
 
@@ -281,7 +285,8 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "Value %s Name"
 msgid "Value %s Name"
 msgstr ""
 
@@ -357,7 +362,8 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#, javascript-format
+#, c-format
+#| msgid "Filter by %s"
 msgid "Filter by %s"
 msgstr ""
 

--- a/shoop/admin/modules/orders/__init__.py
+++ b/shoop/admin/modules/orders/__init__.py
@@ -46,8 +46,13 @@ class OrderModule(CurrencyBound, AdminModule):
             ),
             admin_url(
                 "^orders/new/$",
-                "shoop.admin.modules.orders.views.OrderCreateView",
+                "shoop.admin.modules.orders.views.OrderEditView",
                 name="order.new"
+            ),
+            admin_url(
+                "^orders/(?P<pk>\d+)/edit/$",
+                "shoop.admin.modules.orders.views.OrderEditView",
+                name="order.edit"
             ),
             admin_url(
                 "^orders/$",

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -16,7 +16,7 @@ from shoop.core.models import (
     CompanyContact, Contact, MutableAddress, OrderLineType, OrderStatus,
     PaymentMethod, PersonContact, Product, ShippingMethod, Shop
 )
-from shoop.core.order_creator import OrderCreator, OrderSource
+from shoop.core.order_creator import OrderCreator, OrderModifier, OrderSource
 from shoop.utils.analog import LogEntryKind
 from shoop.utils.numbers import parse_decimal_string
 
@@ -299,6 +299,34 @@ class JsonOrderCreator(object):
         creator = OrderCreator()
         try:
             order = creator.create_order(order_source=source)
+            self._postprocess_order(order, state)
+            return order
+        except Exception as exc:  # pragma: no cover
+            self.add_error(exc)
+            return
+
+    def update_order_from_state(self, state, order_to_update, creator=None, ip_address=None):
+        """
+        Update an order from a state dict unserialized from JSON.
+
+        :param state: State dictionary
+        :type state: dict
+        :param order_to_update: Order object to edit
+        :type order_to_update: shoop.core.models.Order
+        :param creator: Creator user
+        :type creator: django.contrib.auth.models.User|None
+        :param ip_address: Remote IP address (IPv4 or IPv6)
+        :type ip_address: str
+        :return: The created order, or None if something failed along the way
+        :rtype: Order|None
+        """
+        source = self.create_source_from_state(
+            state, creator=creator, ip_address=ip_address, save=True)
+
+        # Then create an OrderCreator and try to get things done!
+        modifier = OrderModifier()
+        try:
+            order = modifier.update_order_from_source(order_source=source, order=order_to_update)
             self._postprocess_order(order, state)
             return order
         except Exception as exc:  # pragma: no cover

--- a/shoop/admin/modules/orders/static_src/create/actions/index.js
+++ b/shoop/admin/modules/orders/static_src/create/actions/index.js
@@ -19,6 +19,7 @@ export const addLine = createAction("addLine");
 export const deleteLine = createAction("deleteLine");
 export const updateLineFromProduct = createAction("updateLineFromProduct");
 export const setLineProperty = createAction("setLineProperty", (id, property, value) => ({id, property, value}));
+export const setLines = createAction("setLines");
 // Customers actions
 export const clearExistingCustomer = createAction("clearExistingCustomer");
 export const setAddressProperty = createAction("setAddressProperty", (type, field, value) => ({type, field, value}));
@@ -35,6 +36,7 @@ export const setPaymentMethod = createAction("setPaymentMethod");
 export const updateTotals = createAction("updateTotals");
 export const setOrderSource = createAction("setOrderSource");
 export const clearOrderSourceData = createAction("clearOrderSourceData");
+export const setOrderId = createAction("setOrderId");
 // Comment action
 export const setComment = createAction("setComment");
 
@@ -112,9 +114,9 @@ export const updateLines = () => {
 export const receiveProductData = createAction("receiveProductData");
 export const receiveCustomerData = createAction("receiveCustomerData");
 export const receiveOrderSourceData = createAction("receiveOrderSourceData");
-export const endCreatingOrder = createAction("endCreatingOrder");
+export const endFinalizingOrder = createAction("endFinalizingOrder");
 
-function handleCreateResponse(dispatch, data) {
+function handleFinalizeResponse(dispatch, data) {
     const {success, errorMessage, orderIdentifier, url} = data;
     if (success) {
         if (url) {
@@ -125,7 +127,7 @@ function handleCreateResponse(dispatch, data) {
         }
         return;
     }
-    dispatch(endCreatingOrder());  // Only flag end if something went awry
+    dispatch(endFinalizingOrder());  // Only flag end if something went awry
     if (errorMessage) {
         const {Messages} = window;
         if (Messages) {
@@ -138,14 +140,14 @@ function handleCreateResponse(dispatch, data) {
     alert(gettext("An unspecified error occurred.\n") + data);
 }
 
-export const beginCreatingOrder = function () {
+export const beginFinalizingOrder = function () {
     return (dispatch, getState) => {
         const state = _.assign({}, getState(), {productData: null, order: null}); // We don't care about that substate
-        post("create", {state}).then((data) => {
-            handleCreateResponse(dispatch, data);
+        post("finalize", {state}).then((data) => {
+            handleFinalizeResponse(dispatch, data);
         }, (data) => {  // error handler
-            handleCreateResponse(dispatch, data);
+            handleFinalizeResponse(dispatch, data);
         });
-        dispatch(createAction("beginCreatingOrder")());
+        dispatch(createAction("beginFinalizingOrder")());
     };
 };

--- a/shoop/admin/modules/orders/static_src/create/reducers/lines.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/lines.js
@@ -170,9 +170,26 @@ function setLineProperty(state, {payload}) {
     return setLineProperties(state, id, updates);
 }
 
+function setLines(state, {payload}) {
+    var lines = [];
+    _.map(payload, (line) => {
+        _.merge(
+            line,
+            getDiscountsAndTotal(
+                ensureNumericValue(line.quantity),
+                ensureNumericValue(line.baseUnitPrice),
+                ensureNumericValue(line.unitPrice)
+            )
+        );
+        lines.push(line);
+    });
+    return _.assign([], state, lines);
+}
+
 export default handleActions({
     addLine: ((state) => [].concat(state, newLine())),
     deleteLine: ((state, {payload}) => _.reject(state, (line) => line.id === payload)),
     updateLineFromProduct,
-    setLineProperty
+    setLineProperty,
+    setLines
 }, []);

--- a/shoop/admin/modules/orders/static_src/create/reducers/order.js
+++ b/shoop/admin/modules/orders/static_src/create/reducers/order.js
@@ -24,9 +24,11 @@ export default handleActions({
     beginCreatingOrder: ((state) => _.assign(state, {creating: true})),
     endCreatingOrder:  ((state) => _.assign(state, {creating: false})),
     updateTotals,
+    setOrderId: ((state, {payload}) => _.assign(state, {id: payload})),
     setOrderSource: ((state, {payload}) => _.assign(state, {source: payload})),
     clearOrderSourceData: ((state) => _.assign(state, {source: null}))
 }, {
+    id: null,
     creating: false,
     source: null,
     total: 0

--- a/shoop/admin/modules/orders/static_src/create/store.js
+++ b/shoop/admin/modules/orders/static_src/create/store.js
@@ -6,7 +6,8 @@
  * This source code is licensed under the AGPLv3 license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {createStore, applyMiddleware} from "redux";
+import {compose, createStore, applyMiddleware} from "redux";
+import {autoRehydrate} from "redux-persist";
 import reducer from "./reducers";
 
 const logger = ({ getState }) => (next) => (action) => {
@@ -27,7 +28,7 @@ const thunk = function ({ dispatch, getState }) {
             next(action);
 };
 
-const createLoggedStore = applyMiddleware(thunk, logger)(createStore);
+const createLoggedStore = compose(autoRehydrate(), applyMiddleware(thunk, logger))(createStore);
 const store = createLoggedStore(reducer);
 
 export default store;

--- a/shoop/admin/modules/orders/static_src/create/view/index.js
+++ b/shoop/admin/modules/orders/static_src/create/view/index.js
@@ -13,7 +13,7 @@ import {customerSelectView} from "./customers";
 import {shipmentMethodSelectView, paymentMethodSelectView} from "./methods";
 import {confirmView} from "./confirm";
 import {contentBlock} from "./utils";
-import {beginCreatingOrder, clearOrderSourceData, retrieveCustomerData, retrieveOrderSourceData} from "../actions";
+import {beginFinalizingOrder, clearOrderSourceData, retrieveOrderSourceData} from "../actions";
 import store from "../store";
 
 export default function view() {
@@ -32,35 +32,45 @@ export default function view() {
                 m("button.btn.btn-success.btn-lg.pull-right" + (creating ? ".disabled" : ""), {
                     disabled: creating,
                     onclick: () => {
-                        store.dispatch(beginCreatingOrder());
+                        store.dispatch(beginFinalizingOrder());
                     }
                 }, m("i.fa.fa-check"), " " + gettext("Confirm"))
             ])
         );
     } else {
-        return m("div.container-fluid",
-            (choices.length > 1 ? contentBlock("i.fa.fa-building", gettext("Select Shop"), shopSelectView(store)) : null),
-            contentBlock("i.fa.fa-cubes", gettext("Order Contents"), orderLinesView(store, creating)),
-            contentBlock("i.fa.fa-user", gettext("Customer Details"), customerSelectView(store)),
-            contentBlock("i.fa.fa-truck", gettext("Shipping Method"), shipmentMethodSelectView(store)),
-            contentBlock("i.fa.fa-credit-card", gettext("Payment Method"), paymentMethodSelectView(store)),
-            m("div.order-footer",
-                m("div.text", m(
-                    "small",
-                    gettext("Method rules, taxes and possible extra discounts are calculated after proceeding."))
-                ),
-                m("div.text", m("h2", m("small", gettext("Total") + ": "), total + " " + selected.currency)),
-                m("div.proceed-button", [
-                    m("button.btn.btn-success.btn-block" + (creating ? ".disabled" : ""), {
-                        disabled: creating,
-                        onclick: () => {
-                            if(!source) {
-                                store.dispatch(retrieveOrderSourceData());
+        return [
+            m("div.container-fluid",
+                m("button.btn.btn-gray.btn-inverse.pull-right", {
+                    onclick: () => {
+                        window.localStorage.setItem("resetSavedOrder", "true");
+                        window.location.reload();
+                    }
+                }, m("i.fa.fa-undo", " " + gettext("Discard Changes")))
+            ),
+            m("div.container-fluid",
+                (choices.length > 1 ? contentBlock("i.fa.fa-building", gettext("Select Shop"), shopSelectView(store)) : null),
+                contentBlock("i.fa.fa-cubes", gettext("Order Contents"), orderLinesView(store, creating)),
+                contentBlock("i.fa.fa-user", gettext("Customer Details"), customerSelectView(store)),
+                contentBlock("i.fa.fa-truck", gettext("Shipping Method"), shipmentMethodSelectView(store)),
+                contentBlock("i.fa.fa-credit-card", gettext("Payment Method"), paymentMethodSelectView(store)),
+                m("div.order-footer",
+                    m("div.text", m(
+                        "small",
+                        gettext("Method rules, taxes and possible extra discounts are calculated after proceeding."))
+                    ),
+                    m("div.text", m("h2", m("small", gettext("Total") + ": "), total + " " + selected.currency)),
+                    m("div.proceed-button", [
+                        m("button.btn.btn-success.btn-block" + (creating ? ".disabled" : ""), {
+                            disabled: creating,
+                            onclick: () => {
+                                if(!source) {
+                                    store.dispatch(retrieveOrderSourceData());
+                                }
                             }
-                        }
-                    }, m("i.fa.fa-check"), " " + gettext("Proceed"))
-                ])
+                        }, m("i.fa.fa-check"), " " + gettext("Proceed"))
+                    ])
+                )
             )
-        );
+        ]
     }
 }

--- a/shoop/admin/modules/orders/views/__init__.py
+++ b/shoop/admin/modules/orders/views/__init__.py
@@ -6,13 +6,13 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .create import OrderCreateView
 from .detail import OrderDetailView, OrderSetStatusView
+from .edit import OrderEditView
 from .list import OrderListView
 from .payment import OrderCreatePaymentView
 from .shipment import OrderCreateShipmentView
 
 __all__ = [
-    "OrderDetailView", "OrderListView", "OrderCreatePaymentView", "OrderCreateShipmentView",
-    "OrderSetStatusView", "OrderCreateView"
+    "OrderDetailView", "OrderEditView", "OrderListView", "OrderCreatePaymentView",
+    "OrderCreateShipmentView", "OrderSetStatusView"
 ]

--- a/shoop/admin/modules/orders/views/detail.py
+++ b/shoop/admin/modules/orders/views/detail.py
@@ -74,6 +74,13 @@ class OrderDetailView(DetailView):
             ),
             extra_css_class="btn-danger btn-inverse"
         ))
+        toolbar.append(URLActionButton(
+            text=_("Edit order"),
+            icon="fa fa-money",
+            disable_reason=_("This order cannot modified at this point") if not order.can_edit() else None,
+            url=reverse("shoop_admin:order.edit", kwargs={"pk": order.pk}),
+            extra_css_class="btn-info"
+        ))
 
         for button in get_provide_objects("admin_order_toolbar_button"):
             toolbar.append(button(order))

--- a/shoop/admin/npm-shrinkwrap.json
+++ b/shoop/admin/npm-shrinkwrap.json
@@ -4,321 +4,321 @@
   "dependencies": {
     "autoprefixer-loader": {
       "version": "3.1.0",
-      "from": "autoprefixer-loader@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/autoprefixer-loader/-/autoprefixer-loader-3.1.0.tgz",
       "dependencies": {
         "autoprefixer": {
           "version": "6.2.3",
-          "from": "autoprefixer@>=6.0.2 <7.0.0",
+          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
           "dependencies": {
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
             },
             "normalize-range": {
               "version": "0.1.2",
-              "from": "normalize-range@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
             },
             "num2fraction": {
               "version": "1.2.2",
-              "from": "num2fraction@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "browserslist": {
               "version": "1.0.1",
-              "from": "browserslist@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
             },
             "caniuse-db": {
               "version": "1.0.30000386",
-              "from": "caniuse-db@>=1.0.30000382 <2.0.0",
+              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
             }
           }
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.10 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "postcss-safe-parser": {
           "version": "1.0.4",
-          "from": "postcss-safe-parser@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-1.0.4.tgz"
         }
       }
     },
     "babel-core": {
       "version": "5.8.34",
-      "from": "babel-core@>=5.8.23 <6.0.0",
+      "from": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.34.tgz",
       "dependencies": {
         "babel-plugin-constant-folding": {
           "version": "1.0.1",
-          "from": "babel-plugin-constant-folding@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
         },
         "babel-plugin-dead-code-elimination": {
           "version": "1.0.2",
-          "from": "babel-plugin-dead-code-elimination@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
         },
         "babel-plugin-eval": {
           "version": "1.0.1",
-          "from": "babel-plugin-eval@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
         },
         "babel-plugin-inline-environment-variables": {
           "version": "1.0.1",
-          "from": "babel-plugin-inline-environment-variables@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
         },
         "babel-plugin-jscript": {
           "version": "1.0.4",
-          "from": "babel-plugin-jscript@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
         },
         "babel-plugin-member-expression-literals": {
           "version": "1.0.1",
-          "from": "babel-plugin-member-expression-literals@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
         },
         "babel-plugin-property-literals": {
           "version": "1.0.1",
-          "from": "babel-plugin-property-literals@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
         },
         "babel-plugin-proto-to-assign": {
           "version": "1.0.4",
-          "from": "babel-plugin-proto-to-assign@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
         },
         "babel-plugin-react-constant-elements": {
           "version": "1.0.3",
-          "from": "babel-plugin-react-constant-elements@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
         },
         "babel-plugin-react-display-name": {
           "version": "1.0.3",
-          "from": "babel-plugin-react-display-name@>=1.0.3 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
         },
         "babel-plugin-remove-console": {
           "version": "1.0.1",
-          "from": "babel-plugin-remove-console@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
         },
         "babel-plugin-remove-debugger": {
           "version": "1.0.1",
-          "from": "babel-plugin-remove-debugger@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
         },
         "babel-plugin-runtime": {
           "version": "1.0.7",
-          "from": "babel-plugin-runtime@>=1.0.7 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
         },
         "babel-plugin-undeclared-variables-check": {
           "version": "1.0.2",
-          "from": "babel-plugin-undeclared-variables-check@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
           "dependencies": {
             "leven": {
               "version": "1.0.2",
-              "from": "leven@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
             }
           }
         },
         "babel-plugin-undefined-to-void": {
           "version": "1.1.6",
-          "from": "babel-plugin-undefined-to-void@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
         },
         "babylon": {
           "version": "5.8.34",
-          "from": "babylon@>=5.8.34 <6.0.0",
+          "from": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz",
           "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.34.tgz"
         },
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.33 <3.0.0",
+          "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "convert-source-map": {
           "version": "1.1.2",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
         },
         "core-js": {
           "version": "1.2.6",
-          "from": "core-js@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
         },
         "debug": {
           "version": "2.2.0",
-          "from": "debug@>=2.1.1 <3.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.1",
-              "from": "ms@0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
             }
           }
         },
         "detect-indent": {
           "version": "3.0.1",
-          "from": "detect-indent@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "minimist": {
               "version": "1.2.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
             }
           }
         },
         "esutils": {
           "version": "2.0.2",
-          "from": "esutils@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
         },
         "fs-readdir-recursive": {
           "version": "0.1.2",
-          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
         },
         "globals": {
           "version": "6.4.1",
-          "from": "globals@>=6.4.0 <7.0.0",
+          "from": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
         },
         "home-or-tmp": {
           "version": "1.0.0",
-          "from": "home-or-tmp@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
           "dependencies": {
             "os-tmpdir": {
               "version": "1.0.1",
-              "from": "os-tmpdir@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
             },
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
         },
         "is-integer": {
           "version": "1.0.6",
-          "from": "is-integer@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
           "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
@@ -327,44 +327,44 @@
         },
         "js-tokens": {
           "version": "1.0.1",
-          "from": "js-tokens@1.0.1",
+          "from": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
         },
         "json5": {
           "version": "0.4.0",
-          "from": "json5@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
           "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
         },
         "line-numbers": {
           "version": "0.2.0",
-          "from": "line-numbers@0.2.0",
+          "from": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
           "dependencies": {
             "left-pad": {
               "version": "0.0.3",
-              "from": "left-pad@0.0.3",
+              "from": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
             }
           }
         },
         "minimatch": {
           "version": "2.0.10",
-          "from": "minimatch@>=2.0.3 <3.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.2",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -373,249 +373,249 @@
         },
         "output-file-sync": {
           "version": "1.1.1",
-          "from": "output-file-sync@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "private": {
           "version": "0.1.6",
-          "from": "private@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/private/-/private-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
         },
         "regenerator": {
           "version": "0.8.40",
-          "from": "regenerator@0.8.40",
+          "from": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
           "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
           "dependencies": {
             "commoner": {
               "version": "0.10.4",
-              "from": "commoner@>=0.10.3 <0.11.0",
+              "from": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
               "dependencies": {
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.5.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "detective": {
                   "version": "4.3.1",
-                  "from": "detective@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
                   "dependencies": {
                     "acorn": {
                       "version": "1.2.2",
-                      "from": "acorn@>=1.0.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
                     },
                     "defined": {
                       "version": "1.0.0",
-                      "from": "defined@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
                     }
                   }
                 },
                 "graceful-fs": {
                   "version": "4.1.2",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                 },
                 "iconv-lite": {
                   "version": "0.4.13",
-                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "from": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
                   "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                 },
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "q": {
                   "version": "1.4.1",
-                  "from": "q@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                 }
               }
             },
             "defs": {
               "version": "1.1.1",
-              "from": "defs@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
               "dependencies": {
                 "alter": {
                   "version": "0.2.0",
-                  "from": "alter@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
                   "dependencies": {
                     "stable": {
                       "version": "0.1.5",
-                      "from": "stable@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz",
                       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
                     }
                   }
                 },
                 "ast-traverse": {
                   "version": "0.1.1",
-                  "from": "ast-traverse@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
                 },
                 "breakable": {
                   "version": "1.0.0",
-                  "from": "breakable@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
                 },
                 "simple-fmt": {
                   "version": "0.1.0",
-                  "from": "simple-fmt@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
                 },
                 "simple-is": {
                   "version": "0.2.0",
-                  "from": "simple-is@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
                 },
                 "stringmap": {
                   "version": "0.2.2",
-                  "from": "stringmap@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
                 },
                 "stringset": {
                   "version": "0.2.1",
-                  "from": "stringset@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
                 },
                 "tryor": {
                   "version": "0.1.2",
-                  "from": "tryor@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
                 },
                 "yargs": {
                   "version": "3.27.0",
-                  "from": "yargs@>=3.27.0 <3.28.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.2.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.2",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "0.2.7",
-                              "from": "lazy-cache@>=0.2.4 <0.3.0",
+                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -624,29 +624,29 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
                     },
                     "os-locale": {
                       "version": "1.4.0",
-                      "from": "os-locale@>=1.4.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
                       "dependencies": {
                         "lcid": {
                           "version": "1.0.0",
-                          "from": "lcid@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
                           "dependencies": {
                             "invert-kv": {
                               "version": "1.0.0",
-                              "from": "invert-kv@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
                             }
                           }
@@ -655,12 +655,12 @@
                     },
                     "window-size": {
                       "version": "0.1.4",
-                      "from": "window-size@>=0.1.2 <0.2.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz"
                     },
                     "y18n": {
                       "version": "3.2.0",
-                      "from": "y18n@>=3.2.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
                     }
                   }
@@ -669,73 +669,73 @@
             },
             "esprima-fb": {
               "version": "15001.1001.0-dev-harmony-fb",
-              "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+              "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
               "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
             },
             "recast": {
               "version": "0.10.33",
-              "from": "recast@0.10.33",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
               "dependencies": {
                 "ast-types": {
                   "version": "0.8.12",
-                  "from": "ast-types@0.8.12",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
                   "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                 }
               }
             },
             "through": {
               "version": "2.3.8",
-              "from": "through@>=2.3.8 <2.4.0",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
               "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
             }
           }
         },
         "regexpu": {
           "version": "1.3.0",
-          "from": "regexpu@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
           "dependencies": {
             "esprima": {
               "version": "2.7.1",
-              "from": "esprima@>=2.6.0 <3.0.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
               "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
             },
             "recast": {
               "version": "0.10.39",
-              "from": "recast@>=0.10.10 <0.11.0",
+              "from": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.39.tgz",
               "dependencies": {
                 "esprima-fb": {
                   "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@>=15001.1001.0-dev-harmony-fb <15001.1002.0",
+                  "from": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
                   "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
                 },
                 "ast-types": {
                   "version": "0.8.12",
-                  "from": "ast-types@0.8.12",
+                  "from": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
                   "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
                 }
               }
             },
             "regenerate": {
               "version": "1.2.1",
-              "from": "regenerate@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
             },
             "regjsgen": {
               "version": "0.2.0",
-              "from": "regjsgen@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
             },
             "regjsparser": {
               "version": "0.1.5",
-              "from": "regjsparser@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
               "dependencies": {
                 "jsesc": {
                   "version": "0.5.0",
-                  "from": "jsesc@>=0.5.0 <0.6.0",
+                  "from": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
                 }
               }
@@ -744,17 +744,17 @@
         },
         "repeating": {
           "version": "1.1.3",
-          "from": "repeating@>=1.1.2 <2.0.0",
+          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
           "dependencies": {
             "is-finite": {
               "version": "1.0.1",
-              "from": "is-finite@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
               "dependencies": {
                 "number-is-nan": {
                   "version": "1.0.0",
-                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                 }
               }
@@ -763,37 +763,37 @@
         },
         "resolve": {
           "version": "1.1.6",
-          "from": "resolve@>=1.1.6 <2.0.0",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "from": "shebang-regex@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
         },
         "slash": {
           "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
         },
         "source-map": {
           "version": "0.5.3",
-          "from": "source-map@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
         },
         "source-map-support": {
           "version": "0.2.10",
-          "from": "source-map-support@>=0.2.10 <0.3.0",
+          "from": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.1.32",
-              "from": "source-map@0.1.32",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
@@ -802,53 +802,53 @@
         },
         "to-fast-properties": {
           "version": "1.0.1",
-          "from": "to-fast-properties@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
         },
         "trim-right": {
           "version": "1.0.1",
-          "from": "trim-right@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
         },
         "try-resolve": {
           "version": "1.0.1",
-          "from": "try-resolve@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
         }
       }
     },
     "babel-loader": {
       "version": "5.4.0",
-      "from": "babel-loader@>=5.1.4 <6.0.0",
+      "from": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-5.4.0.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.9 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         }
       }
     },
     "bower": {
       "version": "1.7.1",
-      "from": "bower@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.7.1.tgz",
       "resolved": "https://registry.npmjs.org/bower/-/bower-1.7.1.tgz",
       "dependencies": {
         "abbrev": {
@@ -2063,7 +2063,7 @@
         },
         "semver-utils": {
           "version": "1.1.1",
-          "from": "semver-utils@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/semver-utils/-/semver-utils-1.1.1.tgz"
         },
         "shell-quote": {
@@ -2642,81 +2642,81 @@
     },
     "chokidar": {
       "version": "1.4.1",
-      "from": "chokidar@>=1.0.5 <2.0.0",
+      "from": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.4.1.tgz",
       "dependencies": {
         "anymatch": {
           "version": "1.3.0",
-          "from": "anymatch@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
           "dependencies": {
             "arrify": {
               "version": "1.0.1",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
             },
             "micromatch": {
               "version": "2.3.5",
-              "from": "micromatch@>=2.1.5 <3.0.0",
+              "from": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
               "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.5.tgz",
               "dependencies": {
                 "arr-diff": {
                   "version": "2.0.0",
-                  "from": "arr-diff@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
                   "dependencies": {
                     "arr-flatten": {
                       "version": "1.0.1",
-                      "from": "arr-flatten@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
                     }
                   }
                 },
                 "array-unique": {
                   "version": "0.2.1",
-                  "from": "array-unique@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
                 },
                 "braces": {
                   "version": "1.8.2",
-                  "from": "braces@>=1.8.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
                   "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.2.tgz",
                   "dependencies": {
                     "expand-range": {
                       "version": "1.8.1",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
                       "dependencies": {
                         "fill-range": {
                           "version": "2.2.3",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
                           "dependencies": {
                             "is-number": {
                               "version": "2.1.0",
-                              "from": "is-number@>=2.1.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
                             },
                             "isobject": {
                               "version": "2.0.0",
-                              "from": "isobject@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
                               "dependencies": {
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 }
                               }
                             },
                             "randomatic": {
                               "version": "1.1.5",
-                              "from": "randomatic@>=1.1.3 <2.0.0",
+                              "from": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz",
                               "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.5.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -2725,131 +2725,131 @@
                     },
                     "preserve": {
                       "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
                     },
                     "repeat-element": {
                       "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
                     }
                   }
                 },
                 "expand-brackets": {
                   "version": "0.1.4",
-                  "from": "expand-brackets@>=0.1.4 <0.2.0",
+                  "from": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz",
                   "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.4.tgz"
                 },
                 "extglob": {
                   "version": "0.3.1",
-                  "from": "extglob@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.1.tgz",
                   "dependencies": {
                     "ansi-green": {
                       "version": "0.1.1",
-                      "from": "ansi-green@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-green/-/ansi-green-0.1.1.tgz",
                       "dependencies": {
                         "ansi-wrap": {
                           "version": "0.1.0",
-                          "from": "ansi-wrap@0.1.0",
+                          "from": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz"
                         }
                       }
                     },
                     "success-symbol": {
                       "version": "0.1.0",
-                      "from": "success-symbol@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/success-symbol/-/success-symbol-0.1.0.tgz"
                     }
                   }
                 },
                 "filename-regex": {
                   "version": "2.0.0",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
                 },
                 "is-extglob": {
                   "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
                 },
                 "kind-of": {
                   "version": "3.0.2",
-                  "from": "kind-of@>=3.0.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz",
                   "dependencies": {
                     "is-buffer": {
                       "version": "1.1.0",
-                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                     }
                   }
                 },
                 "lazy-cache": {
                   "version": "0.2.7",
-                  "from": "lazy-cache@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                   "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
                 },
                 "normalize-path": {
                   "version": "2.0.1",
-                  "from": "normalize-path@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz"
                 },
                 "object.omit": {
                   "version": "2.0.0",
-                  "from": "object.omit@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.0.tgz",
                   "dependencies": {
                     "for-own": {
                       "version": "0.1.3",
-                      "from": "for-own@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
                       "dependencies": {
                         "for-in": {
                           "version": "0.1.4",
-                          "from": "for-in@>=0.1.4 <0.2.0",
+                          "from": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
                         }
                       }
                     },
                     "is-extendable": {
                       "version": "0.1.1",
-                      "from": "is-extendable@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
                     }
                   }
                 },
                 "parse-glob": {
                   "version": "3.0.4",
-                  "from": "parse-glob@>=3.0.4 <4.0.0",
+                  "from": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
                   "dependencies": {
                     "glob-base": {
                       "version": "0.3.0",
-                      "from": "glob-base@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
                     },
                     "is-dotfile": {
                       "version": "1.0.2",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz"
                     }
                   }
                 },
                 "regex-cache": {
                   "version": "0.4.2",
-                  "from": "regex-cache@>=0.4.2 <0.5.0",
+                  "from": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
                   "dependencies": {
                     "is-equal-shallow": {
                       "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
                     },
                     "is-primitive": {
                       "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
                     }
                   }
@@ -2860,76 +2860,76 @@
         },
         "async-each": {
           "version": "0.1.6",
-          "from": "async-each@>=0.1.6 <0.2.0",
+          "from": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
           "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
         },
         "glob-parent": {
           "version": "2.0.0",
-          "from": "glob-parent@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "is-binary-path": {
           "version": "1.0.1",
-          "from": "is-binary-path@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
           "dependencies": {
             "binary-extensions": {
               "version": "1.4.0",
-              "from": "binary-extensions@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz",
               "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.4.0.tgz"
             }
           }
         },
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "dependencies": {
             "is-extglob": {
               "version": "1.0.0",
-              "from": "is-extglob@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         },
         "readdirp": {
           "version": "2.0.0",
-          "from": "readdirp@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.0.0.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             },
             "minimatch": {
               "version": "2.0.10",
-              "from": "minimatch@>=2.0.10 <3.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -2938,32 +2938,32 @@
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -2974,103 +2974,103 @@
     },
     "css-loader": {
       "version": "0.23.1",
-      "from": "css-loader@>=0.23.0 <0.24.0",
+      "from": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.23.1.tgz",
       "dependencies": {
         "css-selector-tokenizer": {
           "version": "0.5.4",
-          "from": "css-selector-tokenizer@>=0.5.1 <0.6.0",
+          "from": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.5.4.tgz",
           "dependencies": {
             "cssesc": {
               "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
             },
             "fastparse": {
               "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
             }
           }
         },
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=2.6.1 <4.0.0",
+          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "dependencies": {
             "autoprefixer": {
               "version": "6.2.3",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
+              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
               "dependencies": {
                 "normalize-range": {
                   "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
                 },
                 "num2fraction": {
                   "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
                 },
                 "browserslist": {
                   "version": "1.0.1",
-                  "from": "browserslist@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000386",
-                  "from": "caniuse-db@>=1.0.30000382 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
             },
             "postcss-calc": {
               "version": "5.2.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -3079,32 +3079,32 @@
             },
             "postcss-colormin": {
               "version": "2.1.8",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "dependencies": {
                 "colormin": {
                   "version": "1.0.7",
-                  "from": "colormin@>=1.0.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -3113,7 +3113,7 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
+                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
                     }
                   }
@@ -3122,132 +3122,132 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
             },
             "postcss-discard-comments": {
               "version": "2.0.3",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
             },
             "postcss-discard-unused": {
               "version": "2.1.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
+                  "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.3",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.2",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                     }
                   }
@@ -3256,49 +3256,49 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
             },
             "postcss-normalize-url": {
               "version": "3.0.4",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                         }
                       }
@@ -3309,154 +3309,154 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "1.1.4",
-                      "from": "sax@>=1.1.4 <1.2.0",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
                     },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                         }
                       }
                     },
                     "js-yaml": {
                       "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "1.0.3",
-                          "from": "argparse@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
                           "dependencies": {
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
                         },
                         "inherit": {
                           "version": "2.2.3",
-                          "from": "inherit@>=2.2.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
+                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
                     },
                     "whet.extend": {
                       "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
                       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
+                      "from": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
+                          "from": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
@@ -3471,34 +3471,34 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
             },
             "postcss-zindex": {
               "version": "2.0.1",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
@@ -3507,44 +3507,44 @@
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "lodash.camelcase": {
           "version": "3.0.1",
-          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
           "dependencies": {
             "lodash._createcompounder": {
               "version": "3.0.0",
-              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
               "dependencies": {
                 "lodash.deburr": {
                   "version": "3.1.0",
-                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.1.0.tgz"
                 },
                 "lodash.words": {
                   "version": "3.1.0",
-                  "from": "lodash.words@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.words/-/lodash.words-3.1.0.tgz"
                 }
               }
@@ -3553,85 +3553,85 @@
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.10 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "postcss-modules-extract-imports": {
           "version": "1.0.0",
-          "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.0.tgz"
         },
         "postcss-modules-local-by-default": {
           "version": "1.0.1",
-          "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.0.1.tgz"
         },
         "postcss-modules-scope": {
           "version": "1.0.0",
-          "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.0.tgz"
         },
         "postcss-modules-values": {
           "version": "1.1.1",
-          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.1.1.tgz",
           "dependencies": {
             "icss-replace-symbols": {
               "version": "1.0.2",
-              "from": "icss-replace-symbols@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz"
             }
           }
         },
         "source-list-map": {
           "version": "0.1.5",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
           "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
         }
       }
     },
     "file-loader": {
       "version": "0.8.5",
-      "from": "file-loader@>=0.8.1 <0.9.0",
+      "from": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.8.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
@@ -3640,44 +3640,44 @@
     },
     "glob": {
       "version": "5.0.15",
-      "from": "glob@>=5.0.0 <5.1.0",
+      "from": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
       "dependencies": {
         "inflight": {
           "version": "1.0.4",
-          "from": "inflight@>=1.0.4 <2.0.0",
+          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "inherits": {
           "version": "2.0.1",
-          "from": "inherits@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
         },
         "minimatch": {
           "version": "3.0.0",
-          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
           "dependencies": {
             "brace-expansion": {
               "version": "1.1.2",
-              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
               "dependencies": {
                 "balanced-match": {
                   "version": "0.3.0",
-                  "from": "balanced-match@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                 },
                 "concat-map": {
                   "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
+                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                 }
               }
@@ -3686,144 +3686,144 @@
         },
         "once": {
           "version": "1.3.3",
-          "from": "once@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.1",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
             }
           }
         },
         "path-is-absolute": {
           "version": "1.0.0",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
         }
       }
     },
     "gulp": {
       "version": "3.9.0",
-      "from": "gulp@>=3.9.0 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.0.tgz",
       "dependencies": {
         "archy": {
           "version": "1.0.0",
-          "from": "archy@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "deprecated": {
           "version": "0.0.1",
-          "from": "deprecated@>=0.0.1 <0.0.2",
+          "from": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "liftoff": {
           "version": "2.2.0",
-          "from": "liftoff@>=2.1.0 <3.0.0",
+          "from": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.0.tgz",
           "dependencies": {
             "extend": {
               "version": "2.0.1",
-              "from": "extend@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "findup-sync": {
               "version": "0.3.0",
-              "from": "findup-sync@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
             },
             "flagged-respawn": {
               "version": "0.3.1",
-              "from": "flagged-respawn@>=0.3.1 <0.4.0",
+              "from": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz",
               "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
             },
             "rechoir": {
               "version": "0.6.2",
-              "from": "rechoir@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
               "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.1.6 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "orchestrator": {
           "version": "0.3.7",
-          "from": "orchestrator@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
           "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
           "dependencies": {
             "end-of-stream": {
               "version": "0.1.5",
-              "from": "end-of-stream@>=0.1.5 <0.2.0",
+              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
               "dependencies": {
                 "once": {
                   "version": "1.3.3",
-                  "from": "once@>=1.3.0 <1.4.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -3832,102 +3832,102 @@
             },
             "sequencify": {
               "version": "0.0.7",
-              "from": "sequencify@>=0.0.7 <0.1.0",
+              "from": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
             },
             "stream-consume": {
               "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
             }
           }
         },
         "pretty-hrtime": {
           "version": "1.0.1",
-          "from": "pretty-hrtime@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz"
         },
         "semver": {
           "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
+          "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "tildify": {
           "version": "1.1.2",
-          "from": "tildify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.2.tgz",
           "dependencies": {
             "os-homedir": {
               "version": "1.0.1",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
             }
           }
         },
         "v8flags": {
           "version": "2.0.10",
-          "from": "v8flags@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
           "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.10.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
-              "from": "user-home@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
         },
         "vinyl-fs": {
           "version": "0.3.14",
-          "from": "vinyl-fs@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
           "dependencies": {
             "defaults": {
               "version": "1.0.3",
-              "from": "defaults@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
               "dependencies": {
                 "clone": {
                   "version": "1.0.2",
-                  "from": "clone@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
                 }
               }
             },
             "glob-stream": {
               "version": "3.1.18",
-              "from": "glob-stream@>=3.1.5 <4.0.0",
+              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -3936,22 +3936,22 @@
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -3960,78 +3960,78 @@
                 },
                 "ordered-read-streams": {
                   "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                 },
                 "glob2base": {
                   "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "dependencies": {
                     "find-index": {
                       "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                     }
                   }
                 },
                 "unique-stream": {
                   "version": "1.0.0",
-                  "from": "unique-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
                 }
               }
             },
             "glob-watcher": {
               "version": "0.0.6",
-              "from": "glob-watcher@>=0.0.6 <0.0.7",
+              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
               "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
               "dependencies": {
                 "gaze": {
                   "version": "0.5.2",
-                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                         },
                         "glob": {
                           "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                             },
                             "inherits": {
                               "version": "1.0.2",
-                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                             }
                           }
                         },
                         "minimatch": {
                           "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.7.3",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
@@ -4044,90 +4044,90 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -4138,127 +4138,127 @@
     },
     "gulp-autoprefixer": {
       "version": "3.1.0",
-      "from": "gulp-autoprefixer@>=3.1.0 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.0.tgz",
       "dependencies": {
         "autoprefixer": {
           "version": "6.2.3",
-          "from": "autoprefixer@>=6.0.2 <7.0.0",
+          "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
           "dependencies": {
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
             },
             "normalize-range": {
               "version": "0.1.2",
-              "from": "normalize-range@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
             },
             "num2fraction": {
               "version": "1.2.2",
-              "from": "num2fraction@>=1.2.2 <2.0.0",
+              "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
             },
             "browserslist": {
               "version": "1.0.1",
-              "from": "browserslist@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
             },
             "caniuse-db": {
               "version": "1.0.30000386",
-              "from": "caniuse-db@>=1.0.30000382 <2.0.0",
+              "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
               "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
             }
           }
         },
         "postcss": {
           "version": "5.0.14",
-          "from": "postcss@>=5.0.10 <6.0.0",
+          "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
           "dependencies": {
             "supports-color": {
               "version": "3.1.2",
-              "from": "supports-color@>=3.1.2 <4.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
               "dependencies": {
                 "has-flag": {
                   "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                 }
               }
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "js-base64": {
               "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
+              "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
               "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.1",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -4267,76 +4267,76 @@
     },
     "gulp-babel": {
       "version": "5.3.0",
-      "from": "gulp-babel@>=5.2.1 <6.0.0",
+      "from": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-5.3.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-babel/-/gulp-babel-5.3.0.tgz",
       "dependencies": {
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
+          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -4345,49 +4345,49 @@
     },
     "gulp-buffer": {
       "version": "0.0.2",
-      "from": "gulp-buffer@0.0.2",
+      "from": "https://registry.npmjs.org/gulp-buffer/-/gulp-buffer-0.0.2.tgz",
       "resolved": "https://registry.npmjs.org/gulp-buffer/-/gulp-buffer-0.0.2.tgz",
       "dependencies": {
         "through2": {
           "version": "0.4.2",
-          "from": "through2@>=0.4.0 <0.5.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "2.1.2",
-              "from": "xtend@>=2.1.1 <2.2.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
                 }
               }
@@ -4398,56 +4398,56 @@
     },
     "gulp-concat": {
       "version": "2.6.0",
-      "from": "gulp-concat@>=2.6.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
       "dependencies": {
         "concat-with-sourcemaps": {
           "version": "1.0.4",
-          "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.4.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -4456,115 +4456,115 @@
     },
     "gulp-cssnano": {
       "version": "2.1.0",
-      "from": "gulp-cssnano@>=2.1.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.0.tgz",
       "dependencies": {
         "cssnano": {
           "version": "3.4.0",
-          "from": "cssnano@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.4.0.tgz",
           "dependencies": {
             "autoprefixer": {
               "version": "6.2.3",
-              "from": "autoprefixer@>=6.0.3 <7.0.0",
+              "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
               "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.2.3.tgz",
               "dependencies": {
                 "normalize-range": {
                   "version": "0.1.2",
-                  "from": "normalize-range@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
                 },
                 "num2fraction": {
                   "version": "1.2.2",
-                  "from": "num2fraction@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
                 },
                 "browserslist": {
                   "version": "1.0.1",
-                  "from": "browserslist@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.0.1.tgz"
                 },
                 "caniuse-db": {
                   "version": "1.0.30000386",
-                  "from": "caniuse-db@>=1.0.30000382 <2.0.0",
+                  "from": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz",
                   "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000386.tgz"
                 }
               }
             },
             "decamelize": {
               "version": "1.1.2",
-              "from": "decamelize@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
               "dependencies": {
                 "escape-string-regexp": {
                   "version": "1.0.4",
-                  "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                 }
               }
             },
             "defined": {
               "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
             },
             "indexes-of": {
               "version": "1.0.1",
-              "from": "indexes-of@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
             },
             "postcss": {
               "version": "5.0.14",
-              "from": "postcss@>=5.0.10 <6.0.0",
+              "from": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
               "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.0.14.tgz",
               "dependencies": {
                 "supports-color": {
                   "version": "3.1.2",
-                  "from": "supports-color@>=3.1.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                   "dependencies": {
                     "has-flag": {
                       "version": "1.0.0",
-                      "from": "has-flag@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
                     }
                   }
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                 },
                 "js-base64": {
                   "version": "2.1.9",
-                  "from": "js-base64@>=2.1.9 <3.0.0",
+                  "from": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
                   "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
                 }
               }
             },
             "postcss-calc": {
               "version": "5.2.0",
-              "from": "postcss-calc@>=5.0.0 <6.0.0",
+              "from": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.2.0.tgz",
               "dependencies": {
                 "postcss-message-helpers": {
                   "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
                 },
                 "reduce-css-calc": {
                   "version": "1.2.0",
-                  "from": "reduce-css-calc@>=1.2.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.2.0.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.1.0",
-                      "from": "balanced-match@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.1.0.tgz"
                     },
                     "reduce-function-call": {
                       "version": "1.0.1",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.1.tgz"
                     }
                   }
@@ -4573,32 +4573,32 @@
             },
             "postcss-colormin": {
               "version": "2.1.8",
-              "from": "postcss-colormin@>=2.1.7 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.1.8.tgz",
               "dependencies": {
                 "colormin": {
                   "version": "1.0.7",
-                  "from": "colormin@>=1.0.5 <2.0.0",
+                  "from": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.0.7.tgz",
                   "dependencies": {
                     "color": {
                       "version": "0.11.1",
-                      "from": "color@>=0.11.0 <0.12.0",
+                      "from": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "resolved": "https://registry.npmjs.org/color/-/color-0.11.1.tgz",
                       "dependencies": {
                         "color-convert": {
                           "version": "0.5.3",
-                          "from": "color-convert@>=0.5.3 <0.6.0",
+                          "from": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
                           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
                         },
                         "color-string": {
                           "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
                           "dependencies": {
                             "color-name": {
                               "version": "1.1.1",
-                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
                             }
                           }
@@ -4607,7 +4607,7 @@
                     },
                     "css-color-names": {
                       "version": "0.0.3",
-                      "from": "css-color-names@0.0.3",
+                      "from": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.3.tgz"
                     }
                   }
@@ -4616,132 +4616,132 @@
             },
             "postcss-convert-values": {
               "version": "2.3.4",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.3.4.tgz"
             },
             "postcss-discard-comments": {
               "version": "2.0.3",
-              "from": "postcss-discard-comments@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.3.tgz"
             },
             "postcss-discard-duplicates": {
               "version": "2.0.0",
-              "from": "postcss-discard-duplicates@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.0.0.tgz"
             },
             "postcss-discard-empty": {
               "version": "2.0.0",
-              "from": "postcss-discard-empty@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.0.0.tgz"
             },
             "postcss-discard-unused": {
               "version": "2.1.0",
-              "from": "postcss-discard-unused@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.1.0.tgz",
               "dependencies": {
                 "flatten": {
                   "version": "0.0.1",
-                  "from": "flatten@0.0.1",
+                  "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-filter-plugins": {
               "version": "2.0.0",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.0.tgz",
               "dependencies": {
                 "uniqid": {
                   "version": "1.0.0",
-                  "from": "uniqid@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-idents": {
               "version": "2.1.3",
-              "from": "postcss-merge-idents@>=2.1.3 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.3.tgz",
               "dependencies": {
                 "has-own": {
                   "version": "1.0.0",
-                  "from": "has-own@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-own/-/has-own-1.0.0.tgz"
                 }
               }
             },
             "postcss-merge-longhand": {
               "version": "2.0.1",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.1.tgz"
             },
             "postcss-merge-rules": {
               "version": "2.0.3",
-              "from": "postcss-merge-rules@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.0.3.tgz"
             },
             "postcss-minify-font-values": {
               "version": "1.0.2",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.2.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-gradients": {
               "version": "1.0.1",
-              "from": "postcss-minify-gradients@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.1.tgz"
             },
             "postcss-minify-params": {
               "version": "1.0.4",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.0.4.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-minify-selectors": {
               "version": "2.0.2",
-              "from": "postcss-minify-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.0.2.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "postcss-selector-parser": {
                   "version": "1.3.0",
-                  "from": "postcss-selector-parser@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.0.tgz",
                   "dependencies": {
                     "flatten": {
                       "version": "0.0.1",
-                      "from": "flatten@0.0.1",
+                      "from": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/flatten/-/flatten-0.0.1.tgz"
                     },
                     "uniq": {
                       "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
                     }
                   }
@@ -4750,49 +4750,49 @@
             },
             "postcss-normalize-charset": {
               "version": "1.1.0",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.0.tgz"
             },
             "postcss-normalize-url": {
               "version": "3.0.4",
-              "from": "postcss-normalize-url@>=3.0.4 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
               "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.4.tgz",
               "dependencies": {
                 "is-absolute-url": {
                   "version": "2.0.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.0.0.tgz"
                 },
                 "normalize-url": {
                   "version": "1.4.0",
-                  "from": "normalize-url@>=1.3.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.4.0.tgz",
                   "dependencies": {
                     "prepend-http": {
                       "version": "1.0.3",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.3.tgz"
                     },
                     "query-string": {
                       "version": "3.0.0",
-                      "from": "query-string@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.0.tgz",
                       "dependencies": {
                         "strict-uri-encode": {
                           "version": "1.1.0",
-                          "from": "strict-uri-encode@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
                         }
                       }
                     },
                     "sort-keys": {
                       "version": "1.1.1",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.1.tgz",
                       "dependencies": {
                         "is-plain-obj": {
                           "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
                         }
                       }
@@ -4803,154 +4803,154 @@
             },
             "postcss-ordered-values": {
               "version": "2.0.2",
-              "from": "postcss-ordered-values@>=2.0.2 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz",
               "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.0.2.tgz"
             },
             "postcss-reduce-idents": {
               "version": "2.2.1",
-              "from": "postcss-reduce-idents@>=2.2.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.2.1.tgz"
             },
             "postcss-reduce-transforms": {
               "version": "1.0.3",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+              "from": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.3.tgz"
             },
             "postcss-svgo": {
               "version": "2.1.1",
-              "from": "postcss-svgo@>=2.0.4 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.1.tgz",
               "dependencies": {
                 "is-svg": {
                   "version": "1.1.1",
-                  "from": "is-svg@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-1.1.1.tgz"
                 },
                 "svgo": {
                   "version": "0.6.1",
-                  "from": "svgo@>=0.6.1 <0.7.0",
+                  "from": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.6.1.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "1.1.4",
-                      "from": "sax@>=1.1.4 <1.2.0",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz"
                     },
                     "coa": {
                       "version": "1.0.1",
-                      "from": "coa@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
                       "dependencies": {
                         "q": {
                           "version": "1.4.1",
-                          "from": "q@>=1.1.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
                         }
                       }
                     },
                     "js-yaml": {
                       "version": "3.4.6",
-                      "from": "js-yaml@>=3.4.3 <3.5.0",
+                      "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.4.6.tgz",
                       "dependencies": {
                         "argparse": {
                           "version": "1.0.3",
-                          "from": "argparse@>=1.0.2 <2.0.0",
+                          "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.3.tgz",
                           "dependencies": {
                             "sprintf-js": {
                               "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                               "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
                             }
                           }
                         },
                         "esprima": {
                           "version": "2.7.1",
-                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
                           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
                         },
                         "inherit": {
                           "version": "2.2.3",
-                          "from": "inherit@>=2.2.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz",
                           "resolved": "https://registry.npmjs.org/inherit/-/inherit-2.2.3.tgz"
                         }
                       }
                     },
                     "colors": {
                       "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
+                      "from": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
                     },
                     "whet.extend": {
                       "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "from": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
                       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
                     },
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
+                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                         }
                       }
                     },
                     "csso": {
                       "version": "1.4.4",
-                      "from": "csso@>=1.4.2 <1.5.0",
+                      "from": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "resolved": "https://registry.npmjs.org/csso/-/csso-1.4.4.tgz",
                       "dependencies": {
                         "clap": {
                           "version": "1.0.10",
-                          "from": "clap@>=1.0.9 <2.0.0",
+                          "from": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "resolved": "https://registry.npmjs.org/clap/-/clap-1.0.10.tgz",
                           "dependencies": {
                             "chalk": {
                               "version": "1.1.1",
-                              "from": "chalk@1.1.1",
+                              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                               "dependencies": {
                                 "ansi-styles": {
                                   "version": "2.1.0",
-                                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                                 },
                                 "escape-string-regexp": {
                                   "version": "1.0.4",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                                 },
                                 "has-ansi": {
                                   "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "strip-ansi": {
                                   "version": "3.0.0",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                                   "dependencies": {
                                     "ansi-regex": {
                                       "version": "2.0.0",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                                     }
                                   }
                                 },
                                 "supports-color": {
                                   "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                                 }
                               }
@@ -4965,34 +4965,34 @@
             },
             "postcss-unique-selectors": {
               "version": "2.0.1",
-              "from": "postcss-unique-selectors@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.1.tgz",
               "dependencies": {
                 "alphanum-sort": {
                   "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
                 },
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
             },
             "postcss-value-parser": {
               "version": "3.2.3",
-              "from": "postcss-value-parser@>=3.1.1 <4.0.0",
+              "from": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.2.3.tgz"
             },
             "postcss-zindex": {
               "version": "2.0.1",
-              "from": "postcss-zindex@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.0.1.tgz",
               "dependencies": {
                 "uniqs": {
                   "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
                 }
               }
@@ -5001,17 +5001,17 @@
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.1",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -5020,32 +5020,32 @@
     },
     "gulp-if": {
       "version": "2.0.0",
-      "from": "gulp-if@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.0.tgz",
       "dependencies": {
         "gulp-match": {
           "version": "1.0.0",
-          "from": "gulp-match@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.0.tgz",
           "dependencies": {
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -5056,27 +5056,27 @@
         },
         "ternary-stream": {
           "version": "2.0.0",
-          "from": "ternary-stream@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.0.tgz",
           "dependencies": {
             "duplexify": {
               "version": "3.4.2",
-              "from": "duplexify@>=3.4.2 <4.0.0",
+              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "from": "end-of-stream@1.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -5085,37 +5085,37 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -5124,47 +5124,47 @@
             },
             "fork-stream": {
               "version": "0.0.4",
-              "from": "fork-stream@>=0.0.4 <0.0.5",
+              "from": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz"
             },
             "merge-stream": {
               "version": "1.0.0",
-              "from": "merge-stream@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -5175,49 +5175,49 @@
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -5226,152 +5226,152 @@
     },
     "gulp-less": {
       "version": "3.0.5",
-      "from": "gulp-less@>=3.0.3 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
       "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.5.tgz",
       "dependencies": {
         "accord": {
           "version": "0.20.5",
-          "from": "accord@>=0.20.1 <0.21.0",
+          "from": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
           "resolved": "https://registry.npmjs.org/accord/-/accord-0.20.5.tgz",
           "dependencies": {
             "convert-source-map": {
               "version": "1.1.2",
-              "from": "convert-source-map@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
             },
             "fobject": {
               "version": "0.0.3",
-              "from": "fobject@0.0.3",
+              "from": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.8",
-                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
                 }
               }
             },
             "indx": {
               "version": "0.2.3",
-              "from": "indx@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
             },
             "resolve": {
               "version": "1.1.6",
-              "from": "resolve@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
             },
             "semver": {
               "version": "4.3.6",
-              "from": "semver@>=4.3.4 <5.0.0",
+              "from": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
               "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
             },
             "uglify-js": {
               "version": "2.6.1",
-              "from": "uglify-js@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
               "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
                   "version": "0.5.3",
-                  "from": "source-map@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
                 },
                 "uglify-to-browserify": {
                   "version": "1.0.2",
-                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
                 },
                 "yargs": {
                   "version": "3.10.0",
-                  "from": "yargs@>=3.10.0 <3.11.0",
+                  "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.2.1",
-                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                     },
                     "cliui": {
                       "version": "2.1.0",
-                      "from": "cliui@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                       "dependencies": {
                         "center-align": {
                           "version": "0.1.2",
-                          "from": "center-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
                             },
                             "lazy-cache": {
                               "version": "0.2.7",
-                              "from": "lazy-cache@>=0.2.4 <0.3.0",
+                              "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                               "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
                             }
                           }
                         },
                         "right-align": {
                           "version": "0.1.3",
-                          "from": "right-align@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.1 <0.2.0",
+                              "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
                                   "version": "2.0.1",
-                                  "from": "kind-of@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                                   "dependencies": {
                                     "is-buffer": {
                                       "version": "1.1.0",
-                                      "from": "is-buffer@>=1.0.2 <2.0.0",
+                                      "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                     }
                                   }
                                 },
                                 "longest": {
                                   "version": "1.0.1",
-                                  "from": "longest@>=1.0.1 <2.0.0",
+                                  "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                                 },
                                 "repeat-string": {
                                   "version": "1.5.2",
-                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                                   "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                                 }
                               }
@@ -5380,19 +5380,19 @@
                         },
                         "wordwrap": {
                           "version": "0.0.2",
-                          "from": "wordwrap@0.0.2",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                         }
                       }
                     },
                     "decamelize": {
                       "version": "1.1.1",
-                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
                     },
                     "window-size": {
                       "version": "0.1.0",
-                      "from": "window-size@0.1.0",
+                      "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                     }
                   }
@@ -5401,73 +5401,73 @@
             },
             "when": {
               "version": "3.7.5",
-              "from": "when@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/when/-/when-3.7.5.tgz",
               "resolved": "https://registry.npmjs.org/when/-/when-3.7.5.tgz"
             }
           }
         },
         "object-assign": {
           "version": "4.0.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -5476,44 +5476,44 @@
     },
     "gulp-plumber": {
       "version": "1.0.1",
-      "from": "gulp-plumber@>=1.0.1 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.0.1.tgz",
       "dependencies": {
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -5522,185 +5522,185 @@
     },
     "gulp-size": {
       "version": "2.0.0",
-      "from": "gulp-size@>=2.0.0 <3.0.0",
+      "from": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-2.0.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.4",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "gzip-size": {
           "version": "3.0.0",
-          "from": "gzip-size@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
           "dependencies": {
             "duplexer": {
               "version": "0.1.1",
-              "from": "duplexer@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
             }
           }
         },
         "pretty-bytes": {
           "version": "2.0.1",
-          "from": "pretty-bytes@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-2.0.1.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.7.0",
-              "from": "meow@>=3.1.0 <4.0.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.0.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.0.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.2",
-                  "from": "decamelize@>=1.1.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.2.tgz",
                   "dependencies": {
                     "escape-string-regexp": {
                       "version": "1.0.4",
-                      "from": "escape-string-regexp@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.2.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                   "dependencies": {
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "signal-exit@>=2.1.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "map-obj@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.2.0",
-                              "from": "spdx-license-ids@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz"
                             }
                           }
@@ -5711,32 +5711,32 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                             }
                           }
@@ -5745,32 +5745,32 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
@@ -5779,29 +5779,29 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
                                 }
                               }
@@ -5810,27 +5810,27 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                 }
                               }
@@ -5843,22 +5843,22 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz"
                             }
                           }
@@ -5867,75 +5867,75 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
             },
             "number-is-nan": {
               "version": "1.0.0",
-              "from": "number-is-nan@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
             }
           }
         },
         "stream-counter": {
           "version": "1.0.0",
-          "from": "stream-counter@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-1.0.0.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -5944,98 +5944,98 @@
     },
     "gulp-sourcemaps": {
       "version": "1.6.0",
-      "from": "gulp-sourcemaps@>=1.5.2 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
       "dependencies": {
         "convert-source-map": {
           "version": "1.1.2",
-          "from": "convert-source-map@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.2.tgz"
         },
         "graceful-fs": {
           "version": "4.1.2",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
         },
         "strip-bom": {
           "version": "2.0.0",
-          "from": "strip-bom@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "dependencies": {
             "is-utf8": {
               "version": "0.2.0",
-              "from": "is-utf8@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl": {
           "version": "1.1.0",
-          "from": "vinyl@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.1.0.tgz",
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             },
             "replace-ext": {
               "version": "0.0.1",
-              "from": "replace-ext@0.0.1",
+              "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
             }
           }
@@ -6044,171 +6044,171 @@
     },
     "gulp-uglify": {
       "version": "1.5.1",
-      "from": "gulp-uglify@>=1.4.0 <2.0.0",
+      "from": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.5.1.tgz",
       "dependencies": {
         "deap": {
           "version": "1.0.0",
-          "from": "deap@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/deap/-/deap-1.0.0.tgz"
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
           "dependencies": {
             "chalk": {
               "version": "1.1.1",
-              "from": "chalk@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "2.1.0",
-                  "from": "ansi-styles@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "3.0.0",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "2.0.0",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.12",
-              "from": "dateformat@>=1.0.11 <2.0.0",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "4.0.1",
-                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                 },
                 "meow": {
                   "version": "3.6.0",
-                  "from": "meow@>=3.3.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "2.0.0",
-                      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "2.0.1",
-                          "from": "camelcase@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "loud-rejection": {
                       "version": "1.2.0",
-                      "from": "loud-rejection@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                       "dependencies": {
                         "signal-exit": {
                           "version": "2.1.2",
-                          "from": "signal-exit@>=2.1.2 <3.0.0",
+                          "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                         }
                       }
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.3 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "normalize-package-data": {
                       "version": "2.3.5",
-                      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                       "dependencies": {
                         "hosted-git-info": {
                           "version": "2.1.4",
-                          "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                          "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                         },
                         "is-builtin-module": {
                           "version": "1.0.0",
-                          "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                           "dependencies": {
                             "builtin-modules": {
                               "version": "1.1.0",
-                              "from": "builtin-modules@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                             }
                           }
                         },
                         "semver": {
                           "version": "5.1.0",
-                          "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                          "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                         },
                         "validate-npm-package-license": {
                           "version": "3.0.1",
-                          "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                          "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                           "dependencies": {
                             "spdx-correct": {
                               "version": "1.0.2",
-                              "from": "spdx-correct@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
                             },
                             "spdx-expression-parse": {
                               "version": "1.0.2",
-                              "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                               "dependencies": {
                                 "spdx-exceptions": {
                                   "version": "1.0.4",
-                                  "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                                 },
                                 "spdx-license-ids": {
                                   "version": "1.1.0",
-                                  "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                                 }
                               }
@@ -6219,32 +6219,32 @@
                     },
                     "object-assign": {
                       "version": "4.0.1",
-                      "from": "object-assign@>=4.0.1 <5.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                     },
                     "read-pkg-up": {
                       "version": "1.0.1",
-                      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                       "dependencies": {
                         "find-up": {
                           "version": "1.1.0",
-                          "from": "find-up@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                           "dependencies": {
                             "path-exists": {
                               "version": "2.1.0",
-                              "from": "path-exists@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                 }
                               }
@@ -6253,32 +6253,32 @@
                         },
                         "read-pkg": {
                           "version": "1.1.0",
-                          "from": "read-pkg@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                           "dependencies": {
                             "load-json-file": {
                               "version": "1.1.0",
-                              "from": "load-json-file@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "parse-json": {
                                   "version": "2.2.0",
-                                  "from": "parse-json@>=2.2.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                                   "dependencies": {
                                     "error-ex": {
                                       "version": "1.3.0",
-                                      "from": "error-ex@>=1.2.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                       "dependencies": {
                                         "is-arrayish": {
                                           "version": "0.2.1",
-                                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                          "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                           "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                         }
                                       }
@@ -6287,29 +6287,29 @@
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.1",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                     }
                                   }
                                 },
                                 "strip-bom": {
                                   "version": "2.0.0",
-                                  "from": "strip-bom@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                                   "dependencies": {
                                     "is-utf8": {
                                       "version": "0.2.0",
-                                      "from": "is-utf8@>=0.2.0 <0.3.0",
+                                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                                       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                     }
                                   }
@@ -6318,27 +6318,27 @@
                             },
                             "path-type": {
                               "version": "1.1.0",
-                              "from": "path-type@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                               "dependencies": {
                                 "graceful-fs": {
                                   "version": "4.1.2",
-                                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                                 },
                                 "pify": {
                                   "version": "2.3.0",
-                                  "from": "pify@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                                 },
                                 "pinkie-promise": {
                                   "version": "2.0.0",
-                                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                                   "dependencies": {
                                     "pinkie": {
                                       "version": "2.0.1",
-                                      "from": "pinkie@>=2.0.0 <3.0.0",
+                                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                     }
                                   }
@@ -6351,27 +6351,27 @@
                     },
                     "redent": {
                       "version": "1.0.0",
-                      "from": "redent@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                       "dependencies": {
                         "indent-string": {
                           "version": "2.1.0",
-                          "from": "indent-string@>=2.1.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                           "dependencies": {
                             "repeating": {
                               "version": "2.0.0",
-                              "from": "repeating@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                               "dependencies": {
                                 "is-finite": {
                                   "version": "1.0.1",
-                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                                   "dependencies": {
                                     "number-is-nan": {
                                       "version": "1.0.0",
-                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                     }
                                   }
@@ -6382,14 +6382,14 @@
                         },
                         "strip-indent": {
                           "version": "1.0.1",
-                          "from": "strip-indent@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                         }
                       }
                     },
                     "trim-newlines": {
                       "version": "1.0.0",
-                      "from": "trim-newlines@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                     }
                   }
@@ -6400,171 +6400,171 @@
         },
         "isobject": {
           "version": "2.0.0",
-          "from": "isobject@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.0.0.tgz",
           "dependencies": {
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             }
           }
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "uglify-js": {
           "version": "2.6.0",
-          "from": "uglify-js@2.6.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.0.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -6573,19 +6573,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -6594,17 +6594,17 @@
         },
         "uglify-save-license": {
           "version": "0.4.1",
-          "from": "uglify-save-license@>=0.4.1 <0.5.0",
+          "from": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz",
           "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.2.0",
-          "from": "vinyl-sourcemaps-apply@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.0.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.1 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             }
           }
@@ -6613,171 +6613,171 @@
     },
     "gulp-util": {
       "version": "3.0.7",
-      "from": "gulp-util@>=3.0.6 <4.0.0",
+      "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
       "dependencies": {
         "array-differ": {
           "version": "1.0.0",
-          "from": "array-differ@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
         },
         "array-uniq": {
           "version": "1.0.2",
-          "from": "array-uniq@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
         },
         "beeper": {
           "version": "1.1.0",
-          "from": "beeper@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.0.tgz"
         },
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.11 <2.0.0",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "meow": {
               "version": "3.6.0",
-              "from": "meow@>=3.3.0 <4.0.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.6.0.tgz",
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.0.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.0.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "2.0.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.0.1.tgz"
                     },
                     "map-obj": {
                       "version": "1.0.1",
-                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                     }
                   }
                 },
                 "loud-rejection": {
                   "version": "1.2.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.2.0.tgz",
                   "dependencies": {
                     "signal-exit": {
                       "version": "2.1.2",
-                      "from": "signal-exit@>=2.1.2 <3.0.0",
+                      "from": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-2.1.2.tgz"
                     }
                   }
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
+                  "from": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.4",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                      "from": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz",
                       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.4.tgz"
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.0",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.0.tgz"
                         }
                       }
                     },
                     "semver": {
                       "version": "5.1.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                      "from": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.0.tgz"
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                      "from": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.2",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
                           "dependencies": {
                             "spdx-exceptions": {
                               "version": "1.0.4",
-                              "from": "spdx-exceptions@>=1.0.4 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz"
                             },
                             "spdx-license-ids": {
                               "version": "1.1.0",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz",
                               "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.1.0.tgz"
                             }
                           }
@@ -6788,32 +6788,32 @@
                 },
                 "object-assign": {
                   "version": "4.0.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.0.1.tgz"
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.0",
-                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.0.tgz",
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
                         },
                         "pinkie-promise": {
                           "version": "2.0.0",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.1",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                             }
                           }
@@ -6822,32 +6822,32 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "from": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
                                       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
                                     }
                                   }
@@ -6856,29 +6856,29 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.0",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                                 }
                               }
@@ -6887,27 +6887,27 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.2",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                               "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
                             },
                             "pinkie-promise": {
                               "version": "2.0.0",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.1",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                                 }
                               }
@@ -6920,27 +6920,27 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.0",
-                          "from": "repeating@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.0.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -6951,14 +6951,14 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
                 }
               }
@@ -6967,22 +6967,22 @@
         },
         "fancy-log": {
           "version": "1.1.0",
-          "from": "fancy-log@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.1.0.tgz"
         },
         "gulplog": {
           "version": "1.0.0",
-          "from": "gulplog@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
           "dependencies": {
             "glogg": {
               "version": "1.0.0",
-              "from": "glogg@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
               "dependencies": {
                 "sparkles": {
                   "version": "1.0.0",
-                  "from": "sparkles@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
                 }
               }
@@ -6991,133 +6991,133 @@
         },
         "has-gulplog": {
           "version": "0.1.0",
-          "from": "has-gulplog@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
           "dependencies": {
             "sparkles": {
               "version": "1.0.0",
-              "from": "sparkles@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
             }
           }
         },
         "lodash._reescape": {
           "version": "3.0.0",
-          "from": "lodash._reescape@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
         },
         "lodash._reevaluate": {
           "version": "3.0.0",
-          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
         },
         "lodash._reinterpolate": {
           "version": "3.0.0",
-          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
         },
         "lodash.template": {
           "version": "3.6.2",
-          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
           "dependencies": {
             "lodash._basecopy": {
               "version": "3.0.1",
-              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
             },
             "lodash._basetostring": {
               "version": "3.0.1",
-              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz"
             },
             "lodash._basevalues": {
               "version": "3.0.0",
-              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
             },
             "lodash._isiterateecall": {
               "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
               "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
             },
             "lodash.escape": {
               "version": "3.0.0",
-              "from": "lodash.escape@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
             },
             "lodash.keys": {
               "version": "3.1.2",
-              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
               "dependencies": {
                 "lodash._getnative": {
                   "version": "3.9.1",
-                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.4",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.4.tgz"
                 },
                 "lodash.isarray": {
                   "version": "3.0.4",
-                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                 }
               }
             },
             "lodash.restparam": {
               "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
             },
             "lodash.templatesettings": {
               "version": "3.1.0",
-              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
             }
           }
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         },
         "multipipe": {
           "version": "0.1.2",
-          "from": "multipipe@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
           "dependencies": {
             "duplexer2": {
               "version": "0.0.2",
-              "from": "duplexer2@0.0.2",
+              "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
@@ -7128,76 +7128,76 @@
         },
         "object-assign": {
           "version": "3.0.0",
-          "from": "object-assign@>=3.0.0 <4.0.0",
+          "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
         },
         "replace-ext": {
           "version": "0.0.1",
-          "from": "replace-ext@0.0.1",
+          "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
         },
         "through2": {
           "version": "2.0.0",
-          "from": "through2@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
         },
         "vinyl": {
           "version": "0.5.3",
-          "from": "vinyl@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
           "dependencies": {
             "clone": {
               "version": "1.0.2",
-              "from": "clone@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
@@ -7206,34 +7206,34 @@
     },
     "imports-loader": {
       "version": "0.6.5",
-      "from": "imports-loader@>=0.6.3 <0.7.0",
+      "from": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.6.5.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "source-map": {
           "version": "0.1.43",
-          "from": "source-map@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
@@ -7242,103 +7242,103 @@
     },
     "less": {
       "version": "2.5.3",
-      "from": "less@>=2.5.1 <3.0.0",
+      "from": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
       "resolved": "https://registry.npmjs.org/less/-/less-2.5.3.tgz",
       "dependencies": {
         "errno": {
           "version": "0.1.4",
-          "from": "errno@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
           "dependencies": {
             "prr": {
               "version": "0.0.0",
-              "from": "prr@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
               "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
             }
           }
         },
         "graceful-fs": {
           "version": "3.0.8",
-          "from": "graceful-fs@>=3.0.5 <4.0.0",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
         },
         "image-size": {
           "version": "0.3.5",
-          "from": "image-size@>=0.3.5 <0.4.0",
+          "from": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
           "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.2.11 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "promise": {
           "version": "6.1.0",
-          "from": "promise@>=6.0.1 <7.0.0",
+          "from": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
           "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
           "dependencies": {
             "asap": {
               "version": "1.0.0",
-              "from": "asap@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
             }
           }
         },
         "request": {
           "version": "2.67.0",
-          "from": "request@>=2.51.0 <3.0.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.67.0.tgz",
           "dependencies": {
             "bl": {
               "version": "1.0.0",
-              "from": "bl@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -7347,145 +7347,145 @@
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
               "version": "1.0.0-rc3",
-              "from": "form-data@>=1.0.0-rc3 <1.1.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
               "dependencies": {
                 "async": {
                   "version": "1.5.0",
-                  "from": "async@>=1.4.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
                   "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
                 }
               }
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
               "version": "2.1.8",
-              "from": "mime-types@>=2.1.7 <2.2.0",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.8.tgz",
               "dependencies": {
                 "mime-db": {
                   "version": "1.20.0",
-                  "from": "mime-db@>=1.20.0 <1.21.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz",
                   "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.20.0.tgz"
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
               "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "qs": {
               "version": "5.2.0",
-              "from": "qs@>=5.2.0 <5.3.0",
+              "from": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
               "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz"
             },
             "tunnel-agent": {
               "version": "0.4.2",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
             },
             "tough-cookie": {
               "version": "2.2.1",
-              "from": "tough-cookie@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
             },
             "http-signature": {
               "version": "1.1.0",
-              "from": "http-signature@>=1.1.0 <1.2.0",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "0.1.5",
-                  "from": "assert-plus@>=0.1.5 <0.2.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                 },
                 "jsprim": {
                   "version": "1.2.2",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.2.2.tgz",
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
+                      "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                     },
                     "json-schema": {
                       "version": "0.2.2",
-                      "from": "json-schema@0.2.2",
+                      "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.2.tgz"
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
+                      "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.7.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.7.1.tgz",
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                     },
                     "assert-plus": {
                       "version": "0.2.0",
-                      "from": "assert-plus@>=0.2.0 <0.3.0",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
                     },
                     "dashdash": {
                       "version": "1.10.1",
-                      "from": "dashdash@>=1.10.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
                       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.10.1.tgz",
                       "dependencies": {
                         "assert-plus": {
                           "version": "0.1.5",
-                          "from": "assert-plus@>=0.1.0 <0.2.0",
+                          "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
                           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
                         }
                       }
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
                     },
                     "tweetnacl": {
                       "version": "0.13.2",
-                      "from": "tweetnacl@>=0.13.0 <1.0.0",
+                      "from": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.2.tgz"
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.0.1 <1.0.0",
+                      "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                     }
                   }
@@ -7494,173 +7494,173 @@
             },
             "oauth-sign": {
               "version": "0.8.0",
-              "from": "oauth-sign@>=0.8.0 <0.9.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz",
               "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.0.tgz"
             },
             "hawk": {
               "version": "3.1.2",
-              "from": "hawk@>=3.1.0 <3.2.0",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.2.tgz",
               "dependencies": {
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
                 },
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                   "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
                 }
               }
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
               "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
             },
             "har-validator": {
               "version": "2.0.3",
-              "from": "har-validator@>=2.0.2 <2.1.0",
+              "from": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.3.tgz",
               "dependencies": {
                 "chalk": {
                   "version": "1.1.1",
-                  "from": "chalk@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.1.0",
-                      "from": "ansi-styles@>=2.1.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
                     },
                     "escape-string-regexp": {
                       "version": "1.0.3",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.0",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
+                      "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.12.3",
-                  "from": "is-my-json-valid@>=2.12.3 <3.0.0",
+                  "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.3.tgz",
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "2.0.0",
-                      "from": "jsonpointer@2.0.0",
+                      "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.0",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz",
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.1",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.1.tgz"
                     }
                   }
@@ -7671,12 +7671,12 @@
         },
         "source-map": {
           "version": "0.4.4",
-          "from": "source-map@>=0.4.2 <0.5.0",
+          "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "dependencies": {
             "amdefine": {
               "version": "1.0.0",
-              "from": "amdefine@>=0.0.4",
+              "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
             }
           }
@@ -7685,22 +7685,22 @@
     },
     "less-loader": {
       "version": "2.2.2",
-      "from": "less-loader@>=2.2.0 <3.0.0",
+      "from": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/less-loader/-/less-loader-2.2.2.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
@@ -7709,139 +7709,139 @@
     },
     "lodash": {
       "version": "3.10.1",
-      "from": "lodash@>=3.9.3 <4.0.0",
+      "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
     },
     "main-bower-files": {
       "version": "2.11.0",
-      "from": "main-bower-files@>=2.8.1 <3.0.0",
+      "from": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.11.0.tgz",
       "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.11.0.tgz",
       "dependencies": {
         "chalk": {
           "version": "1.1.1",
-          "from": "chalk@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
           "dependencies": {
             "ansi-styles": {
               "version": "2.1.0",
-              "from": "ansi-styles@>=2.1.0 <3.0.0",
+              "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
             },
             "escape-string-regexp": {
               "version": "1.0.3",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
             },
             "has-ansi": {
               "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "strip-ansi": {
               "version": "3.0.0",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
               "dependencies": {
                 "ansi-regex": {
                   "version": "2.0.0",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "2.0.1",
-          "from": "extend@>=2.0.1 <3.0.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
         },
         "globby": {
           "version": "2.1.0",
-          "from": "globby@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
           "dependencies": {
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "async": {
               "version": "1.5.0",
-              "from": "async@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
             },
             "object-assign": {
               "version": "3.0.0",
-              "from": "object-assign@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             }
           }
         },
         "multimatch": {
           "version": "2.1.0",
-          "from": "multimatch@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
-              "from": "array-differ@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
               "version": "1.0.1",
-              "from": "array-union@>=1.0.1 <2.0.0",
+              "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
                   "version": "1.0.2",
-                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
                 }
               }
             },
             "arrify": {
               "version": "1.0.1",
-              "from": "arrify@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
               "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
             },
             "minimatch": {
               "version": "3.0.0",
-              "from": "minimatch@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
               "dependencies": {
                 "brace-expansion": {
                   "version": "1.1.2",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                   "dependencies": {
                     "balanced-match": {
                       "version": "0.3.0",
-                      "from": "balanced-match@>=0.3.0 <0.4.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                     },
                     "concat-map": {
                       "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                     }
                   }
@@ -7852,37 +7852,37 @@
         },
         "path-exists": {
           "version": "1.0.0",
-          "from": "path-exists@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
         },
         "strip-json-comments": {
           "version": "1.0.4",
-          "from": "strip-json-comments@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
         },
         "vinyl-fs": {
           "version": "1.0.0",
-          "from": "vinyl-fs@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
           "dependencies": {
             "duplexify": {
               "version": "3.4.2",
-              "from": "duplexify@>=3.2.0 <4.0.0",
+              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
-                  "from": "end-of-stream@1.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                   "dependencies": {
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <1.4.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -7891,37 +7891,37 @@
                 },
                 "readable-stream": {
                   "version": "2.0.5",
-                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "process-nextick-args": {
                       "version": "1.0.6",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                     }
                   }
@@ -7930,39 +7930,39 @@
             },
             "glob-stream": {
               "version": "4.1.1",
-              "from": "glob-stream@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
               "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
               "dependencies": {
                 "glob": {
                   "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
                   "dependencies": {
                     "inflight": {
                       "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -7971,22 +7971,22 @@
                 },
                 "minimatch": {
                   "version": "2.0.10",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.2",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.2.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.3.0",
-                          "from": "balanced-match@>=0.3.0 <0.4.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -7995,69 +7995,69 @@
                 },
                 "ordered-read-streams": {
                   "version": "0.1.0",
-                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
                 },
                 "glob2base": {
                   "version": "0.0.12",
-                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
                   "dependencies": {
                     "find-index": {
                       "version": "0.1.1",
-                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
                     }
                   }
                 },
                 "unique-stream": {
                   "version": "2.2.0",
-                  "from": "unique-stream@>=2.0.2 <3.0.0",
+                  "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.0.tgz",
                   "dependencies": {
                     "through2-filter": {
                       "version": "2.0.0",
-                      "from": "through2-filter@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
                       "dependencies": {
                         "through2": {
                           "version": "2.0.0",
-                          "from": "through2@>=2.0.0 <2.1.0",
+                          "from": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
                           "dependencies": {
                             "readable-stream": {
                               "version": "2.0.5",
-                              "from": "readable-stream@>=2.0.0 <2.1.0",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.2",
-                                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                                 },
                                 "inherits": {
                                   "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
-                                  "from": "isarray@0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                                 },
                                 "process-nextick-args": {
                                   "version": "1.0.6",
-                                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                                 },
                                 "string_decoder": {
                                   "version": "0.10.31",
-                                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
                                 "util-deprecate": {
                                   "version": "1.0.2",
-                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                                 }
                               }
@@ -8066,7 +8066,7 @@
                         },
                         "xtend": {
                           "version": "4.0.1",
-                          "from": "xtend@>=4.0.0 <4.1.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                         }
                       }
@@ -8077,54 +8077,54 @@
             },
             "glob-watcher": {
               "version": "0.0.8",
-              "from": "glob-watcher@>=0.0.8 <0.0.9",
+              "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
               "dependencies": {
                 "gaze": {
                   "version": "0.5.2",
-                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                   "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
                   "dependencies": {
                     "globule": {
                       "version": "0.1.0",
-                      "from": "globule@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "1.0.2",
-                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
                         },
                         "glob": {
                           "version": "3.1.21",
-                          "from": "glob@>=3.1.21 <3.2.0",
+                          "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
                           "dependencies": {
                             "graceful-fs": {
                               "version": "1.2.3",
-                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
                               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
                             },
                             "inherits": {
                               "version": "1.0.2",
-                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz"
                             }
                           }
                         },
                         "minimatch": {
                           "version": "0.2.14",
-                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                           "dependencies": {
                             "lru-cache": {
                               "version": "2.7.3",
-                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
                               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz"
                             },
                             "sigmund": {
                               "version": "1.0.1",
-                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                             }
                           }
@@ -8137,100 +8137,100 @@
             },
             "graceful-fs": {
               "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
             },
             "merge-stream": {
               "version": "0.1.8",
-              "from": "merge-stream@>=0.1.7 <0.2.0",
+              "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz"
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                 }
               }
             },
             "object-assign": {
               "version": "2.1.1",
-              "from": "object-assign@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
             },
             "strip-bom": {
               "version": "1.0.0",
-              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
               "dependencies": {
                 "first-chunk-stream": {
                   "version": "1.0.0",
-                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
                 },
                 "is-utf8": {
                   "version": "0.2.0",
-                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
                 }
               }
             },
             "through2": {
               "version": "0.6.5",
-              "from": "through2@>=0.6.1 <0.7.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.4.6",
-              "from": "vinyl@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
               "dependencies": {
                 "clone": {
                   "version": "0.2.0",
-                  "from": "clone@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -8241,235 +8241,235 @@
     },
     "marked": {
       "version": "0.3.5",
-      "from": "marked@>=0.3.3 <0.4.0",
+      "from": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
     },
     "node-libs-browser": {
       "version": "0.5.3",
-      "from": "node-libs-browser@>=0.5.2 <0.6.0",
+      "from": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.3.tgz",
       "dependencies": {
         "assert": {
           "version": "1.3.0",
-          "from": "assert@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
           "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
         },
         "browserify-zlib": {
           "version": "0.1.4",
-          "from": "browserify-zlib@>=0.1.4 <0.2.0",
+          "from": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
           "dependencies": {
             "pako": {
               "version": "0.2.8",
-              "from": "pako@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz",
               "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.8.tgz"
             }
           }
         },
         "buffer": {
           "version": "3.5.5",
-          "from": "buffer@>=3.0.3 <4.0.0",
+          "from": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.5.5.tgz",
           "dependencies": {
             "base64-js": {
               "version": "0.0.8",
-              "from": "base64-js@0.0.8",
+              "from": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
               "version": "1.1.6",
-              "from": "ieee754@>=1.1.4 <2.0.0",
+              "from": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz",
               "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             }
           }
         },
         "console-browserify": {
           "version": "1.1.0",
-          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
           "dependencies": {
             "date-now": {
               "version": "0.1.4",
-              "from": "date-now@>=0.1.4 <0.2.0",
+              "from": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
             }
           }
         },
         "constants-browserify": {
           "version": "0.0.1",
-          "from": "constants-browserify@0.0.1",
+          "from": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
         },
         "crypto-browserify": {
           "version": "3.2.8",
-          "from": "crypto-browserify@>=3.2.6 <3.3.0",
+          "from": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
           "dependencies": {
             "pbkdf2-compat": {
               "version": "2.0.1",
-              "from": "pbkdf2-compat@2.0.1",
+              "from": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
             },
             "ripemd160": {
               "version": "0.2.0",
-              "from": "ripemd160@0.2.0",
+              "from": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
             },
             "sha.js": {
               "version": "2.2.6",
-              "from": "sha.js@2.2.6",
+              "from": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz",
               "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
             }
           }
         },
         "domain-browser": {
           "version": "1.1.7",
-          "from": "domain-browser@>=1.1.1 <2.0.0",
+          "from": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
           "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
         },
         "events": {
           "version": "1.1.0",
-          "from": "events@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/events/-/events-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/events/-/events-1.1.0.tgz"
         },
         "http-browserify": {
           "version": "1.7.0",
-          "from": "http-browserify@>=1.3.2 <2.0.0",
+          "from": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
           "dependencies": {
             "Base64": {
               "version": "0.2.1",
-              "from": "Base64@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
               "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "https-browserify": {
           "version": "0.0.0",
-          "from": "https-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
         },
         "os-browserify": {
           "version": "0.1.2",
-          "from": "os-browserify@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
         },
         "path-browserify": {
           "version": "0.0.0",
-          "from": "path-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
         },
         "process": {
           "version": "0.11.2",
-          "from": "process@>=0.11.0 <0.12.0",
+          "from": "https://registry.npmjs.org/process/-/process-0.11.2.tgz",
           "resolved": "https://registry.npmjs.org/process/-/process-0.11.2.tgz"
         },
         "punycode": {
           "version": "1.4.0",
-          "from": "punycode@>=1.2.4 <2.0.0",
+          "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.0.tgz"
         },
         "querystring-es3": {
           "version": "0.2.1",
-          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "from": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
           "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
         },
         "readable-stream": {
           "version": "1.1.13",
-          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "stream-browserify": {
           "version": "1.0.0",
-          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.25 <0.11.0",
+          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "timers-browserify": {
           "version": "1.4.2",
-          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "from": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz"
         },
         "tty-browserify": {
           "version": "0.0.0",
-          "from": "tty-browserify@0.0.0",
+          "from": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
         },
         "url": {
           "version": "0.10.3",
-          "from": "url@>=0.10.1 <0.11.0",
+          "from": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.2",
-              "from": "punycode@1.3.2",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
             },
             "querystring": {
               "version": "0.2.0",
-              "from": "querystring@0.2.0",
+              "from": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
             }
           }
         },
         "util": {
           "version": "0.10.3",
-          "from": "util@>=0.10.3 <0.11.0",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.1 <2.1.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             }
           }
         },
         "vm-browserify": {
           "version": "0.0.4",
-          "from": "vm-browserify@0.0.4",
+          "from": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
           "dependencies": {
             "indexof": {
               "version": "0.0.1",
-              "from": "indexof@0.0.1",
+              "from": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
             }
           }
@@ -8478,42 +8478,42 @@
     },
     "redux": {
       "version": "3.0.5",
-      "from": "redux@>=3.0.4 <4.0.0",
+      "from": "https://registry.npmjs.org/redux/-/redux-3.0.5.tgz",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.0.5.tgz"
     },
     "redux-actions": {
       "version": "0.9.0",
-      "from": "redux-actions@>=0.9.0 <0.10.0",
+      "from": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.0.tgz",
       "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-0.9.0.tgz",
       "dependencies": {
         "flux-standard-action": {
           "version": "0.6.0",
-          "from": "flux-standard-action@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/flux-standard-action/-/flux-standard-action-0.6.0.tgz",
           "dependencies": {
             "lodash.isplainobject": {
               "version": "3.2.0",
-              "from": "lodash.isplainobject@>=3.2.0 <4.0.0",
+              "from": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
               "dependencies": {
                 "lodash._basefor": {
                   "version": "3.0.3",
-                  "from": "lodash._basefor@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._basefor/-/lodash._basefor-3.0.3.tgz"
                 },
                 "lodash.isarguments": {
                   "version": "3.0.5",
-                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.5.tgz"
                 },
                 "lodash.keysin": {
                   "version": "3.0.8",
-                  "from": "lodash.keysin@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
                   "dependencies": {
                     "lodash.isarray": {
                       "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
                     }
                   }
@@ -8524,29 +8524,46 @@
         },
         "reduce-reducers": {
           "version": "0.1.1",
-          "from": "reduce-reducers@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-0.1.1.tgz"
+        }
+      }
+    },
+    "redux-persist": {
+      "version": "3.1.1",
+      "from": "redux-persist@*",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-3.1.1.tgz",
+      "dependencies": {
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@>=5.0.1 <6.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+        },
+        "lodash": {
+          "version": "4.12.0",
+          "from": "lodash@>=4.11.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz"
         }
       }
     },
     "style-loader": {
       "version": "0.13.0",
-      "from": "style-loader@>=0.13.0 <0.14.0",
+      "from": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.13.0.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.7 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
@@ -8555,90 +8572,90 @@
     },
     "url-loader": {
       "version": "0.5.7",
-      "from": "url-loader@>=0.5.6 <0.6.0",
+      "from": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
       "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.7.tgz",
       "dependencies": {
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@>=1.2.0 <1.3.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
         }
       }
     },
     "vinyl-source-stream": {
       "version": "1.1.0",
-      "from": "vinyl-source-stream@>=1.1.0 <2.0.0",
+      "from": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.0.tgz",
       "dependencies": {
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.3 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
               "version": "0.2.0",
-              "from": "clone@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
             },
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.2 <0.7.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
             }
           }
@@ -8647,113 +8664,113 @@
     },
     "webpack": {
       "version": "1.12.9",
-      "from": "webpack@>=1.12.9 <2.0.0",
+      "from": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.12.9.tgz",
       "dependencies": {
         "async": {
           "version": "1.5.0",
-          "from": "async@>=1.3.0 <2.0.0",
+          "from": "https://registry.npmjs.org/async/-/async-1.5.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.0.tgz"
         },
         "clone": {
           "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
         },
         "enhanced-resolve": {
           "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
           "dependencies": {
             "memory-fs": {
               "version": "0.2.0",
-              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
             },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             }
           }
         },
         "esprima": {
           "version": "2.7.1",
-          "from": "esprima@>=2.5.0 <3.0.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.1.tgz"
         },
         "interpret": {
           "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
+          "from": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz",
           "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
         },
         "loader-utils": {
           "version": "0.2.12",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "from": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.12.tgz",
           "dependencies": {
             "big.js": {
               "version": "3.1.3",
-              "from": "big.js@>=3.0.2 <4.0.0",
+              "from": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
               "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
-              "from": "json5@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
             }
           }
         },
         "memory-fs": {
           "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "from": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
           "dependencies": {
             "errno": {
               "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
+              "from": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
               "dependencies": {
                 "prr": {
                   "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
+                  "from": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "2.0.5",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.5.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.6",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz",
                   "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.6.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -8762,156 +8779,156 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "from": "minimist@0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
             }
           }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "dependencies": {
             "wordwrap": {
               "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
             },
             "minimist": {
               "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
             }
           }
         },
         "supports-color": {
           "version": "3.1.2",
-          "from": "supports-color@>=3.1.0 <4.0.0",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "dependencies": {
             "has-flag": {
               "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
             }
           }
         },
         "tapable": {
           "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
+          "from": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
           "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
         },
         "uglify-js": {
           "version": "2.6.1",
-          "from": "uglify-js@>=2.6.0 <2.7.0",
+          "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.1.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
               "version": "0.5.3",
-              "from": "source-map@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
             },
             "uglify-to-browserify": {
               "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
             },
             "yargs": {
               "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
+              "from": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "dependencies": {
                 "camelcase": {
                   "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                 },
                 "cliui": {
                   "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                   "dependencies": {
                     "center-align": {
                       "version": "0.1.2",
-                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
                         },
                         "lazy-cache": {
                           "version": "0.2.7",
-                          "from": "lazy-cache@>=0.2.4 <0.3.0",
+                          "from": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
                           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz"
                         }
                       }
                     },
                     "right-align": {
                       "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "from": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                       "dependencies": {
                         "align-text": {
                           "version": "0.1.3",
-                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "from": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                           "dependencies": {
                             "kind-of": {
                               "version": "2.0.1",
-                              "from": "kind-of@>=2.0.0 <3.0.0",
+                              "from": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
                               "dependencies": {
                                 "is-buffer": {
                                   "version": "1.1.0",
-                                  "from": "is-buffer@>=1.0.2 <2.0.0",
+                                  "from": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz",
                                   "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
                                 }
                               }
                             },
                             "longest": {
                               "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
+                              "from": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
                             },
                             "repeat-string": {
                               "version": "1.5.2",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "from": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz",
                               "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
                             }
                           }
@@ -8920,19 +8937,19 @@
                     },
                     "wordwrap": {
                       "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
+                      "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.1.1",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
                 },
                 "window-size": {
                   "version": "0.1.0",
-                  "from": "window-size@0.1.0",
+                  "from": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
                 }
               }
@@ -8941,41 +8958,41 @@
         },
         "watchpack": {
           "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
+          "from": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
             },
             "graceful-fs": {
               "version": "4.1.2",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
             }
           }
         },
         "webpack-core": {
           "version": "0.6.8",
-          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.8.tgz",
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "dependencies": {
                 "amdefine": {
                   "version": "1.0.0",
-                  "from": "amdefine@>=0.0.4",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
                 }
               }
             },
             "source-list-map": {
               "version": "0.1.5",
-              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz",
               "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
             }
           }

--- a/shoop/admin/package.json
+++ b/shoop/admin/package.json
@@ -41,6 +41,7 @@
     "node-libs-browser": "^0.5.2",
     "redux": "^3.0.4",
     "redux-actions": "^0.9.0",
+    "redux-persist": "^3.1.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.6",
     "vinyl-source-stream": "^1.1.0",

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -487,7 +487,7 @@ class Order(MoneyPropped, models.Model):
         shipment.save()
 
         self.add_log_entry(_(u"Shipment #%d created.") % shipment.id)
-        self.check_and_set_fully_shipped()
+        self.update_shipping_status()
         shipment_created.send(sender=type(self), order=self, shipment=shipment)
         return shipment
 
@@ -582,13 +582,17 @@ class Order(MoneyPropped, models.Model):
         shipped = (self.shipping_status != ShippingStatus.NOT_SHIPPED)
         return not (canceled or paid or shipped)
 
-    def check_and_set_fully_shipped(self):
-        if self.shipping_status != ShippingStatus.FULLY_SHIPPED:
-            if not self.get_unshipped_products():
-                self.shipping_status = ShippingStatus.FULLY_SHIPPED
-                self.add_log_entry(_(u"All products have been shipped. Fully Shipped status set."))
-                self.save(update_fields=("shipping_status",))
-                return True
+    def update_shipping_status(self):
+        if self.shipping_status == ShippingStatus.FULLY_SHIPPED:
+            return
+
+        if not self.get_unshipped_products():
+            self.shipping_status = ShippingStatus.FULLY_SHIPPED
+            self.add_log_entry(_(u"All products have been shipped. Fully Shipped status set."))
+            self.save(update_fields=("shipping_status",))
+        elif self.shipments.count():
+            self.shipping_status = ShippingStatus.PARTIALLY_SHIPPED
+            self.save(update_fields=("shipping_status",))
 
     def get_known_additional_data(self):
         """

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -649,6 +649,14 @@ class Order(MoneyPropped, models.Model):
     def get_tracking_codes(self):
         return [shipment.tracking_code for shipment in self.shipments.all() if shipment.tracking_code]
 
+    def can_edit(self):
+        return (
+            not self.is_canceled() and
+            not self.is_complete() and
+            self.shipping_status == ShippingStatus.NOT_SHIPPED and
+            self.payment_status == PaymentStatus.NOT_PAID
+        )
+
 
 OrderLogEntry = define_log_model(Order)
 

--- a/shoop/core/order_creator/__init__.py
+++ b/shoop/core/order_creator/__init__.py
@@ -9,6 +9,7 @@
 from shoop.utils import update_module_attributes
 
 from ._creator import OrderCreator
+from ._modifier import OrderModifier
 from ._source import OrderSource, SourceLine, TaxesNotCalculated
 from ._source_modifier import (
     get_order_source_modifier_modules, is_code_usable,
@@ -19,6 +20,7 @@ __all__ = [
     "get_order_source_modifier_modules",
     "is_code_usable",
     "OrderCreator",
+    "OrderModifier",
     "OrderSource",
     "OrderSourceModifierModule",
     "SourceLine",

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.db.transaction import atomic
+
+from shoop.core.models import Order
+
+from ._creator import OrderProcessor
+
+
+class OrderModifier(OrderProcessor):
+
+    @atomic
+    def update_order_from_source(self, order_source, order):
+        data = self.get_source_base_data(order_source)
+        Order.objects.filter(pk=order.pk).update(**data)
+
+        order = Order.objects.get(pk=order.pk)
+
+        for line in order.lines.all():
+            line.delete()
+
+        return self.finalize_creation(order, order_source)

--- a/shoop_tests/core/test_order_modifier.py
+++ b/shoop_tests/core/test_order_modifier.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.core.exceptions import ValidationError
+
+from shoop.core.models import Order, MutableAddress, OrderLineType, get_person_contact, Shop, ShopStatus
+from shoop.core.order_creator import OrderCreator
+from shoop.core.order_creator._modifier import OrderModifier
+from shoop.testing.factories import (
+    get_initial_order_status, get_default_payment_method, get_default_shipping_method,
+    get_default_shop, get_default_product, get_default_supplier
+)
+from shoop_tests.utils.basketish_order_source import BasketishOrderSource
+
+
+def get_order_and_source(admin_user):
+    # create original source to tamper with
+    source = BasketishOrderSource(get_default_shop())
+    source.status = get_initial_order_status()
+    source.billing_address = MutableAddress.objects.create(name="Original Billing")
+    source.shipping_address = MutableAddress.objects.create(name="Original Shipping")
+    source.customer = get_person_contact(admin_user)
+    source.payment_method = get_default_payment_method()
+    source.shipping_method = get_default_shipping_method()
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=get_default_product(),
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+    )
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+    assert len(source.get_lines()) == 2
+    source.creator = admin_user
+    creator = OrderCreator()
+    order = creator.create_order(source)
+    return order, source
+
+
+@pytest.mark.django_db
+def test_order_modifier(rf, admin_user):
+
+    order, source = get_order_and_source(admin_user)
+
+    # get original values
+    taxful_total_price = order.taxful_total_price_value
+    taxless_total_price = order.taxless_total_price_value
+    original_line_count = order.lines.count()
+
+    # modify source
+    source.billing_address = MutableAddress.objects.create(name="New Billing")
+    source.shipping_address = MutableAddress.objects.create(name="New Shipping")
+
+    modifier = OrderModifier()
+    modifier.update_order_from_source(source, order)  # new param to edit order from source
+
+    assert Order.objects.count() == 1
+
+    order = Order.objects.first()
+    assert order.billing_address.name == "New Billing"
+    assert order.shipping_address.name == "New Shipping"
+    assert order.taxful_total_price_value == taxful_total_price
+    assert order.taxless_total_price_value == taxless_total_price
+
+    # add new line to order source
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+    modifier.update_order_from_source(source, order)
+
+    assert order.lines.count() == original_line_count + 1
+
+
+@pytest.mark.django_db
+def test_shop_change(rf, admin_user):
+    order, source = get_order_and_source(admin_user)
+
+    shop = Shop.objects.create(
+        name="Another shop",
+        identifier="another-shop",
+        status=ShopStatus.ENABLED,
+        public_name="Another shop"
+    )
+
+    source.shop = shop
+
+    modifier = OrderModifier()
+
+    with pytest.raises(ValidationError):
+        modifier.update_order_from_source(source, order)
+
+
+def test_order_cannot_be_created():
+    modifier = OrderModifier()
+    with pytest.raises(AttributeError):
+        modifier.create_order(None)

--- a/shoop_tests/core/test_shipments.py
+++ b/shoop_tests/core/test_shipments.py
@@ -28,7 +28,7 @@ def test_shipment_identifier():
             assert shipment.identifier.startswith(expected_key_start)
         assert order.shipments.count() == int(line.quantity)
     assert order.shipping_status == ShippingStatus.FULLY_SHIPPED  # Check that order is now fully shipped
-
+    assert not order.can_edit()
 
 @pytest.mark.django_db
 def test_shipment_creation_from_unsaved_shipment():
@@ -80,10 +80,12 @@ def test_partially_shipped_order_status():
     shop = get_default_shop()
     supplier = get_default_supplier()
     order = _get_order(shop, supplier)
+    assert order.can_edit()
     first_product_line = order.lines.exclude(product_id=None).first()
     assert first_product_line.quantity > 1
     order.create_shipment({first_product_line.product: 1}, supplier=supplier)
     assert order.shipping_status == ShippingStatus.PARTIALLY_SHIPPED
+    assert not order.can_edit()
 
 
 def _get_order(shop, supplier):

--- a/shoop_tests/core/test_shipments.py
+++ b/shoop_tests/core/test_shipments.py
@@ -8,7 +8,7 @@
 import decimal
 import pytest
 
-from shoop.core.models import Shipment
+from shoop.core.models import Shipment, ShippingStatus
 from shoop.testing.factories import (
     add_product_to_order, create_empty_order, create_product,
     get_default_shop, get_default_supplier
@@ -27,6 +27,7 @@ def test_shipment_identifier():
             expected_key_start = "%s/%s" % (order.pk, i)
             assert shipment.identifier.startswith(expected_key_start)
         assert order.shipments.count() == int(line.quantity)
+    assert order.shipping_status == ShippingStatus.FULLY_SHIPPED  # Check that order is now fully shipped
 
 
 @pytest.mark.django_db
@@ -72,6 +73,17 @@ def test_shipment_creation_with_invalid_unsaved_shipment():
                 unsaved_shipment = Shipment(supplier=supplier, order=second_order)
                 order.create_shipment({line.product: 1}, shipment=unsaved_shipment)
     assert order.shipments.count() == 0
+
+
+@pytest.mark.django_db
+def test_partially_shipped_order_status():
+    shop = get_default_shop()
+    supplier = get_default_supplier()
+    order = _get_order(shop, supplier)
+    first_product_line = order.lines.exclude(product_id=None).first()
+    assert first_product_line.quantity > 1
+    order.create_shipment({first_product_line.product: 1}, supplier=supplier)
+    assert order.shipping_status == ShippingStatus.PARTIALLY_SHIPPED
 
 
 def _get_order(shop, supplier):


### PR DESCRIPTION
* Refactor the `OrderCreator` for easier extensibility
* Add `OrderModifier` for basic `Order` modifying from `OrderSource`
* Core: Update shipping status correctly in ``Order.create_shipment``
* Core: Add ``Order.can_edit``
* Admin: Enable order editing