### PR TITLE
Add request parameter on get_payment_process_response method

### DIFF
--- a/shoop/core/models/_service_payment.py
+++ b/shoop/core/models/_service_payment.py
@@ -39,9 +39,9 @@ class PaymentMethod(Service):
     def can_delete(self):
         return not Order.objects.filter(payment_method=self).exists()
 
-    def get_payment_process_response(self, order, urls):
+    def get_payment_process_response(self, order, urls, request):
         self._make_sure_is_usable()
-        return self.provider.get_payment_process_response(self, order, urls)
+        return self.provider.get_payment_process_response(self, order, urls, request)
 
     def process_payment_return_request(self, order, request):
         self._make_sure_is_usable()
@@ -73,13 +73,14 @@ class PaymentProcessor(ServiceProvider):
         PaymentMethod.objects.filter(payment_processor=self).update(**{"enabled": False})
         super(PaymentProcessor, self).delete(*args, **kwargs)
 
-    def get_payment_process_response(self, service, order, urls):
+    def get_payment_process_response(self, service, order, urls, request):
         """
         Get payment process response for given order.
 
         :type service: shoop.core.models.PaymentMethod
         :type order: shoop.core.models.Order
         :type urls: PaymentUrls
+        :type request: django.http.HttpRequest
         :rtype: django.http.HttpResponse|None
         """
         return HttpResponseRedirect(urls.return_url)

--- a/shoop/front/views/payment.py
+++ b/shoop/front/views/payment.py
@@ -51,7 +51,7 @@ class ProcessPaymentView(DetailView):
             if not order.is_paid():
                 if payment_method:
                     return payment_method.get_payment_process_response(
-                        order=order, urls=get_payment_urls(request, order))
+                        order=order, urls=get_payment_urls(request, order), request=request)
         elif mode == "return":
             if payment_method:
                 payment_method.process_payment_return_request(order=order, request=request)

--- a/shoop/testing/models/_pseudo_payment.py
+++ b/shoop/testing/models/_pseudo_payment.py
@@ -67,7 +67,7 @@ class PseudoPaymentProcessor(PaymentProcessor):
     def compute_pseudo_mac(self, order):
         return hmac.new(key=b"PseudoPayment", msg=order.key.encode("utf-8")).hexdigest()
 
-    def get_payment_process_response(self, service, order, urls):
+    def get_payment_process_response(self, service, order, urls, request):
         transform = self._get_text_transformer(service)
         mac = self.compute_pseudo_mac(order)
         url_list = [

--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/payment_canceled.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/payment_canceled.jinja
@@ -5,5 +5,5 @@
 {% block content %}
     <p>{% trans %}You have canceled payment{% endtrans %}</p>
 
-    <p><a href="{{ payment_urls.payment }}" class="btn btn-primary btn-lg">{% trans %}Retry payment{% endtrans %}</a></p>
+    <p><a href="{{ payment_urls.payment_url }}" class="btn btn-primary btn-lg">{% trans %}Retry payment{% endtrans %}</a></p>
 {% endblock %}


### PR DESCRIPTION
Access to the user session may be useful for some kinds of payment processors.
Fix wrong variable name on payment_cancelled template.