### PR TITLE
Admin: Enable adding log entries to orders

### DIFF
--- a/doc/api/shoop.admin.modules.orders.views.rst
+++ b/doc/api/shoop.admin.modules.orders.views.rst
@@ -28,6 +28,14 @@ shoop.admin.modules.orders.views.list module
     :undoc-members:
     :show-inheritance:
 
+shoop.admin.modules.orders.views.log module
+-------------------------------------------
+
+.. automodule:: shoop.admin.modules.orders.views.log
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 shoop.admin.modules.orders.views.payment module
 -----------------------------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Enable adding log entries to orders
 - Add ``Order.can_edit``
 - Update shipping status correctly in ``Order.create_shipment``
 - Add ``OrderModifier`` for basic ``Order`` modifying from ``OrderSource``

--- a/shoop/admin/locale/en/LC_MESSAGES/django.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/django.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-13 01:21+0000\n"
+"POT-Creation-Date: 2016-05-21 05:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -626,6 +626,7 @@ msgstr ""
 msgid "Edit %(model)s"
 msgstr ""
 
+#, python-brace-format
 msgid "Create {service_name}"
 msgstr ""
 
@@ -1023,6 +1024,18 @@ msgstr ""
 msgid "Taxless"
 msgstr ""
 
+msgid "Message"
+msgstr ""
+
+msgid "No log entries have been added yet."
+msgstr ""
+
+msgid "Use the input below to add new log entries."
+msgstr ""
+
+msgid "Add to Log"
+msgstr ""
+
 msgid "Paid"
 msgstr ""
 
@@ -1081,6 +1094,12 @@ msgid "Order Contents"
 msgstr ""
 
 msgid "Payments"
+msgstr ""
+
+msgid "Log Entries"
+msgstr ""
+
+msgid "There was an error adding the log entry."
 msgstr ""
 
 msgid "Error!"
@@ -1257,8 +1276,8 @@ msgstr ""
 
 #, python-format
 msgid ""
-"Telemetry data was last submitted at %(submission_datetime)s - (%"
-"(submission_timesince)s) ago"
+"Telemetry data was last submitted at %(submission_datetime)s - "
+"(%(submission_timesince)s) ago"
 msgstr ""
 
 msgid "See the data that was submitted."

--- a/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
+++ b/shoop/admin/locale/en/LC_MESSAGES/djangojs.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-05-13 01:21+0000\n"
+"POT-Creation-Date: 2016-05-21 05:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 "Generated-By: Babel 2.1.1\n"
 
@@ -31,20 +31,21 @@ msgstr ""
 msgid "New file name?"
 msgstr ""
 
-#, c-format
-#| msgid "Are you sure you want to delete the file %s?"
+#, javascript-format
 msgid "Are you sure you want to delete the file %s?"
 msgstr ""
 
 msgid "New folder name?"
 msgstr ""
 
-#, c-format
-#| msgid "Are you sure you want to delete the %s folder?"
+#, javascript-format
 msgid "Are you sure you want to delete the %s folder?"
 msgstr ""
 
 msgid "New folder"
+msgstr ""
+
+msgid "current"
 msgstr ""
 
 msgid "Oldest first"
@@ -94,8 +95,7 @@ msgstr ""
 msgid "Delete folder"
 msgstr ""
 
-#, c-format
-#| msgid "Order %s created."
+#, javascript-format
 msgid "Order %s created."
 msgstr ""
 
@@ -226,8 +226,7 @@ msgid ""
 "customer first."
 msgstr ""
 
-#, c-format
-#| msgid "All prices are in %s currency."
+#, javascript-format
 msgid "All prices are in %s currency."
 msgstr ""
 
@@ -285,8 +284,7 @@ msgstr ""
 msgid "Identifier"
 msgstr ""
 
-#, c-format
-#| msgid "Value %s Name"
+#, javascript-format
 msgid "Value %s Name"
 msgstr ""
 
@@ -329,6 +327,12 @@ msgstr ""
 msgid "Expand Editor"
 msgstr ""
 
+msgid "Order Log"
+msgstr ""
+
+msgid "Log items:"
+msgstr ""
+
 msgid "From"
 msgstr ""
 
@@ -362,8 +366,7 @@ msgstr ""
 msgid "Next"
 msgstr ""
 
-#, c-format
-#| msgid "Filter by %s"
+#, javascript-format
 msgid "Filter by %s"
 msgstr ""
 

--- a/shoop/admin/modules/orders/__init__.py
+++ b/shoop/admin/modules/orders/__init__.py
@@ -40,6 +40,11 @@ class OrderModule(CurrencyBound, AdminModule):
                 name="order.set-status"
             ),
             admin_url(
+                "^orders/(?P<pk>\d+)/new-log-entry/$",
+                "shoop.admin.modules.orders.views.NewLogEntryView",
+                name="order.new-log-entry"
+            ),
+            admin_url(
                 "^orders/(?P<pk>\d+)/$",
                 "shoop.admin.modules.orders.views.OrderDetailView",
                 name="order.detail"

--- a/shoop/admin/modules/orders/views/__init__.py
+++ b/shoop/admin/modules/orders/views/__init__.py
@@ -9,10 +9,11 @@
 from .detail import OrderDetailView, OrderSetStatusView
 from .edit import OrderEditView
 from .list import OrderListView
+from .log import NewLogEntryView
 from .payment import OrderCreatePaymentView
 from .shipment import OrderCreateShipmentView
 
 __all__ = [
-    "OrderDetailView", "OrderEditView", "OrderListView", "OrderCreatePaymentView",
-    "OrderCreateShipmentView", "OrderSetStatusView"
+    "NewLogEntryView", "OrderDetailView", "OrderEditView", "OrderListView",
+    "OrderCreatePaymentView", "OrderCreateShipmentView", "OrderSetStatusView"
 ]

--- a/shoop/admin/modules/orders/views/detail.py
+++ b/shoop/admin/modules/orders/views/detail.py
@@ -17,7 +17,9 @@ from django.views.generic import DetailView
 from shoop.admin.toolbar import PostActionButton, Toolbar, URLActionButton
 from shoop.admin.utils.urls import get_model_url
 from shoop.apps.provides import get_provide_objects
-from shoop.core.models import Order, OrderStatus, OrderStatusRole
+from shoop.core.models import (
+    Order, OrderLogEntry, OrderStatus, OrderStatusRole
+)
 from shoop.utils.excs import Problem
 
 
@@ -91,6 +93,10 @@ class OrderDetailView(DetailView):
         context = super(OrderDetailView, self).get_context_data(**kwargs)
         context["toolbar"] = self.get_toolbar()
         context["title"] = force_text(self.object)
+        context["log_entries"] = (
+            OrderLogEntry.objects.filter(target=self.object).order_by("-created_on").all()[:12]
+            # TODO: We're currently trimming to 12 entries, probably need pagination
+        )
         return context
 
 

--- a/shoop/admin/modules/orders/views/log.py
+++ b/shoop/admin/modules/orders/views/log.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.http.response import JsonResponse
+from django.utils.encoding import force_text
+from django.views.generic import View
+
+from shoop.core.models import Order, OrderLogEntry
+from shoop.utils.analog import LogEntryKind
+from shoop.utils.i18n import get_locally_formatted_datetime
+
+
+class NewLogEntryView(View):
+    """
+    Create a log `note` item associated with a particular order.
+    """
+    def post(self, request, *args, **kwargs):
+        order = Order.objects.get(pk=kwargs["pk"])
+        message = request.POST["message"]
+        entry = OrderLogEntry.objects.create(
+            target=order,
+            message=message,
+            kind=LogEntryKind.NOTE,
+            user=request.user,
+        )
+
+        return JsonResponse({
+            "message": entry.message,
+            "kind": force_text(entry.kind.label),
+            "created_on": get_locally_formatted_datetime(entry.created_on),
+            "user": force_text(entry.user.username),
+        })

--- a/shoop/admin/templates/shoop/admin/orders/_order_log_entries.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/_order_log_entries.jinja
@@ -1,0 +1,38 @@
+<div id="order-log-entries">
+    <table class="table table-striped{% if not log_entries %} hidden{% endif %}">
+        <thead>
+            <tr>
+                <th>{% trans %}Message{% endtrans %}</th>
+                <th>{% trans %}Type{% endtrans %}</th>
+                <th>{% trans %}Date{% endtrans %}</th>
+                <th>{% trans %}User{% endtrans %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for entry in log_entries %}
+                <tr>
+                    <td>{{ entry.message }}</td>
+                    <td>{{ entry.kind }}</td>
+                    <td>{{ entry.created_on }}</td>
+                    <td>{{ entry.user }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% if not log_entries %}
+        <div id="no-log-entries-text">
+            <p>{% trans %}No log entries have been added yet.{% endtrans %}</p>
+            <p>{% trans %}Use the input below to add new log entries.{% endtrans %}</p>
+        </div>
+    {% endif %}
+    <form action="" method="post">
+        <div class="form-group">
+            <label class="control-label" for="log-message">{% trans %}Message{% endtrans %}</label>
+            <textarea class="form-control" id="log-message" type="text"></textarea>
+        </div>
+        <div class="form-group text-center">
+            <button class="btn btn-info" href="#">{% trans %}Add to Log{% endtrans %}</button>
+        </div>
+        {% csrf_token %}
+    </form>
+</div>

--- a/shoop/admin/templates/shoop/admin/orders/detail.jinja
+++ b/shoop/admin/templates/shoop/admin/orders/detail.jinja
@@ -64,6 +64,10 @@
                     {% include "shoop/admin/orders/_detail_payments.jinja" with context %}
                 {% endcall %}
             {% endif %}
+
+            {% call content_block(_("Log Entries"), "fa-pencil") %}
+                {% include "shoop/admin/orders/_order_log_entries.jinja" with context %}
+            {% endcall %}
         </div>
     {% endcall %}
 {% endblock %}
@@ -74,3 +78,48 @@
         {%- if not loop.last %}, {% endif -%}
     {%- endfor -%}
 {%- endmacro -%}
+
+{% block extra_js %}
+<script>
+    (function(){
+        function toggleHidden(){
+            $("#order-log-entries table").toggleClass("hidden");
+            $("#order-log-entries #no-log-entries-text").toggleClass("hidden");
+        }
+        function prependRow(log){
+            $("#order-log-entries tbody").prepend(
+                "<tr><td>" + log.message + "</td><td>" + log.kind +
+                "</td><td>" + log.created_on + "</td><td>" + log.user + "</td></tr>"
+            );
+        }
+        $("#order-log-entries button").on("click", function(event){
+            event.preventDefault();
+            var $children = $("#order-log-entries tbody").children();
+            var numEntries = $children.length;
+            if(numEntries==0){
+                toggleHidden();
+            }
+            else if(numEntries>12){
+                $children.last().remove();
+                $("#order-log-entries tbody")
+            }
+            $.ajax({
+                type: "POST",
+                url: "{{ url('shoop_admin:order.new-log-entry', pk=order.pk) }}",
+                data: {
+                    "message": $("#log-message").val(),
+                    "csrfmiddlewaretoken": '{{ csrf_token }}',
+                },
+                success: function(data){
+                    prependRow(data);
+                    $("#log-message").val("");
+                },
+                error: function(){
+                    alert("{% trans %}There was an error adding the log entry.{% endtrans %}")
+                },
+            });
+
+        });
+    })();
+</script>
+{% endblock %}


### PR DESCRIPTION
Enable adding log entries to orders

Merchant can create `note` log entries for orders under `Log
Entries` in order detail view.

Refs SHOOP-2240