### PR TITLE
Fix tax bugs in order edit (SHOOP-2338, SHOOP-1993)

### DIFF
--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -92,6 +92,7 @@ def encode_line(line):
 
 
 def get_line_data_for_edit(shop, line):
+    total_price = line.taxful_price.value if shop.prices_include_tax else line.taxless_price.value
     base_data = {
         "id": line.id,
         "type": "other" if line.quantity else "text",
@@ -99,8 +100,8 @@ def get_line_data_for_edit(shop, line):
         "quantity": line.quantity,
         "sku": line.sku,
         "baseUnitPrice": line.base_unit_price.value,
-        "unitPrice": line.taxless_price.value / line.quantity if line.quantity else 0,
-        "unitPriceIncludesTax": line.price.includes_tax,
+        "unitPrice": total_price / line.quantity if line.quantity else 0,
+        "unitPriceIncludesTax": shop.prices_include_tax,
         "errors": "",
         "step": ""
     }

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -22,6 +22,7 @@ class OrderModifier(OrderProcessor):
         order = Order.objects.get(pk=order.pk)
 
         for line in order.lines.all():
+            line.taxes.all().delete()  # Delete all tax lines before OrderLine's
             line.delete()
 
         return self.finalize_creation(order, order_source)


### PR DESCRIPTION
Core: Enable modifying orders with taxes
Admin: Use correct taxed prices for order editing