### PR TITLE
Taxing of lines without tax class (SHOOP-2077)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Add new abstract method ``get_taxed_price`` to ``TaxModule``
 - Add ``ShopProduct.is_visible``
 - Add ``Order.can_edit``
 - Update shipping status correctly in ``Order.create_shipment``

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Implement taxing of lines without tax class
 - Add new abstract method ``get_taxed_price`` to ``TaxModule``
 - Add ``ShopProduct.is_visible``
 - Add ``Order.can_edit``

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -19,7 +19,7 @@ from six import iteritems
 from shoop.core import taxing
 from shoop.core.models import (
     AnonymousContact, OrderStatus, PaymentMethod, Product, ShippingMethod,
-    Shop, Supplier, TaxClass
+    ShippingMode, Shop, Supplier, TaxClass
 )
 from shoop.core.pricing import Price, Priceful, TaxfulPrice, TaxlessPrice
 from shoop.core.taxing import should_calculate_taxes_automatically, TaxableItem
@@ -232,6 +232,20 @@ class OrderSource(object):
     @status.setter
     def status(self, status):
         self.status_id = (status.id if status else None)
+
+    @property
+    def is_empty(self):
+        return not bool(self.get_lines())
+
+    @property
+    def product_ids(self):
+        return set(x.product.id for x in self.get_lines() if x.product)
+
+    def has_shippable_lines(self):
+        for line in self.get_lines():
+            if line.product:
+                if line.product.shipping_mode == ShippingMode.SHIPPED:
+                    return True
 
     @property
     def codes(self):

--- a/shoop/core/pricing/_priceful.py
+++ b/shoop/core/pricing/_priceful.py
@@ -82,6 +82,9 @@ class Priceful(object):
         """
         Amount of discount for the total quantity.
 
+        Normally positive or zero, but might also be negative if product
+        is being sold with higher price than its normal price.
+
         :rtype: shoop.core.pricing.Price
         """
         return (self.base_price - self.price)

--- a/shoop/core/taxing/_line_tax.py
+++ b/shoop/core/taxing/_line_tax.py
@@ -43,6 +43,8 @@ class LineTax(object):
 
     @property
     def rate(self):
+        if not self.base_amount:
+            return self.tax.rate
         return (self.amount / self.base_amount)
 
     @classmethod

--- a/shoop/core/taxing/_module.py
+++ b/shoop/core/taxing/_module.py
@@ -103,14 +103,13 @@ class TaxModule(six.with_metaclass(abc.ABCMeta)):
         taxed_price = self.get_taxed_price_for(context, line, line.price)
         return taxed_price.taxes
 
-    @abc.abstractmethod
     def get_taxed_price_for(self, context, item, price):
         """
         Get TaxedPrice for taxable item.
 
         Taxable items could be products (`~shoop.core.models.Product`),
-        shipping and payment methods (`~shoop.core.models.Method`), and
-        lines (`~shoop.core.order_creator.SourceLine`).
+        services (`~shoop.core.models.Service`), or lines
+        (`~shoop.core.order_creator.SourceLine`).
 
         :param context: Taxing context to calculate in
         :type context: TaxingContext
@@ -118,6 +117,22 @@ class TaxModule(six.with_metaclass(abc.ABCMeta)):
         :type item: shoop.core.taxing.TaxableItem
         :param price: Price (taxful or taxless) to calculate taxes for
         :type price: shoop.core.pricing.Price
+
+        :rtype: shoop.core.taxing.TaxedPrice
+        """
+        return self.get_taxed_price(context, price, item.tax_class)
+
+    @abc.abstractmethod
+    def get_taxed_price(self, context, price, tax_class):
+        """
+        Get TaxedPrice for price and tax class.
+
+        :param context: Taxing context to calculate in
+        :type context: TaxingContext
+        :param price: Price (taxful or taxless) to calculate taxes for
+        :type price: shoop.core.pricing.Price
+        :param tax_class: Tax class of the item to get taxes for
+        :type tax_class: shoop.core.models.TaxClass
 
         :rtype: shoop.core.taxing.TaxedPrice
         """

--- a/shoop/core/taxing/_tax_summary.py
+++ b/shoop/core/taxing/_tax_summary.py
@@ -45,7 +45,7 @@ class TaxSummary(list):
                     tax_id=None, tax_code='', tax_name=_("Untaxed"),
                     tax_rate=Decimal(0), based_on=untaxed.amount,
                     tax_amount=zero_amount))
-        return cls(sorted(lines, key=(lambda x: (x.tax_rate or 0))))
+        return cls(sorted(lines, key=TaxSummaryLine.get_sort_key))
 
     def __repr__(self):
         super_repr = super(TaxSummary, self).__repr__()
@@ -68,6 +68,9 @@ class TaxSummaryLine(object):
         self.based_on = based_on
         self.tax_amount = tax_amount
         self.taxful = based_on + tax_amount
+
+    def get_sort_key(self):
+        return (-self.tax_rate or 0, self.tax_name)
 
     def __repr__(self):
         return '<{} {}/{}/{:.3%} based_on={} tax_amount={})>'.format(

--- a/shoop/core/taxing/utils.py
+++ b/shoop/core/taxing/utils.py
@@ -6,11 +6,50 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import defaultdict
+
 from shoop.core.pricing import TaxfulPrice, TaxlessPrice
 from shoop.utils.money import Money
 
 from ._line_tax import SourceLineTax
 from ._price import TaxedPrice
+
+
+def get_tax_class_proportions(lines):
+    """
+    Generate tax class proportions from taxed lines.
+
+    Sum prices per tax class and return a list of (tax_class, factor)
+    pairs, where factor is the proportion of total price of lines with
+    given tax class from the total price of all lines.
+
+    :type lines: list[shoop.core.order_creator.SourceLine]
+    :param lines: List of taxed lines to generate proportions from
+    :rtype: list[(shoop.core.models.TaxClass, decimal.Decimal)]
+    :return:
+      List of tax classes with a proportion, or empty list if total
+      price is zero.  Sum of proportions is 1.
+    """
+    if not lines:
+        return []
+
+    zero = lines[0].price.new(0)
+
+    total_by_tax_class = defaultdict(lambda: zero)
+    total = zero
+
+    for line in lines:
+        total_by_tax_class[line.tax_class] += line.price
+        total += line.price
+
+    if not total:
+        # Can't calculate proportions, if total is zero
+        return []
+
+    return [
+        (tax_class, tax_class_total / total)
+        for (tax_class, tax_class_total) in total_by_tax_class.items()
+    ]
 
 
 def stacked_value_added_taxes(price, taxes):

--- a/shoop/default_tax/module.py
+++ b/shoop/default_tax/module.py
@@ -20,8 +20,8 @@ class DefaultTaxModule(taxing.TaxModule):
     identifier = "default_tax"
     name = _("Default Taxation")
 
-    def get_taxed_price_for(self, context, item, price):
-        return _calculate_taxes(price, context, item.tax_class)
+    def get_taxed_price(self, context, price, tax_class):
+        return _calculate_taxes(price, context, tax_class)
 
 
 def _calculate_taxes(price, taxing_context, tax_class):

--- a/shoop/front/basket/objects.py
+++ b/shoop/front/basket/objects.py
@@ -16,9 +16,7 @@ from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.core.models import (
-    OrderLineType, PaymentMethod, ShippingMethod, ShippingMode
-)
+from shoop.core.models import OrderLineType, PaymentMethod, ShippingMethod
 from shoop.core.order_creator import OrderSource, SourceLine
 from shoop.front.basket.storage import BasketCompatibilityError, get_storage
 from shoop.utils.numbers import parse_decimal_string
@@ -423,17 +421,3 @@ class BaseBasket(OrderSource):
             in PaymentMethod.objects.available(shop=self.shop, products=self.product_ids)
             if m.is_available_for(self)
         ]
-
-    def has_shippable_lines(self):
-        for line in self.get_lines():
-            if line.product:
-                if line.product.shipping_mode == ShippingMode.SHIPPED:
-                    return True
-
-    @property
-    def product_ids(self):
-        return set(l.product.id for l in self.get_lines() if l.product)
-
-    @property
-    def is_empty(self):
-        return not bool(self.get_lines())

--- a/shoop/utils/money.py
+++ b/shoop/utils/money.py
@@ -45,6 +45,9 @@ class Money(numbers.UnitedDecimal):
         cls_name = type(self).__name__
         return "%s('%s', %r)" % (cls_name, self.value, self.currency)
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (self.value, self.currency))
+
     def __str__(self):
         return "%s %s" % (self.value, self.currency)
 

--- a/shoop_tests/core/test_orders.py
+++ b/shoop_tests/core/test_orders.py
@@ -151,14 +151,14 @@ def test_basic_order():
 
     summary = order.get_tax_summary()
     assert len(summary) == 2
-    assert summary[0].tax_id is None
-    assert summary[0].tax_code == ''
-    assert summary[0].tax_amount == Money(0, currency)
-    assert summary[0].tax_rate == 0
-    assert summary[1].tax_rate * 100 == 50
-    assert summary[1].based_on == Money(100, currency)
-    assert summary[1].tax_amount == Money(50, currency)
-    assert summary[1].taxful == summary[1].based_on + summary[1].tax_amount
+    assert summary[0].tax_rate * 100 == 50
+    assert summary[0].based_on == Money(100, currency)
+    assert summary[0].tax_amount == Money(50, currency)
+    assert summary[0].taxful == summary[0].based_on + summary[0].tax_amount
+    assert summary[1].tax_id is None
+    assert summary[1].tax_code == ''
+    assert summary[1].tax_amount == Money(0, currency)
+    assert summary[1].tax_rate == 0
 
 
 @pytest.mark.django_db

--- a/shoop_tests/core/test_utils_prices.py
+++ b/shoop_tests/core/test_utils_prices.py
@@ -37,7 +37,7 @@ class DummyTaxModule(TaxModule):
     calculations_done = 0
 
     identifier = "dummy_tax_module"
-    def get_taxed_price_for(self, context, item, price):
+    def get_taxed_price(self, context, price, tax_class):
         if price.includes_tax:
             taxful = price
             taxless = TaxlessPrice(price.amount / Decimal('1.2'))

--- a/shoop_tests/functional/test_discount_taxing.py
+++ b/shoop_tests/functional/test_discount_taxing.py
@@ -1,0 +1,553 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import unicode_literals
+
+from collections import defaultdict
+from decimal import Decimal
+
+import pytest
+from django.test.utils import override_settings
+
+from shoop.core.models import OrderLineType, Tax, TaxClass
+from shoop.core.order_creator import OrderSource
+from shoop.core.pricing import TaxlessPrice
+from shoop.core.taxing import TaxSummary
+from shoop.default_tax.models import TaxRule
+from shoop.testing.factories import (
+    create_product, get_payment_method, get_shipping_method, get_shop
+)
+
+
+def setup_module(module):
+    global settings_overrider
+    settings_overrider = override_settings(
+        SHOOP_CALCULATE_TAXES_AUTOMATICALLY_IF_POSSIBLE=False)
+    settings_overrider.__enter__()
+
+
+def teardown_module(module):
+    settings_overrider.__exit__(None, None, None)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_1prod(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price: 200.00|qty: 1|discount:  0.00|tax: A',
+            'discount: SALE   |price: -20.00|qty: 1|discount: 20.00'],
+        tax_rates={'A': ['0.25']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 180
+    assert get_price_by_tax_class(source) == {'TC-A': 200, '': -20}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.25  144.000000000   36.000000000  180.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25  -16.000000000   -4.000000000  -20.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.25  180.000000000   45.000000000  225.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25  -20.000000000   -5.000000000  -25.000000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_2prods(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  10.00|qty: 1|discount:  0.00|tax: A',
+            'product: P2      |price:  20.00|qty: 1|discount:  0.00|tax: B',
+            'discount: SALE   |price:  -3.00|qty: 1|discount:  3.00'],
+        tax_rates={'A': ['0.25'], 'B': ['0.20']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 27
+    assert get_price_by_tax_class(source) == {'TC-A': 10, 'TC-B': 20, '': -3}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.25    7.200000000    1.800000000    9.000000000',
+            'Tax-B   0.20   15.000000000    3.000000000   18.000000000',
+            'Total   0.22   22.200000000    4.800000000   27.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25   -0.800000000   -0.200000000   -1.000000000',
+            'Tax-B   0.20   -1.666666667   -0.333333333   -2.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.25    9.000000000    2.250000000   11.250000000',
+            'Tax-B   0.20   18.000000000    3.600000000   21.600000000',
+            'Total   0.22   27.000000000    5.850000000   32.850000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25   -1.000000000   -0.250000000   -1.250000000',
+            'Tax-B   0.20   -2.000000000   -0.400000000   -2.400000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_2prods_2taxrates(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  10.00|qty: 1|discount:  0.00|tax: A',
+            'product: P2      |price:  20.00|qty: 1|discount:  0.00|tax: B',
+            'discount: SALE   |price:  -3.00|qty: 1|discount:  3.00'],
+        tax_rates={'A': ['0.20', '0.05'], 'B': ['0.15', '0.05']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 27
+    assert get_price_by_tax_class(source) == {'TC-A': 10, 'TC-B': 20, '': -3}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A-1 0.20    7.200000000    1.440000000    8.640000000',
+            'Tax-B-1 0.15   15.000000000    2.250000000   17.250000000',
+            'Tax-A-2 0.05    7.200000000    0.360000000    7.560000000',
+            'Tax-B-2 0.05   15.000000000    0.750000000   15.750000000',
+            'Total   0.22   22.200000000    4.800000000   27.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A-1 0.20   -0.800000000   -0.160000000   -0.960000000',
+            'Tax-A-2 0.05   -0.800000000   -0.040000000   -0.840000000',
+            'Tax-B-1 0.15   -1.666666667   -0.250000000   -1.916666667',
+            'Tax-B-2 0.05   -1.666666667   -0.083333333   -1.750000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A-1 0.20    9.000000000    1.800000000   10.800000000',
+            'Tax-B-1 0.15   18.000000000    2.700000000   20.700000000',
+            'Tax-A-2 0.05    9.000000000    0.450000000    9.450000000',
+            'Tax-B-2 0.05   18.000000000    0.900000000   18.900000000',
+            'Total   0.22   27.000000000    5.850000000   32.850000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A-1 0.20   -1.000000000   -0.200000000   -1.200000000',
+            'Tax-A-2 0.05   -1.000000000   -0.050000000   -1.050000000',
+            'Tax-B-1 0.15   -2.000000000   -0.300000000   -2.300000000',
+            'Tax-B-2 0.05   -2.000000000   -0.100000000   -2.100000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_3prods_with_services(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  10.00|qty: 2|discount:  2.00|tax: A',
+            'product: P2      |price:  40.00|qty: 8|discount:  0.00|tax: B',
+            'product: P3      |price:  60.00|qty: 6|discount: 12.00|tax: C',
+            'payment: Invoice |price:   2.50|qty: 1|discount:  0.00|tax: A',
+            'shipping: Ship   |price:   7.50|qty: 1|discount:  0.00|tax: A',
+            'discount: SALE   |price: -30.00|qty: 1|discount: 30.00'],
+        tax_rates={'A': ['0.25'], 'B': ['0.15'], 'C': ['0.30']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 90
+    assert get_price_by_tax_class(source) == {
+        'TC-A': 20, 'TC-B': 40, 'TC-C': 60, '': -30}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.30   34.615384615   10.384615385   45.000000000',
+            'Tax-A   0.25   12.000000000    3.000000000   15.000000000',
+            'Tax-B   0.15   26.086956522    3.913043478   30.000000000',
+            'Total   0.24   72.702341137   17.297658863   90.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25   -4.000000000   -1.000000000   -5.000000000',
+            'Tax-B   0.15   -8.695652174   -1.304347826  -10.000000000',
+            'Tax-C   0.30  -11.538461538   -3.461538462  -15.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.30   45.000000000   13.500000000   58.500000000',
+            'Tax-A   0.25   15.000000000    3.750000000   18.750000000',
+            'Tax-B   0.15   30.000000000    4.500000000   34.500000000',
+            'Total   0.24   90.000000000   21.750000000  111.750000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.25   -5.000000000   -1.250000000   -6.250000000',
+            'Tax-B   0.15  -10.000000000   -1.500000000  -11.500000000',
+            'Tax-C   0.30  -15.000000000   -4.500000000  -19.500000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_3prods_services_2discounts(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  24.00|qty: 2|discount:  0.00|tax: A',
+            'product: P2      |price: 100.00|qty: 8|discount:  0.00|tax: B',
+            'product: P3      |price:  80.00|qty: 5|discount:  5.00|tax: C',
+            'payment: Invoice |price:   6.25|qty: 1|discount:  0.00|tax: B',
+            'shipping: Ship   |price:  18.75|qty: 1|discount:  2.50|tax: B',
+            'discount: SALE1  |price: -22.90|qty: 1|discount: 22.90',
+            'discount: SALE2  |price: -11.45|qty: 1|discount: 11.45'],
+        tax_rates={'A': ['0.25'], 'B': ['0.20'], 'C': ['0.50']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == Decimal('194.65')
+    assert get_price_by_tax_class(source) == {
+        'TC-A': 24, 'TC-B': 125, 'TC-C': 80, '': Decimal('-34.35')}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.50   45.333333333   22.666666667   68.000000000',
+            'Tax-A   0.25   16.320000000    4.080000000   20.400000000',
+            'Tax-B   0.20   88.541666667   17.708333333  106.250000000',
+            'Total   0.30  150.195000000   44.455000000  194.650000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [
+            ['Tax-A   0.25   -1.920000000   -0.480000000   -2.400000000',
+             'Tax-B   0.20  -10.416666667   -2.083333333  -12.500000000',
+             'Tax-C   0.50   -5.333333333   -2.666666667   -8.000000000'],
+            ['Tax-A   0.25   -0.960000000   -0.240000000   -1.200000000',
+             'Tax-B   0.20   -5.208333333   -1.041666667   -6.250000000',
+             'Tax-C   0.50   -2.666666667   -1.333333333   -4.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.50   68.000000000   34.000000000  102.000000000',
+            'Tax-A   0.25   20.400000000    5.100000000   25.500000000',
+            'Tax-B   0.20  106.250000000   21.250000000  127.500000000',
+            'Total   0.31  194.650000000   60.350000000  255.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [
+            ['Tax-A   0.25   -2.400000000   -0.600000000   -3.000000000',
+             'Tax-B   0.20  -12.500000000   -2.500000000  -15.000000000',
+             'Tax-C   0.50   -8.000000000   -4.000000000  -12.000000000'],
+            ['Tax-A   0.25   -1.200000000   -0.300000000   -1.500000000',
+             'Tax-B   0.20   -6.250000000   -1.250000000   -7.500000000',
+             'Tax-C   0.50   -4.000000000   -2.000000000   -6.000000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_3prods_services_2discounts2(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  30.00|qty: 2|discount:  0.00|tax: A',
+            'product: P2      |price: 120.00|qty: 8|discount:  0.00|tax: B',
+            'product: P3      |price: 120.00|qty: 5|discount:  5.00|tax: C',
+            'payment: Invoice |price:   7.50|qty: 1|discount:  0.00|tax: B',
+            'shipping: Ship   |price:  22.50|qty: 1|discount:  2.50|tax: B',
+            'discount: SALE1  |price: -30.00|qty: 1|discount: 30.00',
+            'discount: SALE2  |price: -15.00|qty: 1|discount: 15.00'],
+        tax_rates={'A': ['0.25'], 'B': ['0.20'], 'C': ['0.50']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 255
+    assert get_price_by_tax_class(source) == {
+        'TC-A': 30, 'TC-B': 150, 'TC-C': 120, '': -45}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.50   68.000000000   34.000000000  102.000000000',
+            'Tax-A   0.25   20.400000000    5.100000000   25.500000000',
+            'Tax-B   0.20  106.250000000   21.250000000  127.500000000',
+            'Total   0.31  194.650000000   60.350000000  255.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [
+            ['Tax-A   0.25   -2.400000000   -0.600000000   -3.000000000',
+             'Tax-B   0.20  -12.500000000   -2.500000000  -15.000000000',
+             'Tax-C   0.50   -8.000000000   -4.000000000  -12.000000000'],
+            ['Tax-A   0.25   -1.200000000   -0.300000000   -1.500000000',
+             'Tax-B   0.20   -6.250000000   -1.250000000   -7.500000000',
+             'Tax-C   0.50   -4.000000000   -2.000000000   -6.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-C   0.50  102.000000000   51.000000000  153.000000000',
+            'Tax-A   0.25   25.500000000    6.375000000   31.875000000',
+            'Tax-B   0.20  127.500000000   25.500000000  153.000000000',
+            'Total   0.32  255.000000000   82.875000000  337.875000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [
+            ['Tax-A   0.25   -3.000000000   -0.750000000   -3.750000000',
+             'Tax-B   0.20  -15.000000000   -3.000000000  -18.000000000',
+             'Tax-C   0.50  -12.000000000   -6.000000000  -18.000000000'],
+            ['Tax-A   0.25   -1.500000000   -0.375000000   -1.875000000',
+             'Tax-B   0.20   -7.500000000   -1.500000000   -9.000000000',
+             'Tax-C   0.50   -6.000000000   -3.000000000   -9.000000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_all_discounted(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:  30.00|qty: 1|discount:  0.00|tax: A',
+            'product: P2      |price:  60.00|qty: 1|discount:  0.00|tax: B',
+            'discount: SALE   |price: -90.00|qty: 1|discount: 90.00'],
+        tax_rates={'A': ['0.20'], 'B': ['0.10']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 0
+    assert get_price_by_tax_class(source) == {'TC-A': 30, 'TC-B': 60, '': -90}
+
+    if taxes == 'taxful':
+        #    Name    Rate    Base amount     Tax amount         Taxful
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.20    0.000000000    0.000000000    0.000000000',
+            'Tax-B   0.10    0.000000000    0.000000000    0.000000000',
+            'Total   0.00    0.000000000    0.000000000    0.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.20  -25.000000000   -5.000000000  -30.000000000',
+            'Tax-B   0.10  -54.545454545   -5.454545455  -60.000000000']]
+    else:
+        assert get_pretty_tax_summary(source) == [
+            'Tax-A   0.20    0.000000000    0.000000000    0.000000000',
+            'Tax-B   0.10    0.000000000    0.000000000    0.000000000',
+            'Total   0.00    0.000000000    0.000000000    0.000000000']
+        assert get_pretty_line_taxes_of_discount_lines(source) == [[
+            'Tax-A   0.20  -30.000000000   -6.000000000  -36.000000000',
+            'Tax-B   0.10  -60.000000000   -6.000000000  -66.000000000']]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_zero_priced_products(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'product: P1      |price:   0.00|qty: 1|discount:  0.00|tax: A',
+            'product: P2      |price:   0.00|qty: 1|discount:  0.00|tax: B',
+            'discount: Foobar |price:  10.00|qty: 1|discount:-10.00'],
+        tax_rates={'A': ['0.25'], 'B': ['0.20']})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 10
+    assert get_price_by_tax_class(source) == {'TC-A': 0, 'TC-B': 0, '': 10}
+
+    #    Name    Rate    Base amount     Tax amount         Taxful
+    assert get_pretty_tax_summary(source) == [
+        'Tax-A   0.25    0.000000000    0.000000000    0.000000000',
+        'Tax-B   0.20    0.000000000    0.000000000    0.000000000',
+        'Untaxed 0.00   10.000000000    0.000000000   10.000000000',
+        'Total   0.00   10.000000000    0.000000000   10.000000000']
+    assert get_pretty_line_taxes_of_discount_lines(source) == [[]]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("taxes", ['taxful', 'taxless'])
+def test_no_products(taxes):
+    source = create_order_source(
+        prices_include_tax=(taxes == 'taxful'),
+        line_data=[
+            'discount: Foobar |price:  50.00|qty: 1|discount:-50.00',
+            'discount: SALE   |price: -10.00|qty: 1|discount: 10.00'],
+        tax_rates={})
+    source.calculate_taxes()
+
+    assert source.total_price.value == 40
+    assert get_price_by_tax_class(source) == {'': 40}
+
+    #    Name    Rate    Base amount     Tax amount         Taxful
+    assert get_pretty_tax_summary(source) == [
+        'Untaxed 0.00   40.000000000    0.000000000   40.000000000']
+    assert get_pretty_line_taxes_of_discount_lines(source) == [[], []]
+
+
+# ================================================================
+# Creating test data
+# ================================================================
+
+class Line(object):
+    def __init__(self, price, quantity=1, discount=0, **kwargs):
+        self.price = Decimal(price)
+        self.quantity = Decimal(quantity)
+        self.discount = Decimal(discount)
+        self.__dict__.update(kwargs)
+        self.base_unit_price = (self.price + self.discount) / self.quantity
+        self.is_product = ('product_sku' in kwargs)
+        self.is_payment = ('payment_name' in kwargs)
+        self.is_shipping = ('shipping_name' in kwargs)
+        self.is_discount = ('discount_text' in kwargs)
+
+    @classmethod
+    def from_text(cls, text):
+        preparsed = (item.split(':') for item in text.split('|'))
+        data = {x[0].strip(): x[1].strip() for x in preparsed}
+        mappings = [
+            ('product', 'product_sku'),
+            ('payment', 'payment_name'),
+            ('shipping', 'shipping_name'),
+            ('discount', 'discount_text'),
+            ('qty', 'quantity'),
+            ('disc', 'discount'),
+            ('tax', 'tax_name'),
+        ]
+        for (old_key, new_key) in mappings:
+            if old_key in data:
+                data[new_key] = data[old_key]
+                del data[old_key]
+        return cls(**data)
+
+
+def create_order_source(prices_include_tax, line_data, tax_rates):
+    """
+    Get order source with some testing data.
+
+    :rtype: OrderSource
+    """
+    lines = [Line.from_text(x) for x in line_data]
+    shop = get_shop(prices_include_tax, currency='USD')
+    tax_classes = create_assigned_tax_classes(tax_rates)
+    products = create_products(shop, lines, tax_classes)
+    services = create_services(shop, lines, tax_classes)
+
+    source = OrderSource(shop)
+    fill_order_source(source, lines, products, services)
+    return source
+
+
+def create_assigned_tax_classes(tax_rates):
+    return {
+        tax_name: create_assigned_tax_class(tax_name, rates_to_assign)
+        for (tax_name, rates_to_assign) in tax_rates.items()
+    }
+
+
+def create_assigned_tax_class(name, rates_to_assign):
+    """
+    Create a tax class and assign taxes for it with tax rules.
+    """
+    tax_class = TaxClass.objects.create(name='TC-%s' % name)
+    for (n, tax_rate) in enumerate(rates_to_assign, 1):
+        tax_name = (
+            'Tax-%s' % name if len(rates_to_assign) == 1 else
+            'Tax-%s-%d' % (name, n))
+        tax = Tax.objects.create(rate=tax_rate, name=tax_name)
+        TaxRule.objects.create(tax=tax).tax_classes.add(tax_class)
+    return tax_class
+
+
+def create_products(shop, lines, tax_classes):
+    return {
+        line.product_sku: create_product(
+            line.product_sku, shop,
+            default_price=line.base_unit_price,
+            tax_class=tax_classes[line.tax_name]
+        )
+        for line in lines if line.is_product
+    }
+
+
+def create_services(shop, lines, tax_classes):
+    def service_name(line):
+        return 'payment_method' if line.is_payment else 'shipping_method'
+    return {
+        service_name(line): create_service(shop, line, tax_classes)
+        for line in lines if (line.is_payment or line.is_shipping)
+    }
+
+
+def create_service(shop, line, tax_classes):
+    assert line.quantity == 1 and line.discount == 0
+    if line.is_payment:
+        meth = get_payment_method(
+            shop=shop, price=line.price, name=line.payment_name)
+    elif line.is_shipping:
+        meth = get_shipping_method(
+            shop=shop, price=line.price, name=line.shipping_name)
+    meth.tax_class = tax_classes[line.tax_name]
+    meth.save()
+    return meth
+
+
+def fill_order_source(source, lines, products, services):
+    for line in lines:
+        if line.is_product:
+            source.add_line(
+                product=products[line.product_sku],
+                quantity=line.quantity,
+                base_unit_price=source.create_price(line.base_unit_price),
+                discount_amount=source.create_price(line.discount),
+            )
+        elif line.is_payment:
+            source.payment_method = services['payment_method']
+        elif line.is_shipping:
+            source.shipping_method = services['shipping_method']
+        elif line.is_discount:
+            source.add_line(
+                type=OrderLineType.DISCOUNT,
+                quantity=line.quantity,
+                base_unit_price=source.create_price(line.base_unit_price),
+                discount_amount=source.create_price(line.discount),
+                text=line.discount_text,
+            )
+
+
+# ================================================================
+# Getting and formatting results
+# ================================================================
+
+def get_price_by_tax_class(source):
+    price_by_tax_class = defaultdict(Decimal)
+    for line in source.get_final_lines(with_taxes=False):
+        tax_class_name = (line.tax_class.name if line.tax_class else '')
+        price_by_tax_class[tax_class_name] += line.price.value
+    return price_by_tax_class
+
+
+TAX_DISTRIBUTION_LINE_FORMAT = (
+    '{n:7s} {r:4.2f} {ba:14.9f} {a:14.9f} {t:14.9f}')
+
+
+def get_pretty_tax_summary(source):
+    summary = get_tax_summary(source)
+    lines = [
+        TAX_DISTRIBUTION_LINE_FORMAT.format(
+            n=line.tax_name, r=line.tax_rate,
+            ba=line.based_on, a=line.tax_amount, t=line.taxful)
+        for line in summary]
+    total_base = source.taxless_total_price.value
+    total_taxful = source.taxful_total_price.value
+    total_tax_amount = sum(x.tax_amount.value for x in summary)
+    total_line = TAX_DISTRIBUTION_LINE_FORMAT.format(
+        n="Total",
+        r=((total_tax_amount / total_base)
+           if abs(total_base) > 0.0001 else 0),
+        ba=total_base, a=total_tax_amount, t=total_taxful)
+    return lines + ([total_line] if len(summary) > 1 else [])
+
+
+def get_tax_summary(source):
+    """
+    Get tax summary of given source lines.
+
+    :type source: OrderSource
+    :type lines: list[SourceLine]
+    :rtype: TaxSummary
+    """
+    all_line_taxes = []
+    untaxed = TaxlessPrice(source.create_price(0).amount)
+    for line in source.get_final_lines():
+        line_taxes = list(line.taxes)
+        all_line_taxes.extend(line_taxes)
+        if not line_taxes:
+            untaxed += line.taxless_price
+    return TaxSummary.from_line_taxes(all_line_taxes, untaxed)
+
+
+def get_pretty_line_taxes_of_discount_lines(source):
+    return [
+        prettify_line_taxes(line)
+        for line in source.get_final_lines()
+        if line.tax_class is None]
+
+
+def prettify_line_taxes(line):
+    return [
+        TAX_DISTRIBUTION_LINE_FORMAT.format(
+            n=line_tax.name, r=line_tax.rate,
+            ba=line_tax.base_amount, a=line_tax.amount,
+            t=(line_tax.base_amount + line_tax.amount))
+        for line_tax in sorted(line.taxes, key=(lambda x: x.name))]

--- a/shoop_tests/functional/test_tax_system.py
+++ b/shoop_tests/functional/test_tax_system.py
@@ -26,7 +26,7 @@ TAX_MODULE_SPEC = [__name__ + ":IrvineCaliforniaTaxation"]
 class IrvineCaliforniaTaxation(TaxModule):
     identifier = "irvine"
 
-    def get_taxed_price_for(self, context, item, price):
+    def get_taxed_price(self, context, price, tax_class):
         taxes = []
         if context.postal_code == "92602":
             taxes = [

--- a/shoop_tests/functional/test_tax_system.py
+++ b/shoop_tests/functional/test_tax_system.py
@@ -38,6 +38,10 @@ class IrvineCaliforniaTaxation(TaxModule):
             ]
         return stacked_value_added_taxes(price, taxes)
 
+    def _add_proportional_taxes(self, context, tax_class_proportions, lines):
+        for line in lines:
+            line.taxes = self.get_taxed_price(context, line.price, None).taxes
+
 
 @pytest.mark.django_db
 def test_stacked_tax_taxless_price():


### PR DESCRIPTION
Implement taxing of lines without a tax class, especially discount
lines.

Has some other related changes too.  See the commit messages for
details.