### PR TITLE
Front: Filter suppliable products correctly

### DIFF
--- a/shoop/front/template_helpers/general.py
+++ b/shoop/front/template_helpers/general.py
@@ -48,7 +48,7 @@ def get_visible_products(context, n_products, ordering=None, filter_dict=None, o
     supplier_filter = Q()
     if orderable_only:
         for supplier in Supplier.objects.all():
-            supplier_filter |= Q(pk__in=supplier.get_suppliable_products(shop, customer))
+            supplier_filter |= Q(shop_products__pk__in=supplier.get_suppliable_products(shop, customer))
         products_qs = products_qs.filter(supplier_filter)
 
     return products_qs.filter(**filter_dict)[:n_products]


### PR DESCRIPTION
``Supplier.get_suppliable_products`` returns list of shop product pk's.

Missing tests since SHOOP-2576 will change this logic completely at the end of this week.