### PR TITLE
Front: Remove "Ordering for company" from checkout if logged in

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -109,6 +109,7 @@ Addons
 Front
 ~~~~~
 
+- Remove "Ordering for company" from checkout if logged in
 - Allow user to link company contact from account page
 - Log-in as company if user is a member of a company
 - Make ``get_product_cross_sells`` faster
@@ -142,6 +143,7 @@ Xtheme
 Classic Gray Theme
 ~~~~~~~~~~~~~~~~~~
 
+- Add Shoop Wishlist addon support for logged in users
 - Hide product order section when prices are hidden
 - Hide cart when prices are hidden
 - Show tracking codes in order detail

--- a/shoop/front/checkout/addresses.py
+++ b/shoop/front/checkout/addresses.py
@@ -60,7 +60,7 @@ class AddressesPhase(CheckoutPhaseViewMixin, FormView):
         fg = FormGroup(**self.get_form_kwargs())
         for kind in self.address_kinds:
             fg.add_form_def(kind, form_class=self.address_form_classes.get(kind, self.address_form_class))
-        if self.company_form_class:
+        if self.company_form_class and not self.request.customer:
             fg.add_form_def("company", self.company_form_class, required=False)
         return fg
 

--- a/shoop_tests/front/test_checkout.py
+++ b/shoop_tests/front/test_checkout.py
@@ -5,11 +5,15 @@
 #
 # This source code is licensed under the AGPLv3 license found in the
 # LICENSE file in the root directory of this source tree.
+import pytest
 from django.test import override_settings
 
-from shoop.front.checkout.addresses import AddressForm
+from shoop.core.models import get_person_contact
+from shoop.front.checkout.addresses import AddressesPhase, AddressForm
 from shoop.front.checkout.single_page import \
     AddressForm as SinglePageAddressForm
+from shoop.testing.factories import get_default_shop
+from shoop.testing.utils import apply_request_middleware
 
 
 def test_checkout_addresses_has_no_default_country():
@@ -51,3 +55,19 @@ def test_required_address_fields():
         assert form.fields["email"].required == True
         assert form.fields["email"].help_text == "Enter email"
         assert form.fields["phone"].help_text == "Enter phone"
+
+
+@pytest.mark.django_db
+def test_address_phase_authorized_user(rf, admin_user):
+    request = apply_request_middleware(rf.get("/"), shop=get_default_shop(), customer=get_person_contact(admin_user))
+    view_func = AddressesPhase.as_view()
+    resp = view_func(request)
+    assert 'company' not in resp.context_data['form'].form_defs
+
+
+@pytest.mark.django_db
+def test_address_phase_anonymous_user(rf):
+    request = apply_request_middleware(rf.get("/"), shop=get_default_shop())
+    view_func = AddressesPhase.as_view()
+    resp = view_func(request)
+    assert 'company' in resp.context_data['form'].form_defs


### PR DESCRIPTION
Only add company info form fields if user is not logged in
Ref SHOOP-2643