### PR TITLE
Classic Gray: Fix "Retry payment" (SHOOP-2677)

### DIFF
--- a/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/payment_canceled.jinja
+++ b/shoop/themes/classic_gray/templates/classic_gray/shoop/front/order/payment_canceled.jinja
@@ -5,5 +5,5 @@
 {% block content %}
     <p>{% trans %}You have canceled payment{% endtrans %}</p>
 
-    <p><a href="{{ payment_urls.payment }}" class="btn btn-primary btn-lg">{% trans %}Retry payment{% endtrans %}</a></p>
+    <p><a href="{{ payment_urls.payment_url }}" class="btn btn-primary btn-lg">{% trans %}Retry payment{% endtrans %}</a></p>
 {% endblock %}


### PR DESCRIPTION
The URL for "Retry payment" button was empty, because it used incorrect
property name `payment`.  Fix it to use the correct `payment_url` which
actually exists in `PaymentUrls` class.