### PR TITLE
Core: Fix decimal notation on model decimal fields (SHOOP-2616)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Unreleased
 Core
 ~~~~
 
+- Fix bug: Do not display decimal values in scientific notation
 - Fix bug: Taxes of child order lines are filled incorrectly
 - Fix bug: Order line parent lines are not linked
 - Add modified on for ``Order``


### PR DESCRIPTION
Fix decimal notation on model decimal fields so values do not display
in scientific notation (i.e., a value of `0` rendering as `0E-9`).

Refs SHOOP-2616