### PR TITLE
Front: Associate company members with company contact details (SHOOP-884)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -188,6 +188,7 @@ Released on 2016-01-21 11:15 +0200.
 Core
 ~~~~
 
+- Add ``get_company_contact`` to ``shoop.core.models``
 - Document Shoop tax system
 - API and documentation clean-up
 - Remove ``AddressManager``

--- a/shoop/core/models/__init__.py
+++ b/shoop/core/models/__init__.py
@@ -19,7 +19,7 @@ from ._categories import Category, CategoryStatus, CategoryVisibility
 from ._configurations import ConfigurationItem
 from ._contacts import (
     AnonymousContact, CompanyContact, Contact, ContactGroup, Gender,
-    get_person_contact, PersonContact
+    get_company_contact, get_person_contact, PersonContact
 )
 from ._counters import Counter, CounterType
 from ._manufacturers import Manufacturer
@@ -80,6 +80,7 @@ __all__ = [
     "CustomerTaxGroup",
     "CustomPaymentProcessor",
     "FixedCostBehaviorComponent",
+    "get_company_contact",
     "get_person_contact",
     "Gender",
     "ImmutableAddress",

--- a/shoop/core/models/_contacts.py
+++ b/shoop/core/models/_contacts.py
@@ -360,3 +360,20 @@ def get_person_contact(user):
         'email': getattr(user, 'email', ''),
     }
     return PersonContact.objects.get_or_create(user=user, defaults=defaults)[0]
+
+
+def get_company_contact(user):
+    """
+    If user has associated PersonContact which is member of
+    CompanyContact, return CompanyContact. Otherwise, return None.
+
+    :param user: User object (or None) to get contact for
+    :type user: django.contrib.auth.models.User|None
+    :return: CompanyContact (or none) of which user's PersonContact
+        is a member
+    :rtype: CompanyContact|None
+    """
+    if not user or user.is_anonymous():
+        return None
+    contact = get_person_contact(user)
+    return contact.company_memberships.first()

--- a/shoop/front/middleware.py
+++ b/shoop/front/middleware.py
@@ -14,7 +14,9 @@ from django.template import loader
 from django.utils import timezone
 
 from shoop.core.middleware import ExceptionMiddleware
-from shoop.core.models import Contact, get_person_contact, Shop
+from shoop.core.models import (
+    Contact, get_company_contact, get_person_contact, Shop
+)
 from shoop.front.basket import get_basket
 
 __all__ = ["ProblemMiddleware", "ShoopFrontMiddleware"]
@@ -77,7 +79,7 @@ class ShoopFrontMiddleware(object):
         request.person = get_person_contact(request.user)
 
     def _set_customer(self, request):
-        request.customer = request.person
+        request.customer = (get_company_contact(request.user) or request.person)
 
     def _set_basket(self, request):
         request.basket = get_basket(request)

--- a/shoop_tests/core/test_contacts.py
+++ b/shoop_tests/core/test_contacts.py
@@ -12,10 +12,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import QuerySet
 
 from shoop.core.models import (
-    AnonymousContact, CompanyContact, ContactGroup, get_person_contact,
-    PersonContact
+    AnonymousContact, CompanyContact, ContactGroup, get_company_contact,
+    get_person_contact, PersonContact
 )
 from shoop.core.pricing import PriceDisplayOptions
+from shoop.testing.factories import create_random_company
 from shoop_tests.utils.fixtures import regular_user
 
 
@@ -244,3 +245,14 @@ def test_contact_group_price_display_for_contact(regular_user):
     default_options = person.get_price_display_options()
     assert default_options.include_taxes
     assert not default_options.hide_prices
+
+
+@pytest.mark.django_db
+def test_get_company_contact(regular_user):
+    person_contact = get_person_contact(regular_user)
+    assert person_contact != AnonymousContact()
+    assert not get_company_contact(regular_user)
+
+    company_contact = create_random_company()
+    company_contact.members.add(person_contact)
+    assert get_company_contact(regular_user) == company_contact


### PR DESCRIPTION
Associate company members with company contact details by default.

If a user's ``PersonContact`` is a member of a ``CompanyContact``,
use the company's contact details by default.

Refs SHOOP-884

Note: I didn't add changes to Front changlog since it the company selection logic will change soon.