### PR TITLE
Admin: Add configurable default parameter to `ChoiceFilter` (SHOOP-2642)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,7 @@ Localization
 Admin
 ~~~~~
 
+- Add default ``is_active`` filter to User admin
 - Enable default values for ``ChoiceFilter``
 - Allow contact adding and removing for company
 - Show companies in person contact edit page

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -72,6 +72,7 @@ Localization
 Admin
 ~~~~~
 
+- Enable default values for ``ChoiceFilter``
 - Allow contact adding and removing for company
 - Show companies in person contact edit page
 - Add target option to ``SearchResult``

--- a/shoop/admin/modules/users/views/list.py
+++ b/shoop/admin/modules/users/views/list.py
@@ -13,7 +13,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext as _
 
 from shoop.admin.utils.picotable import (
-    Column, TextFilter, true_or_false_filter
+    ChoicesFilter, Column, TextFilter, true_or_false_filter
 )
 from shoop.admin.utils.views import PicotableListView
 
@@ -25,7 +25,11 @@ class UserListView(PicotableListView):
         Column("email", _(u"Email"), filter_config=TextFilter()),
         Column("first_name", _(u"First Name"), filter_config=TextFilter()),
         Column("last_name", _(u"Last Name"), filter_config=TextFilter()),
-        Column("is_active", _(u"Active"), filter_config=true_or_false_filter),
+        Column(
+            "is_active",
+            _(u"Active"),
+            filter_config=ChoicesFilter([(False, _("no")), (True, _("yes"))], default=True)
+        ),
         Column("is_staff", _(u"Staff"), filter_config=true_or_false_filter),
         Column("is_superuser", _(u"Superuser"), filter_config=true_or_false_filter),
     ]


### PR DESCRIPTION
Add configurable default parameter to picotable `ChoiceFilter`.

Refs SHOOP-2642

There is a small issue with the PR that I haven't been able to solve. Basically, the dropdown doesn't reflect the default selection value.

I have a WIP branch here that *should* work, but isn't currently:

https://github.com/shawnadelic/shoop/tree/picotable-default-initial-wip