### PR TITLE
Add OrderModifier (SHOOP-2338)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add ``OrderModifier`` for basic ``Order`` modifying from ``OrderSource``
 - Add option use ``Order.create_shipment`` with unsaved ``Shipment``
 - Add identifier for ``Shipment``
 - Fix bug: Fix max length for service method names for ``Order``

--- a/shoop/core/order_creator/__init__.py
+++ b/shoop/core/order_creator/__init__.py
@@ -9,6 +9,7 @@
 from shoop.utils import update_module_attributes
 
 from ._creator import OrderCreator
+from ._modifier import OrderModifier
 from ._source import OrderSource, SourceLine, TaxesNotCalculated
 from ._source_modifier import (
     get_order_source_modifier_modules, is_code_usable,
@@ -19,6 +20,7 @@ __all__ = [
     "get_order_source_modifier_modules",
     "is_code_usable",
     "OrderCreator",
+    "OrderModifier",
     "OrderSource",
     "OrderSourceModifierModule",
     "SourceLine",

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.db.transaction import atomic
+
+from shoop.core.models import Order
+
+from ._creator import OrderProcessor
+
+
+class OrderModifier(OrderProcessor):
+
+    @atomic
+    def update_order_from_source(self, order_source, order):
+        data = self.get_source_base_data(order_source)
+        Order.objects.filter(pk=order.pk).update(**data)
+
+        order = Order.objects.get(pk=order.pk)
+
+        for line in order.lines.all():
+            line.delete()
+
+        return self.finalize_creation(order, order_source)

--- a/shoop_tests/core/test_order_modifier.py
+++ b/shoop_tests/core/test_order_modifier.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+from django.core.exceptions import ValidationError
+
+from shoop.core.models import Order, MutableAddress, OrderLineType, get_person_contact, Shop, ShopStatus
+from shoop.core.order_creator import OrderCreator
+from shoop.core.order_creator._modifier import OrderModifier
+from shoop.testing.factories import (
+    get_initial_order_status, get_default_payment_method, get_default_shipping_method,
+    get_default_shop, get_default_product, get_default_supplier
+)
+from shoop_tests.utils.basketish_order_source import BasketishOrderSource
+
+
+def get_order_and_source(admin_user):
+    # create original source to tamper with
+    source = BasketishOrderSource(get_default_shop())
+    source.status = get_initial_order_status()
+    source.billing_address = MutableAddress.objects.create(name="Original Billing")
+    source.shipping_address = MutableAddress.objects.create(name="Original Shipping")
+    source.customer = get_person_contact(admin_user)
+    source.payment_method = get_default_payment_method()
+    source.shipping_method = get_default_shipping_method()
+    source.add_line(
+        type=OrderLineType.PRODUCT,
+        product=get_default_product(),
+        supplier=get_default_supplier(),
+        quantity=1,
+        base_unit_price=source.create_price(10),
+    )
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+    assert len(source.get_lines()) == 2
+    source.creator = admin_user
+    creator = OrderCreator()
+    order = creator.create_order(source)
+    return order, source
+
+
+@pytest.mark.django_db
+def test_order_modifier(rf, admin_user):
+
+    order, source = get_order_and_source(admin_user)
+
+    # get original values
+    taxful_total_price = order.taxful_total_price_value
+    taxless_total_price = order.taxless_total_price_value
+    original_line_count = order.lines.count()
+
+    # modify source
+    source.billing_address = MutableAddress.objects.create(name="New Billing")
+    source.shipping_address = MutableAddress.objects.create(name="New Shipping")
+
+    modifier = OrderModifier()
+    modifier.update_order_from_source(source, order)  # new param to edit order from source
+
+    assert Order.objects.count() == 1
+
+    order = Order.objects.first()
+    assert order.billing_address.name == "New Billing"
+    assert order.shipping_address.name == "New Shipping"
+    assert order.taxful_total_price_value == taxful_total_price
+    assert order.taxless_total_price_value == taxless_total_price
+
+    # add new line to order source
+    source.add_line(
+        type=OrderLineType.OTHER,
+        quantity=1,
+        base_unit_price=source.create_price(10),
+        require_verification=True,
+    )
+    modifier.update_order_from_source(source, order)
+
+    assert order.lines.count() == original_line_count + 1
+
+
+@pytest.mark.django_db
+def test_shop_change(rf, admin_user):
+    order, source = get_order_and_source(admin_user)
+
+    shop = Shop.objects.create(
+        name="Another shop",
+        identifier="another-shop",
+        status=ShopStatus.ENABLED,
+        public_name="Another shop"
+    )
+
+    source.shop = shop
+
+    modifier = OrderModifier()
+
+    with pytest.raises(ValidationError):
+        modifier.update_order_from_source(source, order)
+
+
+def test_order_cannot_be_created():
+    modifier = OrderModifier()
+    with pytest.raises(AttributeError):
+        modifier.create_order(None)


### PR DESCRIPTION
Add OrderModifier class which can be used to modify existing orders using an OrderSource.

This is the first part of enabling editing orders.  Splitting the PR #466 to two pieces to make it easier to review.  The leftover commits will for the second part.