### PR TITLE
Preserve order data while editing (SHOOP-2587)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,8 @@ Unreleased
 Core
 ~~~~
 
+- Add modified on for ``Order``
+- Add modified by for ``Order`` and ``OrderSource``
 - Add ``get_company_contact`` to ``shoop.core.models``
 - Implement taxing of lines without tax class
 - Add new abstract method ``get_taxed_price`` to ``TaxModule``

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -286,6 +286,9 @@ class JsonOrderCreator(object):
         if not self.is_valid:
             return None
 
+        if order_to_update:
+            for code in order_to_update.codes:
+                source.add_code(code)
         return source
 
     def create_order_from_state(self, state, creator=None, ip_address=None):

--- a/shoop/admin/modules/orders/json_order_creator.py
+++ b/shoop/admin/modules/orders/json_order_creator.py
@@ -305,7 +305,7 @@ class JsonOrderCreator(object):
             self.add_error(exc)
             return
 
-    def update_order_from_state(self, state, order_to_update, creator=None, ip_address=None):
+    def update_order_from_state(self, state, order_to_update, modified_by=None):
         """
         Update an order from a state dict unserialized from JSON.
 
@@ -313,16 +313,12 @@ class JsonOrderCreator(object):
         :type state: dict
         :param order_to_update: Order object to edit
         :type order_to_update: shoop.core.models.Order
-        :param creator: Creator user
-        :type creator: django.contrib.auth.models.User|None
-        :param ip_address: Remote IP address (IPv4 or IPv6)
-        :type ip_address: str
         :return: The created order, or None if something failed along the way
         :rtype: Order|None
         """
-        source = self.create_source_from_state(
-            state, creator=creator, ip_address=ip_address, save=True)
-
+        source = self.create_source_from_state(state, save=True)
+        if source:
+            source.modified_by = modified_by
         modifier = OrderModifier()
         try:
             order = modifier.update_order_from_source(order_source=source, order=order_to_update)

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -265,11 +265,13 @@ class OrderEditView(CreateOrUpdateView):
 
     @transaction.atomic
     def _handle_source_data(self, request):
+        self.object = self.get_object()
         state = json.loads(request.body.decode("utf-8"))["state"]
         source = create_source_from_state(
             state,
             creator=request.user,
             ip_address=request.META.get("REMOTE_ADDR"),
+            order_to_update=self.object if self.object.pk else None
         )
         # Calculate final lines for confirmation
         source.calculate_taxes(force_recalculate=True)

--- a/shoop/admin/modules/orders/views/edit.py
+++ b/shoop/admin/modules/orders/views/edit.py
@@ -290,8 +290,7 @@ class OrderEditView(CreateOrUpdateView):
             order = update_order_from_state(
                 state,
                 self.object,
-                creator=request.user,
-                ip_address=request.META.get("REMOTE_ADDR"),
+                modified_by=request.user
             )
             assert self.object.pk == order.pk
             messages.success(request, _("Order %(identifier)s updated.") % vars(order))

--- a/shoop/campaigns/modules.py
+++ b/shoop/campaigns/modules.py
@@ -9,7 +9,9 @@ import random
 
 from django.utils.translation import ugettext_lazy as _
 
-from shoop.campaigns.models.campaigns import BasketCampaign, CatalogCampaign
+from shoop.campaigns.models.campaigns import (
+    BasketCampaign, CatalogCampaign, CouponUsage
+)
 from shoop.core.models import OrderLineType
 from shoop.core.order_creator import OrderSourceModifierModule
 from shoop.core.pricing import DiscountModule
@@ -111,3 +113,6 @@ class BasketCampaignModule(OrderSourceModifierModule):
         campaigns = BasketCampaign.objects.filter(active=True, coupon__code=code, coupon__active=True)
         for campaign in campaigns:
             campaign.coupon.use(order)
+
+    def clear_codes(self, order):
+        CouponUsage.objects.filter(order=order).delete()

--- a/shoop/core/locale/en/LC_MESSAGES/django.po
+++ b/shoop/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-04-25 22:35+0000\n"
+"POT-Creation-Date: 2016-05-25 21:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: en <LL@li.org>\n"
@@ -486,6 +486,9 @@ msgstr ""
 msgid "default"
 msgstr ""
 
+msgid "modified on"
+msgstr ""
+
 msgid "order identifier"
 msgstr ""
 
@@ -505,6 +508,9 @@ msgid "email address"
 msgstr ""
 
 msgid "creating user"
+msgstr ""
+
+msgid "modifier user"
 msgstr ""
 
 msgid "payment status"
@@ -574,6 +580,9 @@ msgid "orders"
 msgstr ""
 
 msgid "Order marked as paid."
+msgstr ""
+
+msgid "Order marked as partially paid."
 msgstr ""
 
 #, python-format
@@ -807,9 +816,6 @@ msgid "product type"
 msgstr ""
 
 msgid "product types"
-msgstr ""
-
-msgid "modified on"
 msgstr ""
 
 msgid "mode"

--- a/shoop/core/migrations/0024_add_order_modified_info.py
+++ b/shoop/core/migrations/0024_add_order_modified_info.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import shoop.core.fields
+import django.db.models.deletion
+from django.conf import settings
+
+
+def init_modified_info(apps, schema_editor):
+    order_model = apps.get_model("shoop", "Order")
+    order_model.objects.update(
+        modified_on=models.F("created_on"),
+        modified_by=models.F("creator")
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('shoop', '0023_add_shipment_identifier'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='modified_by',
+            field=shoop.core.fields.UnsavedForeignKey(
+                null=True, verbose_name='modifier user', blank=True, on_delete=django.db.models.deletion.PROTECT,
+                related_name='orders_modified', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='order',
+            name='modified_on',
+            field=models.DateTimeField(null=True, verbose_name='modified on', auto_now_add=True),
+        ),
+        migrations.RunPython(init_modified_info, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='order',
+            name='modified_on',
+            field=models.DateTimeField(verbose_name='modified on', auto_now_add=True),
+        ),
+    ]

--- a/shoop/core/migrations/0025_add_codes_for_order.py
+++ b/shoop/core/migrations/0025_add_codes_for_order.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('shoop', '0024_add_order_modified_info'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='order',
+            name='_codes',
+            field=jsonfield.fields.JSONField(blank=True, verbose_name='codes', null=True),
+        ),
+    ]

--- a/shoop/core/models/_orders.py
+++ b/shoop/core/models/_orders.py
@@ -161,6 +161,7 @@ class Order(MoneyPropped, models.Model):
     # Identification
     shop = UnsavedForeignKey("Shop", on_delete=models.PROTECT, verbose_name=_('shop'))
     created_on = models.DateTimeField(auto_now_add=True, editable=False, verbose_name=_('created on'))
+    modified_on = models.DateTimeField(auto_now_add=True, editable=False, verbose_name=_('modified on'))
     identifier = InternalIdentifierField(unique=True, db_index=True, verbose_name=_('order identifier'))
     # TODO: label is actually a choice field, need to check migrations/choice deconstruction
     label = models.CharField(max_length=32, db_index=True, verbose_name=_('label'))
@@ -199,6 +200,10 @@ class Order(MoneyPropped, models.Model):
         settings.AUTH_USER_MODEL, related_name='orders_created', blank=True, null=True,
         on_delete=models.PROTECT,
         verbose_name=_('creating user'))
+    modified_by = UnsavedForeignKey(
+        settings.AUTH_USER_MODEL, related_name='orders_modified', blank=True, null=True,
+        on_delete=models.PROTECT,
+        verbose_name=_('modifier user'))
     deleted = models.BooleanField(db_index=True, default=False, verbose_name=_('deleted'))
     status = UnsavedForeignKey("OrderStatus", verbose_name=_('status'), on_delete=models.PROTECT)
     payment_status = EnumIntegerField(
@@ -328,6 +333,9 @@ class Order(MoneyPropped, models.Model):
 
         if not self.key:
             self.key = get_random_string(32)
+
+        if not self.modified_by:
+            self.modified_by = self.creator
 
     def _save_identifiers(self):
         self.identifier = "%s" % (get_order_identifier(self))

--- a/shoop/core/order_creator/_creator.py
+++ b/shoop/core/order_creator/_creator.py
@@ -218,6 +218,7 @@ class OrderProcessor(object):
         return order
 
     def _assign_code_usages(self, order_source, order):
+        order.codes = order_source.codes
         for code in order_source.codes:
             self._assign_code_usage(order_source, order, code)
 

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -16,9 +16,21 @@ from ._creator import OrderProcessor
 
 class OrderModifier(OrderProcessor):
 
+    _PROTECTED_ATTRIBUTES = [
+        "shop",
+        "currency,"
+        "prices_include_tax",
+        "creator",
+        "created_on",
+        "ip_address"
+    ]
+
     @atomic
     def update_order_from_source(self, order_source, order):
         data = self.get_source_base_data(order_source)
+        for key in self._PROTECTED_ATTRIBUTES:
+            if key in data:
+                data.pop(key)
         data.update({
             "modified_by": real_user_or_none(order_source.modified_by),
             "modified_on": now()

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -6,8 +6,10 @@
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
 from django.db.transaction import atomic
+from django.utils.timezone import now
 
 from shoop.core.models import Order
+from shoop.core.utils.users import real_user_or_none
 
 from ._creator import OrderProcessor
 
@@ -17,6 +19,10 @@ class OrderModifier(OrderProcessor):
     @atomic
     def update_order_from_source(self, order_source, order):
         data = self.get_source_base_data(order_source)
+        data.update({
+            "modified_by": real_user_or_none(order_source.modified_by),
+            "modified_on": now()
+        })
         Order.objects.filter(pk=order.pk).update(**data)
 
         order = Order.objects.get(pk=order.pk)

--- a/shoop/core/order_creator/_modifier.py
+++ b/shoop/core/order_creator/_modifier.py
@@ -12,6 +12,7 @@ from shoop.core.models import Order
 from shoop.core.utils.users import real_user_or_none
 
 from ._creator import OrderProcessor
+from ._source_modifier import get_order_source_modifier_modules
 
 
 class OrderModifier(OrderProcessor):
@@ -38,6 +39,8 @@ class OrderModifier(OrderProcessor):
         Order.objects.filter(pk=order.pk).update(**data)
 
         order = Order.objects.get(pk=order.pk)
+        for module in get_order_source_modifier_modules():
+            module.clear_codes(order)
 
         for line in order.lines.all():
             line.taxes.all().delete()  # Delete all tax lines before OrderLine's

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -113,6 +113,7 @@ class OrderSource(object):
         self._customer = None
         self._orderer = None
         self._creator = None
+        self._modified_by = None
         self.shipping_method_id = None
         self.payment_method_id = None
         self.customer_comment = u""
@@ -153,6 +154,7 @@ class OrderSource(object):
             customer=order.customer,
             orderer=order.orderer,
             creator=order.creator,
+            modified_by=order.modified_by,
             payment_method_id=order.payment_method_id,
             shipping_method_id=order.shipping_method_id,
             customer_comment=order.customer_comment,
@@ -205,6 +207,14 @@ class OrderSource(object):
     @creator.setter
     def creator(self, value):
         self._creator = value
+
+    @property
+    def modified_by(self):
+        return (self._modified_by or self.creator)
+
+    @modified_by.setter
+    def modified_by(self, value):
+        self._modified_by = value
 
     @property
     def shipping_method(self):

--- a/shoop/core/order_creator/_source.py
+++ b/shoop/core/order_creator/_source.py
@@ -168,6 +168,7 @@ class OrderSource(object):
             payment_data=order.payment_data,
             shipping_data=order.shipping_data,
             extra_data=order.extra_data,
+            codes=order.codes
         )
 
     total_price = _PriceSum("price")
@@ -260,6 +261,11 @@ class OrderSource(object):
     @property
     def codes(self):
         return list(self._codes)
+
+    @codes.setter
+    def codes(self, value):
+        for code in value:
+            self.add_code(code)
 
     def add_code(self, code):
         """

--- a/shoop/core/order_creator/_source_modifier.py
+++ b/shoop/core/order_creator/_source_modifier.py
@@ -42,3 +42,6 @@ class OrderSourceModifierModule(object):
 
     def use_code(self, order, code):
         pass
+
+    def clear_codes(self, order):
+        pass

--- a/shoop_tests/admin/test_order_creator.py
+++ b/shoop_tests/admin/test_order_creator.py
@@ -265,6 +265,9 @@ def test_editing_existing_order(rf, admin_user):
     state = get_frontend_order_state(contact=contact)
     shop = get_default_shop()
     order = create_empty_order(shop=shop)
+    order.payment_data = {"payment_data": True}
+    order.shipping_data = {"shipping_data": True}
+    order.extra_data = {"external_id": "123"}
     order.save()
     assert order.lines.count() == 0
     assert order.pk is not None
@@ -293,3 +296,15 @@ def test_editing_existing_order(rf, admin_user):
     assert edited_order.modified_by != order.modified_by
     assert edited_order.modified_by == modifier
     assert edited_order.modified_on > order.modified_on
+
+    # Make sure all non handled attributes is preserved from original order
+    assert edited_order.creator == order.creator
+    assert edited_order.ip_address == order.ip_address
+    assert edited_order.orderer == order.orderer
+    assert edited_order.customer_comment == order.customer_comment
+    assert edited_order.marketing_permission == order.marketing_permission
+    assert edited_order.order_date == order.order_date
+    assert edited_order.status == order.status
+    assert edited_order.payment_data == order.payment_data
+    assert edited_order.shipping_data == order.shipping_data
+    assert edited_order.extra_data == order.extra_data

--- a/shoop_tests/core/test_order_creator.py
+++ b/shoop_tests/core/test_order_creator.py
@@ -35,10 +35,6 @@ def test_codes_type_conversion():
 
     assert source.codes == []
 
-    with pytest.raises(AttributeError):
-        source.codes = "test"
-    assert source.codes == []
-
     source.add_code("t")
     source.add_code("e")
     source.add_code("s")

--- a/shoop_tests/core/test_order_modifier.py
+++ b/shoop_tests/core/test_order_modifier.py
@@ -98,9 +98,10 @@ def test_shop_change(rf, admin_user):
     source.shop = shop
 
     modifier = OrderModifier()
-
-    with pytest.raises(ValidationError):
-        modifier.update_order_from_source(source, order)
+    assert order.shop != source.shop
+    # Changing shop should be blocked. Source shop is just ignored.
+    edited_order = modifier.update_order_from_source(source, order)
+    assert edited_order.shop == order.shop
 
 
 def test_order_cannot_be_created():

--- a/shoop_tests/functional/test_order_edit_with_coupons.py
+++ b/shoop_tests/functional/test_order_edit_with_coupons.py
@@ -1,0 +1,145 @@
+# This file is part of Shoop.
+#
+# Copyright (c) 2012-2016, Shoop Ltd. All rights reserved.
+#
+# This source code is licensed under the AGPLv3 license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import unicode_literals
+
+import decimal
+import json
+import pytest
+
+from shoop.admin.modules.orders.views.edit import OrderEditView
+from shoop.campaigns.models import Coupon, BasketCampaign
+from shoop.campaigns.models.basket_conditions import BasketTotalProductAmountCondition
+from shoop.core.order_creator import OrderCreator
+from shoop.core.models import Order, OrderLineType, Tax, TaxClass
+from shoop.default_tax.models import TaxRule
+from shoop.front.basket import get_basket
+from shoop.testing.factories import (
+   create_product, get_payment_method, get_shipping_method, get_default_supplier, get_initial_order_status, create_random_person, UserFactory
+)
+from shoop_tests.admin.test_order_creator import get_frontend_request_for_command
+from shoop_tests.campaigns import initialize_test
+from shoop_tests.utils import assert_contains, printable_gibberish
+
+
+@pytest.mark.django_db
+def test_order_edit_with_coupon(rf):
+    initial_status = get_initial_order_status()
+    request, shop, group = initialize_test(rf, include_tax=False)
+    order = _get_order_with_coupon(request, initial_status)
+
+    modifier = UserFactory()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+    assert order.customer != contact
+    state = _get_frontend_order_state(shop, contact)
+    assert order.shop.id == state["shop"]["selected"]["id"]
+
+    request = get_frontend_request_for_command(state, "finalize", modifier)
+    response = OrderEditView.as_view()(request, pk=order.pk)
+    assert_contains(response, "orderIdentifier")
+    data = json.loads(response.content.decode("utf8"))
+    edited_order = Order.objects.get(pk=order.pk)
+
+    assert edited_order.identifier == data["orderIdentifier"] == order.identifier
+    assert edited_order.pk == order.pk
+    assert edited_order.lines.count() == 4
+    assert OrderLineType.DISCOUNT in [l.type for l in edited_order.lines.all()]
+    assert edited_order.coupon_usages.count() == 1
+
+
+@pytest.mark.django_db
+def test_campaign_with_non_active_coupon(rf):
+    initial_status = get_initial_order_status()
+    request, shop, group = initialize_test(rf, include_tax=False)
+    order = _get_order_with_coupon(request, initial_status)
+    coupon = order.coupon_usages.first().coupon
+    coupon.active = False
+    coupon.save()
+
+    modifier = UserFactory()
+    contact = create_random_person(locale="en_US", minimum_name_comp_len=5)
+    assert order.customer != contact
+    state = _get_frontend_order_state(shop, contact)
+    assert order.shop.id == state["shop"]["selected"]["id"]
+
+    request = get_frontend_request_for_command(state, "finalize", modifier)
+    response = OrderEditView.as_view()(request, pk=order.pk)
+    assert_contains(response, "orderIdentifier")
+    data = json.loads(response.content.decode("utf8"))
+    edited_order = Order.objects.get(pk=order.pk)
+
+    assert edited_order.identifier == data["orderIdentifier"] == order.identifier
+    assert edited_order.pk == order.pk
+    assert edited_order.lines.count() == 3
+    assert OrderLineType.DISCOUNT not in [l.type for l in edited_order.lines.all()]
+    assert edited_order.coupon_usages.count() == 0
+
+
+def _get_order_with_coupon(request, initial_status, condition_product_count=1):
+    shop = request.shop
+    basket = get_basket(request)
+    supplier = get_default_supplier()
+    product = create_product(printable_gibberish(), shop=shop, supplier=supplier, default_price="50")
+    basket.add_product(supplier=supplier, shop=shop, product=product, quantity=1)
+
+    dc = Coupon.objects.create(code="TEST", active=True)
+    campaign = BasketCampaign.objects.create(
+        shop=shop,
+        name="test",
+        public_name="test",
+        coupon=dc,
+        discount_amount_value=shop.create_price("20"),
+        active=True
+    )
+    rule = BasketTotalProductAmountCondition.objects.create(value=1)
+    campaign.conditions.add(rule)
+    campaign.save()
+    basket.add_code(dc.code)
+    basket.save()
+
+    basket.status = initial_status
+    creator = OrderCreator(request)
+    order = creator.create_order(basket)
+    assert order.lines.count() == 2
+    assert OrderLineType.DISCOUNT in [l.type for l in order.lines.all()]
+    return order
+
+
+def _get_frontend_order_state(shop, contact):
+    tax = Tax.objects.create(code="test_code", rate=decimal.Decimal("0.20"), name="Default")
+    tax_class = TaxClass.objects.create(identifier="test_tax_class", name="Default")
+    rule = TaxRule.objects.create(tax=tax)
+    rule.tax_classes.add(tax_class)
+    rule.save()
+    product = create_product(
+        sku=printable_gibberish(),
+        supplier=get_default_supplier(),
+        shop=shop
+    )
+    product.tax_class = tax_class
+    product.save()
+    lines = [
+        {"id": "x", "type": "product", "product": {"id": product.id}, "quantity": "32", "baseUnitPrice": 50}
+    ]
+
+    state = {
+        "customer": {"id": contact.id if contact else None},
+        "lines": lines,
+        "methods": {
+            "shippingMethod": {"id": get_shipping_method(shop=shop).id},
+            "paymentMethod": {"id": get_payment_method(shop=shop).id},
+        },
+        "shop": {
+            "selected": {
+                "id": shop.id,
+                "name": shop.safe_translation_getter("name"),
+                "currency": shop.currency,
+                "priceIncludeTaxes": shop.prices_include_tax
+            }
+        }
+    }
+    return state


### PR DESCRIPTION
Core: Add modified by and modified on for orders
Admin: Preserve data for unhandled fields in order edit
Test that coupon usages is added correctly
Campaigns: Preserve coupon codes in order edit