### PR TITLE
Test case for numeric/alphabetic pattern match

### DIFF
--- a/shoop_tests/utils/test_patterns.py
+++ b/shoop_tests/utils/test_patterns.py
@@ -97,6 +97,13 @@ def test_num_match(ctor):
     assert not num_pat.matches(930)
 
 
+@pytest.mark.parametrize("ctor", (Pattern, ReconstitutedPattern))
+def test_num_and_alphabetic_matches(ctor):
+    num_pat = ctor("100-2000")
+    assert num_pat.matches(19), "Matches alphabetically"
+    assert num_pat.matches(300), "Matches numerically"
+
+
 def test_pattern_cache():
     convoluted_pat_text = ",".join([str(x) for x in range(0, 1000, 2)])
     _compile_pattern.cache_clear()


### PR DESCRIPTION
Add a test case which demonstrates how same pattern can match in two
different ways: numerically and alphabetically.  Results might be
somewhat unexpected when the numbers are different length.  It is a good
idea to point out this oddity with a test case.

Refs SHOOP-2607