### PR TITLE
Fix region_code handling in `TaxingContext`

### DIFF
--- a/shoop/core/taxing/_context.py
+++ b/shoop/core/taxing/_context.py
@@ -11,6 +11,6 @@ class TaxingContext(object):
         self.customer_tax_group = customer_tax_group
         self.customer_tax_number = customer_tax_number
         self.country_code = getattr(location, "country_code", None) or getattr(location, "country", None)
-        self.region_code = getattr(location, "region_code", None)
+        self.region_code = getattr(location, "region_code", None) or getattr(location, "region", None)
         self.postal_code = getattr(location, "postal_code", None)
         self.location = location


### PR DESCRIPTION
By default, form renders only `region` field, not `region_code` so taxing doesn't work.
No ref